### PR TITLE
perf: Invoke durable Task scripts in place, skip per-Task scp

### DIFF
--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -208,20 +208,34 @@ def _run_remote_script(
 	from atlas.atlas import scripts_catalog
 	from atlas.atlas.script_uploads import files_to_upload
 
-	script_path = scripts_catalog.resolve(script)
-
 	_ensure_known_hosts_directory()
 
 	uploads = files_to_upload(script)
+	durable_remote = scripts_catalog.durable_remote_path(script)
 
 	with ssh_key_file(connection.ssh_private_key) as key_path:
-		# Create the staging dir and every remote parent directory the uploads
-		# need in one round trip. The purge first: hosts bootstrapped before the
-		# durable-package cutover still carry a per-Task staged copy of the lib
-		# at <staging>/lib, and the entry points' `sys.path.insert(0, <staging>/lib)`
+		# Fast path: the script is shipped durably at /var/lib/atlas/bin (by
+		# bootstrap/sync_scripts, like the atlas package and the systemd hooks) and
+		# needs no per-Task sidecar, so invoke it in place — one round trip, no
+		# mkdir+scp. This is the bulk of Tasks (every VM lifecycle op); the scp it
+		# skips was the dominant latency of an otherwise sub-second start/stop. A
+		# host bootstrapped before the durable-scripts cutover lacks the copy and
+		# must be re-bootstrapped / sync_scripts'd — the same refresh contract the
+		# durable atlas package already follows.
+		if durable_remote and not uploads:
+			command = _remote_command(script, durable_remote, variables)
+			return run_ssh(connection, key_path, command, timeout_seconds=timeout_seconds)
+
+		# Staging path: e2e probe scripts (resolved from the test directory, never
+		# shipped durably) and the few scripts with per-Task sidecars (sync-image).
+		# Create the staging dir and every remote parent directory the uploads need
+		# in one round trip. The purge first: hosts bootstrapped before the
+		# durable-package cutover still carry a per-Task staged copy of the lib at
+		# <staging>/lib, and the entry points' `sys.path.insert(0, <staging>/lib)`
 		# shim puts it AHEAD of PYTHONPATH — so a stale copy there shadows every
 		# durable-package update (e.g. an old paths.py without the new attributes).
 		# Removing it makes the shim the no-op the durable contract assumes.
+		script_path = scripts_catalog.resolve(script)
 		remote_dirs = {REMOTE_STAGING_DIRECTORY}
 		remote_dirs.update(os.path.dirname(remote) for _, remote in uploads)
 		mkdir = (

--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -33,6 +33,14 @@ DURABLE_PACKAGE_DIRECTORY = "/var/lib/atlas/bin"
 # _run_remote_script purges it before every Task.
 STALE_STAGED_PACKAGE_DIRECTORY = f"{REMOTE_STAGING_DIRECTORY}/lib"
 
+# Echoed by the durable-invocation guard when /var/lib/atlas/bin/<script> is
+# absent (a host that predates the durable-scripts cutover). The guard gates the
+# echo behind `test -f … ||`, so this string appears in a Task's output ONLY when
+# the durable copy was missing — never from a script's own run — which lets
+# _run_remote_script fall back to staging without misreading a real script's
+# output or exit code.
+DURABLE_MISSING_MARKER = "__ATLAS_DURABLE_SCRIPT_MISSING__"
+
 
 def run_task(
 	*,
@@ -223,11 +231,30 @@ def _run_remote_script(
 		# must be re-bootstrapped / sync_scripts'd — the same refresh contract the
 		# durable atlas package already follows.
 		if durable_remote and not uploads:
-			command = _remote_command(script, durable_remote, variables)
-			return run_ssh(connection, key_path, command, timeout_seconds=timeout_seconds)
+			# Guard so a host that predates the durable-scripts cutover (no
+			# /var/lib/atlas/bin/<script> yet) degrades to the staging path below
+			# for this one Task instead of failing: `test -f` short-circuits to the
+			# marker before the interpreter ever opens the file, so nothing ran and
+			# a staged re-run is safe. The marker can only come from this guard (the
+			# echo is gated behind the `||`), so it is an unambiguous fall-back
+			# signal. A re-bootstrap / sync_scripts makes the fast path stick.
+			inner = _remote_command(script, durable_remote, variables)
+			guarded = (
+				f"test -f {shlex.quote(durable_remote)} "
+				f"|| {{ echo {DURABLE_MISSING_MARKER}; exit 127; }}\n{inner}"
+			)
+			stdout, stderr, exit_code = run_ssh(connection, key_path, guarded, timeout_seconds=timeout_seconds)
+			if not (exit_code != 0 and DURABLE_MISSING_MARKER in stdout):
+				return stdout, stderr, exit_code
+			frappe.logger("atlas").warning(
+				f"durable script {durable_remote} missing on host; staging this Task — "
+				f"re-bootstrap / sync_scripts the server to restore the fast path"
+			)
+			# fall through to the staging path
 
 		# Staging path: e2e probe scripts (resolved from the test directory, never
-		# shipped durably) and the few scripts with per-Task sidecars (sync-image).
+		# shipped durably), the few scripts with per-Task sidecars (sync-image), and
+		# a durable script whose host copy is missing (the fall-through just above).
 		# Create the staging dir and every remote parent directory the uploads need
 		# in one round trip. The purge first: hosts bootstrapped before the
 		# durable-package cutover still carry a per-Task staged copy of the lib at

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -181,10 +181,10 @@ class Server(Document):
 
 	def _script_uploads(self) -> list[tuple[str, str]]:
 		"""The durable scripts that live under /var/lib/atlas/bin: the importable
-		atlas package plus the systemd-invoked .py hooks. These are pure code — an
-		scp overwrite is all it takes for an edit to land, no daemon-reload. This
-		is exactly the set `sync_scripts()` refreshes during development; bootstrap
-		ships it alongside `_unit_uploads()`."""
+		atlas package, the systemd-invoked .py hooks, and the Task entry scripts.
+		These are pure code — an scp overwrite is all it takes for an edit to land,
+		no daemon-reload. This is exactly the set `sync_scripts()` refreshes during
+		development; bootstrap ships it alongside `_unit_uploads()`."""
 		directory = scripts_catalog.scripts_directory()
 		uploads = [
 			(str(directory / source), destination)
@@ -200,6 +200,13 @@ class Server(Document):
 			if entry.name.startswith("test_"):
 				continue
 			uploads.append((str(entry), f"/var/lib/atlas/bin/atlas/{entry.name}"))
+		# The durable Task entry scripts: every host SSH Task (provision-vm.py,
+		# start/stop/snapshot-stop, …). Shipping them here lets the runner invoke
+		# each in place instead of scp'ing it per Task — the scp was the dominant
+		# latency of an otherwise-instant start/stop. Computed from disk
+		# (scripts_catalog) so a new Task script ships with no edit here.
+		for script in scripts_catalog.host_task_scripts():
+			uploads.append((str(directory / script), f"/var/lib/atlas/bin/{script}"))
 		return uploads
 
 	def _unit_uploads(self) -> list[tuple[str, str]]:

--- a/atlas/atlas/doctype/server/test_server.py
+++ b/atlas/atlas/doctype/server/test_server.py
@@ -55,6 +55,18 @@ class TestServerBootstrap(IntegrationTestCase):
 		upload.assert_called_once()
 		run.assert_called_once()
 
+	def test_script_uploads_ship_task_entry_scripts_durably(self) -> None:
+		# The Task entry scripts (provision/start/stop/snapshot-stop) ship to
+		# /var/lib/atlas/bin so the runner invokes them in place — no per-Task scp.
+		from atlas.atlas import scripts_catalog
+
+		destinations = {dest for _src, dest in self.server._script_uploads()}
+		for script in ("provision-vm.py", "start-vm.py", "stop-vm.py", "snapshot-stop-vm.py"):
+			self.assertIn(f"/var/lib/atlas/bin/{script}", destinations)
+		# The durable set covers every host SSH Task entry point.
+		for script in scripts_catalog.host_task_scripts():
+			self.assertIn(f"/var/lib/atlas/bin/{script}", destinations)
+
 	def test_bootstrap_parses_result_line(self) -> None:
 		from atlas.atlas.doctype.server import server as server_module
 

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -145,6 +145,32 @@ def operator_visible_scripts() -> list[str]:
 	return sorted(name for name in allowed_scripts() if name in OPERATOR_VISIBLE)
 
 
+# Production Task scripts are shipped durably to the host's /var/lib/atlas/bin by
+# Server.bootstrap()/sync_scripts() — the same place the importable atlas package
+# and the systemd hooks already live — and invoked there by the SSH runner with
+# no per-Task scp (the dominant latency of a start/stop/snapshot Task). The dir
+# equals runner.DURABLE_PACKAGE_DIRECTORY; the literal is repeated here so
+# server.py and the runner agree on one location without importing each other.
+DURABLE_SCRIPT_DIRECTORY = "/var/lib/atlas/bin"
+
+
+def host_task_scripts() -> list[str]:
+	"""Production Task scripts shipped durably to /var/lib/atlas/bin — exactly
+	allowed_scripts(), every host SSH Task entry point. Bootstrap / sync_scripts
+	upload these so the runner invokes them in place. e2e probe scripts live in
+	the test-only directory, are not shipped durably, and keep the staging path."""
+	return allowed_scripts()
+
+
+def durable_remote_path(script: str) -> str | None:
+	"""The /var/lib/atlas/bin path the runner invokes for a durably-shipped Task
+	script, or None when the script isn't shipped durably (an e2e probe resolved
+	from the test directory) — which the runner stages per Task instead."""
+	if script in host_task_scripts():
+		return f"{DURABLE_SCRIPT_DIRECTORY}/{script}"
+	return None
+
+
 def resolve(script: str) -> Path:
 	"""Locate a script in either the production or e2e directory. Raises
 	FileNotFoundError if not present in either."""

--- a/atlas/tests/test_scripts_catalog.py
+++ b/atlas/tests/test_scripts_catalog.py
@@ -56,3 +56,21 @@ class TestScriptsCatalog(unittest.TestCase):
 	def test_operator_visible_is_sorted(self) -> None:
 		operator = scripts_catalog.operator_visible_scripts()
 		self.assertEqual(operator, sorted(operator))
+
+	def test_host_task_scripts_equals_allowed(self) -> None:
+		# Every host SSH Task entry point is shipped durably and invoked in place;
+		# the durable set is exactly the allowlist.
+		self.assertEqual(scripts_catalog.host_task_scripts(), scripts_catalog.allowed_scripts())
+
+	def test_durable_remote_path_for_shipped_script(self) -> None:
+		# A production Task script resolves to its durable /var/lib/atlas/bin path,
+		# which the runner invokes without a per-Task scp.
+		self.assertEqual(
+			scripts_catalog.durable_remote_path("start-vm.py"),
+			"/var/lib/atlas/bin/start-vm.py",
+		)
+
+	def test_durable_remote_path_none_for_e2e_probe(self) -> None:
+		# e2e probes live in the test-only directory, are not shipped durably, and
+		# must keep the staging path (None tells the runner to scp them per Task).
+		self.assertIsNone(scripts_catalog.durable_remote_path("phase1-probe.sh"))

--- a/atlas/tests/test_ssh_runner.py
+++ b/atlas/tests/test_ssh_runner.py
@@ -225,7 +225,9 @@ class TestSidecarUploads(IntegrationTestCase):
 		# durable-package update (the bug: provision-vm.py failing with
 		# "'VirtualMachinePaths' object has no attribute ..." after a
 		# bootstrap had already refreshed /var/lib/atlas/bin). The staging
-		# preamble must remove it before every Task.
+		# preamble must remove it before every staged Task. Use an e2e probe
+		# (resolved from the test dir, never shipped durably) so the staging
+		# path runs — durable production scripts now skip it entirely.
 		ssh_commands: list[str] = []
 
 		def capture(args, **kwargs):
@@ -236,14 +238,45 @@ class TestSidecarUploads(IntegrationTestCase):
 		with patch("atlas.atlas._ssh.transport.subprocess.run", side_effect=capture):
 			run_task(
 				connection=CONNECTION,
-				script="snapshot-vm.py",
-				variables={"VIRTUAL_MACHINE_NAME": "x", "SNAPSHOT_ROOTFS_PATH": "/dev/atlas/y"},
+				script="phase1-probe.sh",
+				variables={"NAME": "x"},
 			)
 
 		staging = next(command for command in ssh_commands if "mkdir -p" in command)
 		self.assertIn(f"rm -rf {runner.STALE_STAGED_PACKAGE_DIRECTORY}", staging)
 		# The purge must come before the mkdir that re-creates the staging dir.
 		self.assertLess(staging.index("rm -rf"), staging.index("mkdir -p"))
+
+
+class TestDurableScriptInvocation(IntegrationTestCase):
+	"""A durably-shipped Task script (provision/start/stop/…) is invoked in place
+	at /var/lib/atlas/bin — no per-Task mkdir+scp, just one run."""
+
+	def test_durable_script_skips_staging_and_scp(self) -> None:
+		ssh_commands: list[str] = []
+		scp_count = 0
+
+		def capture(args, **kwargs):
+			nonlocal scp_count
+			if args[0] == "ssh":
+				ssh_commands.append(args[-1])
+			elif args[0] == "scp":
+				scp_count += 1
+			return _ok(args, **kwargs)
+
+		with patch("atlas.atlas._ssh.transport.subprocess.run", side_effect=capture):
+			run_task(
+				connection=CONNECTION,
+				script="start-vm.py",
+				variables={"VIRTUAL_MACHINE_NAME": "uuid-1"},
+			)
+
+		# No script transfer and no staging mkdir — the whole staging round trip
+		# is gone; the only ssh runs the durable copy in place.
+		self.assertEqual(scp_count, 0)
+		self.assertFalse(any("mkdir -p" in command for command in ssh_commands))
+		self.assertEqual(len(ssh_commands), 1)
+		self.assertIn("/var/lib/atlas/bin/start-vm.py", ssh_commands[0])
 
 
 class TestRemoteCommand(IntegrationTestCase):

--- a/atlas/tests/test_ssh_runner.py
+++ b/atlas/tests/test_ssh_runner.py
@@ -278,6 +278,37 @@ class TestDurableScriptInvocation(IntegrationTestCase):
 		self.assertEqual(len(ssh_commands), 1)
 		self.assertIn("/var/lib/atlas/bin/start-vm.py", ssh_commands[0])
 
+	def test_durable_missing_falls_back_to_staging(self) -> None:
+		# A host that predates the durable-scripts cutover lacks
+		# /var/lib/atlas/bin/start-vm.py. The guard short-circuits to the marker
+		# (nothing ran), and the runner must stage + run the script instead of
+		# failing — so the Task still succeeds and an scp happens. Zero-downtime
+		# deploy: the fast path needs no flag-day re-bootstrap of every host.
+		calls: list = []
+
+		def capture(args, **kwargs):
+			calls.append(args)
+			if args[0] == "ssh" and runner.DURABLE_MISSING_MARKER in args[-1]:
+				return subprocess.CompletedProcess(
+					args, 127, stdout=runner.DURABLE_MISSING_MARKER + "\n", stderr=""
+				)
+			return _ok(args, **kwargs)
+
+		with patch("atlas.atlas._ssh.transport.subprocess.run", side_effect=capture):
+			task = run_task(
+				connection=CONNECTION,
+				script="start-vm.py",
+				variables={"VIRTUAL_MACHINE_NAME": "uuid-1"},
+			)
+
+		self.assertEqual(task.status, "Success")
+		# Fell back to staging: the script was scp'd and a staging mkdir ran.
+		self.assertTrue(any(args[0] == "scp" for args in calls))
+		self.assertTrue(any(args[0] == "ssh" and "mkdir -p" in args[-1] for args in calls))
+		# The final invocation runs the staged copy, not the (absent) durable one.
+		last_ssh = [args for args in calls if args[0] == "ssh"][-1]
+		self.assertIn("/tmp/atlas/start-vm.py", last_ssh[-1])
+
 
 class TestRemoteCommand(IntegrationTestCase):
 	"""The .py vs .sh dispatch in runner._remote_command — the heart of the

--- a/spec/04-tasks.md
+++ b/spec/04-tasks.md
@@ -107,20 +107,24 @@ def wait_for_ssh(connection, timeout_seconds: int = 300) -> None:
   - `-o BatchMode=yes` — never prompt.
   - `-o ConnectTimeout=30`.
   - `-o ControlMaster=auto -o ControlPath=~/.atlas/cm/%C -o ControlPersist=60s`
-    — connection multiplexing. A Task opens 2+ connections to the same host
-    back-to-back (stage any sidecar, then run the script); the first does the
-    TCP+SSH handshake and the rest ride the shared master socket. `%C` (a hash
-    of user/host/port) keeps concurrent Tasks to different servers on distinct
-    sockets. This is the dominant latency win for a remote provision — each
-    avoided handshake is ~1.5s+ over a real droplet.
+    — connection multiplexing. A Task that stages a sidecar opens 2+ connections
+    to the same host back-to-back (stage, then run the script); the first does
+    the TCP+SSH handshake and the rest ride the shared master socket. A durable,
+    sidecar-free Task is a single run, and back-to-back Tasks reuse the master
+    too (`ControlPersist`). `%C` (a hash of user/host/port) keeps concurrent
+    Tasks to different servers on distinct sockets. This is a dominant latency
+    win for a remote provision — each avoided handshake is ~1.5s+ over a real
+    droplet.
 - Variables: how they reach the script depends on the script's language
   (see [§ Tasks are Python](#tasks-are-python-the-zx-slice-we-built)):
   - **`.py` task** —
-    `ssh ... PYTHONPATH=/var/lib/atlas/bin python3 /tmp/atlas/script.py --kebab-flag val …`.
+    `ssh ... PYTHONPATH=/var/lib/atlas/bin python3 /var/lib/atlas/bin/script.py --kebab-flag val …`.
     The `variables` dict keys (`UPPER_SNAKE`) become `--kebab-case` CLI flags;
     a list value becomes a repeated flag. Quoted with `shlex.quote()`. The
-    `PYTHONPATH` points `import atlas` at the durable package (next section).
-  - **`.sh` task** — `ssh ... env VAR=val VAR2=val2 bash -x /tmp/atlas/script.sh`.
+    `PYTHONPATH` points `import atlas` at the durable package, and the script
+    itself is durable too, so the common case runs it **in place** (next section).
+    A *staged* script — a sidecar or an e2e probe — runs from `/tmp/atlas/script.py`.
+  - **`.sh` task** — `ssh ... env VAR=val VAR2=val2 bash -x /var/lib/atlas/bin/script.sh`.
     The legacy form, kept for the few remaining shell tasks (`reboot-server.sh`).
   Both are built in `_ssh/runner.py::_remote_command()`, dispatched on the
   `.py`/`.sh` suffix.
@@ -276,6 +280,18 @@ with no host. A Task script imports it from **one durable copy** on the host:
   `sys.path.insert(<staging>/lib)` shim; it is now a harmless no-op (that dir is
   unpopulated) and `PYTHONPATH` wins because it sits ahead of it on `sys.path`.
 
+- **The entry scripts are durable too.** Bootstrap / `sync_scripts` ship every
+  host Task entry script (`scripts_catalog.host_task_scripts()` — provision-vm.py,
+  start/stop/snapshot-stop, …) to `/var/lib/atlas/bin/` beside the package, and
+  `_run_remote_script` invokes the durable copy **in place** when the script
+  needs no sidecar: no per-Task `mkdir`+`scp`, just the one run. The scp was the
+  dominant latency of an otherwise sub-second op — dropping it took a live stop
+  from ~2.2s to ~0.6s, start ~2.8s→~1.1s, and provision ~5.7s→~3.0s on a real
+  droplet. Same staleness contract as the package (re-bootstrap / `sync_scripts`
+  to refresh). Two kinds of script keep the staging path and its stale-lib
+  purge: **e2e probes** (resolved from the test-only directory, never shipped
+  durably) and **sidecar scripts** (`sync-image.py`).
+
 ### Systemd hooks are Python too, but not Tasks
 
 `vm-disk-up.py`, `vm-network-up.py`, `vm-network-down.py`, `vm-restore.py`
@@ -376,8 +392,9 @@ extra files a specific task needs — beside the script. The shared `atlas`
 package is **not** among them: it lives durably at `/var/lib/atlas/bin/atlas/`
 (placed by `Server.bootstrap()`) and Tasks reach it via
 `PYTHONPATH=/var/lib/atlas/bin` (see [§ the shared `atlas` package and how it is
-staged](#the-shared-atlas-package-and-how-it-is-staged)). So a Python Task with
-no sidecar uploads **zero** files — it stages the script and runs it.
+staged](#the-shared-atlas-package-and-how-it-is-staged)). So a durable Python
+Task with no sidecar uploads **zero** files and stages nothing — it runs the
+durable script in place. A sidecar Task stages only its sidecar(s).
 
 The canonical sidecar is `sync-image.py`, which needs the guest
 `atlas-network.service` unit staged so it can be embedded into the ext4 it


### PR DESCRIPTION
## Why

Profiling the VM lifecycle on a real droplet (DO `s-2vcpu-4gb`, FC v1.15.1) showed the **per-Task `scp` of the entry script is the dominant latency** of every operation — often more than the work itself. Each Task did `mkdir` + `scp <script>` + `run` (3 round-trips); to a remote host that `scp` alone measured **~850 ms (small script) to ~1942 ms (`provision-vm.py`, 25 KB)**, while a resume-start's actual work is ~0.1 s. The shared `atlas` lib package is already durable at `/var/lib/atlas/bin` and imported via `PYTHONPATH`; the **entry scripts were the one piece still shipped per Task**.

## What

Extend the existing durable-package pattern to the Task entry scripts:

1. **Ship them durably** — `bootstrap`/`sync_scripts` now place every host SSH Task entry script (`provision-vm.py`, `start`/`stop`/`snapshot-stop`, …) under `/var/lib/atlas/bin`, beside the package and systemd hooks. `scripts_catalog.host_task_scripts()`/`durable_remote_path()` are the single source of truth.
2. **Invoke in place** — when a script is durable and needs no sidecar, the runner runs it at `/var/lib/atlas/bin` in **one** SSH round-trip (no `mkdir`+`scp`). e2e probes (test-only dir) and sidecar scripts (`sync-image.py`) keep the staging path + its stale-lib purge, unchanged.
3. **Graceful fallback** — the durable invocation is guarded (`test -f … || echo marker; exit`, short-circuited before the interpreter opens the file, so nothing runs). If the host lacks the copy (predates this change), the runner **falls back to staging** for that Task. Zero-downtime deploy: stale hosts keep working; a re-sync makes the fast path stick.

## Measured impact (same VM, target droplet)

| op | before | after |
| --- | --- | --- |
| provision | 5685 ms | **2971 ms** (−48%) |
| stop | ~2250 ms | **594–1052 ms** |
| start | ~2800 ms | **1110–1793 ms** |
| terminate | 2170 ms | **1348 ms** |

## Safety

- **Tests:** ~250 unit tests across the affected surface pass; added coverage for the catalog helpers, the durable upload set, durable-in-place invocation (asserts zero `scp`), and the missing-script fallback.
- **Flow audit:** bootstrap (uploads scripts *before* running `bootstrap-server.py`; imports `atlas` via `PYTHONPATH`, no `/tmp/atlas` dep), `sync-image` (keeps staging — sidecar), e2e probes (keep staging), controller-only `issue-cert` (local runner, untouched), systemd hooks (already durable) — all verified.
- **Live:** full provision/stop/start/terminate cycle on a throwaway VM succeeds on the guarded path; the guard's shell semantics verified directly on the host (present → runs; absent → marker, exit 127, inner never runs).
- **Spec:** `spec/04-tasks.md` updated to match (source of truth).

## Rollout

After deploy, refresh existing Active hosts to gain the speedup — per-server **Sync Scripts** button or `bench --site <site> execute atlas.sync_scripts_to_all`. The fallback keeps un-synced hosts correct in the meantime (just no speedup).

## Commits

- `feat: Ship Task entry scripts to the durable bin`
- `perf: Invoke durable Task scripts in place, skip per-Task scp`
- `docs: Spec the durable Task entry scripts`
- `fix: Fall back to staging when a durable script is missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
