### PR TITLE
ci: Satisfy frappe semgrep rules across the app

### DIFF
--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 import frappe
+from frappe import _
 
 from atlas.atlas._ssh.transport import (
 	REMOTE_STAGING_DIRECTORY,
@@ -63,7 +64,7 @@ def run_task(
 	timeout). The Task row is always saved with the outcome before the raise.
 	"""
 	if (server is None) == (connection is None):
-		frappe.throw("run_task: pass exactly one of server= or connection=")
+		frappe.throw(_("run_task: pass exactly one of server= or connection="))
 
 	# Fake provider (developer_mode): a Task on a Fake-backed Server succeeds (or
 	# fails on demand) with no SSH. Only the server= path can be fake — the
@@ -182,6 +183,7 @@ def _mark_running(task: "Task") -> None:
 	task.status = "Running"
 	task.started = frappe.utils.now_datetime()
 	task.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- background job: persist the Running state before the long-running SSH operation so a crash mid-run is observable and the Task isn't stuck Queued
 	frappe.db.commit()
 
 
@@ -204,6 +206,7 @@ def _finalize(
 	task.ended = frappe.utils.now_datetime()
 	task.duration_milliseconds = elapsed_ms
 	task.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- persist the Task outcome before run_task re-raises
 	frappe.db.commit()
 
 

--- a/atlas/atlas/api/signup.py
+++ b/atlas/atlas/api/signup.py
@@ -13,6 +13,7 @@ per email (an attacker can't fan out a thousand Pending rows from one address).
 """
 
 import frappe
+from frappe import _
 from frappe.rate_limiter import rate_limit
 from frappe.utils import validate_email_address
 
@@ -25,6 +26,7 @@ from atlas.atlas.subdomain_label import is_taken, normalize, validate_label, val
 MAX_PENDING_PER_EMAIL = 3
 
 
+# nosemgrep: guest-whitelisted-method -- public signup on-ramp; email and subdomain are validated, the per-email pending count is capped, and the endpoint is rate-limited 5/hour per email
 @frappe.whitelist(allow_guest=True)
 @rate_limit(key="email", limit=5, seconds=60 * 60)
 def request_site(email: str, subdomain: str) -> dict:
@@ -43,7 +45,7 @@ def request_site(email: str, subdomain: str) -> dict:
 	both hammer the same address space."""
 	email = (email or "").strip().lower()
 	if not validate_email_address(email):
-		frappe.throw("Please enter a valid email address.")
+		frappe.throw(_("Please enter a valid email address."))
 
 	# Same Contract-A gate as Site, BEFORE we touch the DB or send mail.
 	validate_label(subdomain)
@@ -83,8 +85,9 @@ def _enforce_pending_cap(email: str) -> None:
 	pending = frappe.db.count("Site Request", {"email": email, "status": "Pending"})
 	if pending >= MAX_PENDING_PER_EMAIL:
 		frappe.throw(
-			"You already have a verification email in flight — check your inbox "
-			"(including spam) before requesting another."
+			_(
+				"You already have a verification email in flight — check your inbox (including spam) before requesting another."
+			)
 		)
 
 

--- a/atlas/atlas/atlas_settings.py
+++ b/atlas/atlas/atlas_settings.py
@@ -11,6 +11,7 @@ canonical call is `atlas.get_provider()`.
 from __future__ import annotations
 
 import frappe
+from frappe import _
 
 from atlas.atlas import providers
 from atlas.atlas.providers.base import Provider, ProvisionRequest, ProvisionResult, SshKey
@@ -19,7 +20,7 @@ from atlas.atlas.providers.base import Provider, ProvisionRequest, ProvisionResu
 def get_provider() -> Provider:
 	name = frappe.get_single("Atlas Settings").provider
 	if not name:
-		frappe.throw("Atlas Settings has no active provider; set one before provisioning")
+		frappe.throw(_("Atlas Settings has no active provider; set one before provisioning"))
 	return providers.for_provider(name)
 
 
@@ -34,7 +35,7 @@ def get_ssh_key() -> SshKey:
 def get_ssh_private_key_path() -> str:
 	path = frappe.db.get_single_value("Atlas Settings", "ssh_private_key_path")
 	if not path:
-		frappe.throw("Atlas Settings has no ssh_private_key_path; cannot SSH")
+		frappe.throw(_("Atlas Settings has no ssh_private_key_path; cannot SSH"))
 	return path
 
 

--- a/atlas/atlas/demo.py
+++ b/atlas/atlas/demo.py
@@ -45,6 +45,7 @@ def run(reset: bool = False) -> None:
 	_ensure_snapshots(machines)
 	_ensure_reserved_ips(servers, machines)
 	demo_data.backdate_tasks(servers, machines)
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the full seeded demo dataset before printing the summary
 	frappe.db.commit()
 	_print_summary(servers, machines)
 
@@ -65,6 +66,7 @@ def wipe() -> None:
 	_delete_demo_non_fake_providers()
 	# Leave the Fake Provider rows + catalog in place — cheap to reuse, and the
 	# active-provider pointer in Atlas Settings stays valid across a reset.
+	# nosemgrep: frappe-manual-commit -- demo teardown: commit after wipe so the demo-row deletions are durable
 	frappe.db.commit()
 
 
@@ -143,6 +145,7 @@ def _ensure_settings() -> None:
 	frappe.db.set_single_value(
 		"Atlas Settings", "ssh_private_key_path", _ensure_throwaway_ssh_key(), update_modified=False
 	)
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded Atlas Settings so later seed phases see the active provider and SSH key
 	frappe.db.commit()
 
 
@@ -154,6 +157,7 @@ def _ensure_throwaway_ssh_key() -> str:
 	path = frappe.get_site_path("private", "files", "atlas-demo-key.pem")
 	if not os.path.exists(path):
 		os.makedirs(os.path.dirname(path), exist_ok=True)
+		# nosemgrep: frappe-security-file-traversal -- fixed path under the site's private files dir (frappe.get_site_path), not untrusted web input
 		with open(path, "w") as handle:
 			handle.write(
 				"-----BEGIN OPENSSH PRIVATE KEY-----\nfake-demo-key-never-used\n-----END OPENSSH PRIVATE KEY-----\n"
@@ -166,6 +170,7 @@ def _ensure_catalog() -> None:
 	"""Seed Provider Size / Provider Image for Fake via the real Refresh-Catalog
 	path, so every Server/size Link resolves."""
 	frappe.get_doc("Provider", ACTIVE_PROVIDER).discover_and_upsert()
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded catalog so later seed phases' size and image Links resolve
 	frappe.db.commit()
 
 

--- a/atlas/atlas/demo_data.py
+++ b/atlas/atlas/demo_data.py
@@ -206,6 +206,7 @@ def ensure_images() -> dict[str, str]:
 				ignore_permissions=True
 			)
 		result[key] = name
+	# nosemgrep: frappe-manual-commit -- persist the seeded demo images before later phases
 	frappe.db.commit()
 	return result
 
@@ -245,6 +246,7 @@ def ensure_servers(active_provider: str) -> dict[str, str]:
 			frappe.db.set_value("Server", name, "status", final_status)
 		result[key] = name
 	result["metal-01"] = _ensure_self_managed_server()
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded demo servers before VMs are built on top of them
 	frappe.db.commit()
 	return result
 
@@ -290,6 +292,7 @@ def ensure_virtual_machines(servers: dict[str, str], images: dict[str, str]) -> 
 			result[spec["key"]] = existing
 			continue
 		result[spec["key"]] = _build_vm(spec, servers, images)
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded demo VMs before snapshots and reserved IPs reference them
 	frappe.db.commit()
 	return result
 
@@ -376,6 +379,7 @@ def ensure_snapshots(machines: dict[str, str]) -> None:
 	if source:
 		_insert_snapshot_row(source, "pending-export", "Pending")
 		_insert_snapshot_row(source, "failed-export", "Failed")
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded demo snapshots and the default_bench_snapshot setting
 	frappe.db.commit()
 
 
@@ -417,6 +421,7 @@ def ensure_reserved_ips(servers: dict[str, str], machines: dict[str, str]) -> No
 	other = servers.get("nyc3-01")
 	if other and not _server_has_free_ip(other):
 		reserved_ip_module.allocate(other)
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the seeded demo reserved IPs and their attachments
 	frappe.db.commit()
 
 
@@ -446,6 +451,7 @@ def backdate_tasks(servers: dict[str, str], machines: dict[str, str]) -> None:
 			continue
 		server = frappe.db.get_value("Virtual Machine", vm_name, "server")
 		_insert_backdated_task(server, vm_name, script, status, minutes_ago)
+	# nosemgrep: frappe-manual-commit -- demo seeder: persist the backdated demo Tasks so the Task list shows realistic history
 	frappe.db.commit()
 
 

--- a/atlas/atlas/doctype/central_settings/central_settings.py
+++ b/atlas/atlas/doctype/central_settings/central_settings.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas.central import (
@@ -66,7 +67,7 @@ class CentralSettings(Document):
 
 	def client(self) -> CentralClient:
 		if not self.url or not self.api_key:
-			frappe.throw("Set Central URL and API Key first")
+			frappe.throw(_("Set Central URL and API Key first"))
 		secret = get_secret("Central Settings", "Central Settings", "api_secret")
 		return CentralClient(self.url, self.api_key, secret)
 
@@ -77,7 +78,7 @@ class CentralSettings(Document):
 		`central.api.register` contract."""
 		region = self.region or frappe.conf.get("atlas_do_region")
 		if not region:
-			frappe.throw("Set a Region (or atlas_do_region in site config) before registering")
+			frappe.throw(_("Set a Region (or atlas_do_region in site config) before registering"))
 		return {
 			"region": region,
 			"base_url": frappe.utils.get_url(),

--- a/atlas/atlas/doctype/digitalocean_settings/digitalocean_settings.py
+++ b/atlas/atlas/doctype/digitalocean_settings/digitalocean_settings.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -12,6 +13,6 @@ class DigitalOceanSettings(Document):
 
 		provider_name = frappe.db.get_single_value("Atlas Settings", "provider")
 		if not provider_name:
-			frappe.throw("Set Atlas Settings.provider before testing the connection")
+			frappe.throw(_("Set Atlas Settings.provider before testing the connection"))
 		result = providers.for_provider(provider_name).authenticate()
 		return dataclasses.asdict(result)

--- a/atlas/atlas/doctype/domain_provider/domain_provider.py
+++ b/atlas/atlas/doctype/domain_provider/domain_provider.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import dataclasses
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import dns
@@ -35,7 +36,7 @@ class DomainProvider(Document):
 	def archive(self) -> None:
 		"""Flip is_active=0. Existing Root Domain FKs survive."""
 		if not self.is_active:
-			frappe.throw("Domain Provider is already archived")
+			frappe.throw(_("Domain Provider is already archived"))
 		frappe.db.set_value(self.doctype, self.name, "is_active", 0)
 
 	@frappe.whitelist()

--- a/atlas/atlas/doctype/image_build/image_build.py
+++ b/atlas/atlas/doctype/image_build/image_build.py
@@ -16,6 +16,7 @@ the desk form's checklist updates live. See spec/15-image-builder.md.
 import time
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import bench_image
@@ -90,6 +91,7 @@ class ImageBuild(Document):
 			frappe.throw(f"Can only re-bake an Available or Failed build (status is {self.status})")
 		self.db_set("status", "Draft")
 		self.db_set("error", None)
+		# nosemgrep: frappe-manual-commit -- persist the Draft status reset before re-enqueuing the build so the background job sees the cleared state
 		frappe.db.commit()
 		self.after_insert()
 
@@ -116,7 +118,7 @@ class ImageBuild(Document):
 		if self.status != "Available":
 			frappe.throw(f"Can only promote an Available build (status is {self.status})")
 		if not self.snapshot:
-			frappe.throw("This build has no snapshot to promote.")
+			frappe.throw(_("This build has no snapshot to promote."))
 		recipe = get_recipe(self.recipe)
 		default_name = recipe.promote_image_name or f"{self.recipe}-{self.name}".lower()
 		image_name = (image_name or "").strip() or default_name
@@ -203,6 +205,7 @@ def _set_status(build, status: str) -> None:
 	update needs no client-side dance. Emitted after the commit so the realtime
 	payload never races ahead of the committed row."""
 	build.db_set("status", status)
+	# nosemgrep: frappe-manual-commit -- background job: commit each status transition so the desk form's polling sees it cross-transaction and the Failed write survives the job's rollback
 	frappe.db.commit()
 	frappe.publish_realtime(
 		event="image_build_progress",
@@ -414,6 +417,7 @@ def _register(recipe, snapshot_name: str) -> None:
 	bake left to the operator."""
 	settings = frappe.get_single("Atlas Settings")
 	settings.db_set(recipe.registers_as, snapshot_name)
+	# nosemgrep: frappe-manual-commit -- background job: persist the newly-registered golden snapshot pointer in Atlas Settings so self-serve clones find it
 	frappe.db.commit()
 
 

--- a/atlas/atlas/doctype/port_mapping/port_mapping.py
+++ b/atlas/atlas/doctype/port_mapping/port_mapping.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 # The routing key is the allocated port (read-only) and the target VM + service
@@ -121,7 +122,7 @@ def allocate_port(region: str) -> int:
 	each other. The `{region}-{public_port}` unique name is the final backstop for
 	the first-row-in-an-empty-region race (one insert wins, the other retries)."""
 	if not region:
-		frappe.throw("Port Mapping needs a region before a port can be allocated")
+		frappe.throw(_("Port Mapping needs a region before a port can be allocated"))
 	low, high = port_pool()
 	# FOR UPDATE on the region's rows serializes concurrent allocations; the lock
 	# is released at transaction end. Reading the ports under the lock means a

--- a/atlas/atlas/doctype/provider/provider.py
+++ b/atlas/atlas/doctype/provider/provider.py
@@ -14,6 +14,7 @@ import json
 from typing import Any
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import providers
@@ -44,7 +45,7 @@ class Provider(Document):
 	def archive(self) -> None:
 		"""Flip is_active=0. Existing Server FKs survive."""
 		if not self.is_active:
-			frappe.throw("Provider is already archived")
+			frappe.throw(_("Provider is already archived"))
 		frappe.db.set_value(self.doctype, self.name, "is_active", 0)
 
 	@frappe.whitelist()
@@ -153,6 +154,7 @@ def _provision_server(provider_row: Provider, title: str, dialog_fields: dict[st
 			server_doc["provider_metadata"] = json.dumps(result.provider_metadata)
 		server = frappe.get_doc(server_doc).insert(ignore_permissions=True)
 
+	# nosemgrep: frappe-manual-commit -- persist the new Server row before enqueuing finish_provisioning so the background job can find it cross-transaction
 	frappe.db.commit()
 
 	frappe.enqueue(

--- a/atlas/atlas/doctype/provider_image/provider_image.py
+++ b/atlas/atlas/doctype/provider_image/provider_image.py
@@ -1,11 +1,12 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class ProviderImage(Document):
 	def autoname(self) -> None:
 		if not self.provider_type or not self.slug:
-			frappe.throw("Provider Image requires provider_type and slug")
+			frappe.throw(_("Provider Image requires provider_type and slug"))
 		self.name = f"{self.provider_type}/{self.slug}"
 
 	def validate(self) -> None:

--- a/atlas/atlas/doctype/provider_size/provider_size.py
+++ b/atlas/atlas/doctype/provider_size/provider_size.py
@@ -1,11 +1,12 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class ProviderSize(Document):
 	def autoname(self) -> None:
 		if not self.provider_type or not self.slug:
-			frappe.throw("Provider Size requires provider_type and slug")
+			frappe.throw(_("Provider Size requires provider_type and slug"))
 		self.name = f"{self.provider_type}/{self.slug}"
 
 	def validate(self) -> None:

--- a/atlas/atlas/doctype/scaleway_settings/scaleway_settings.py
+++ b/atlas/atlas/doctype/scaleway_settings/scaleway_settings.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -12,6 +13,6 @@ class ScalewaySettings(Document):
 
 		provider_name = frappe.db.get_single_value("Atlas Settings", "provider")
 		if not provider_name:
-			frappe.throw("Set Atlas Settings.provider before testing the connection")
+			frappe.throw(_("Set Atlas Settings.provider before testing the connection"))
 		result = providers.for_provider(provider_name).authenticate()
 		return dataclasses.asdict(result)

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -3,6 +3,7 @@ import uuid
 from typing import ClassVar
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import scripts_catalog
@@ -75,7 +76,7 @@ class Server(Document):
 		import atlas
 
 		if self.status == "Archived":
-			frappe.throw("Server is already archived")
+			frappe.throw(_("Server is already archived"))
 		if self.provider_resource_id:
 			atlas.get_provider().destroy(self.provider_resource_id)
 		frappe.db.set_value(self.doctype, self.name, "status", "Archived")
@@ -149,7 +150,7 @@ class Server(Document):
 		if variables is None:
 			variables = {}
 		if not isinstance(variables, dict):
-			frappe.throw("variables must be a JSON object")
+			frappe.throw(_("variables must be a JSON object"))
 		if script not in scripts_catalog.allowed_scripts():
 			frappe.throw(f"Unknown script: {script}")
 		task = run_task(

--- a/atlas/atlas/doctype/site/site.py
+++ b/atlas/atlas/doctype/site/site.py
@@ -13,6 +13,7 @@ methods that `frappe.throw` early on the wrong state.
 """
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas.placement import active_root_domain, default_bench_snapshot, warm_bench_snapshot_for_server
@@ -138,7 +139,7 @@ class Site(Document):
 		(this is the signup race), not a raw duplicate-key error."""
 		label = (self.subdomain or "").strip()
 		if not label:
-			frappe.throw("A subdomain is required")
+			frappe.throw(_("A subdomain is required"))
 		domain = active_root_domain().domain
 		fqdn = f"{label}.{domain}"
 		if frappe.db.exists("Site", fqdn):
@@ -156,7 +157,7 @@ class Site(Document):
 		VirtualMachine.terminate()'s cleanup-then-mark shape. Idempotent-ish: a
 		second call on an already-Terminated row throws."""
 		if self.status == "Terminated":
-			frappe.throw("Site is already terminated")
+			frappe.throw(_("Site is already terminated"))
 		self._delete_subdomain()
 		self._terminate_backing_vm()
 		self.status = "Terminated"
@@ -209,6 +210,7 @@ class _ProvisionClock:
 
 	def _emit(self, message: str) -> None:
 		elapsed = self._now() - self._t0
+		# nosemgrep: frappe-print-function-in-doctypes -- intentional: _ProvisionClock prints its follow-along trace to stdout so it lands in the RQ worker job log alongside the other job lines
 		print(f"[auto_provision {self._site}] +{elapsed:6.1f}s {message}", flush=True)
 
 	def stage(self, label: str) -> None:
@@ -339,6 +341,7 @@ def _set_status(site, status: str) -> None:
 	if stamp_field:
 		site.db_set(stamp_field, frappe.utils.now_datetime())
 	site.db_set("status", status)
+	# nosemgrep: frappe-manual-commit -- background job: commit each status transition so the owner's realtime polling sees it cross-transaction and progress survives a crash mid-provision
 	frappe.db.commit()
 	frappe.publish_realtime(
 		event="site_provisioning",

--- a/atlas/atlas/doctype/site_request/site_request.py
+++ b/atlas/atlas/doctype/site_request/site_request.py
@@ -17,6 +17,7 @@ hands off to `Site` for the authoritative uniqueness + the provision flow.
 """
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_to_date, get_datetime, now_datetime
 
@@ -87,7 +88,7 @@ class SiteRequest(Document):
 			return frappe.get_doc("Site", frappe.db.get_value("Site Request", self.name, "site"))
 		if self.status == "Expired" or self.is_expired():
 			self._mark_expired()
-			frappe.throw("This verification link has expired — please sign up again.")
+			frappe.throw(_("This verification link has expired — please sign up again."))
 		if self.status != "Pending":
 			frappe.throw(f"This request cannot be verified (status is {self.status}).")
 
@@ -163,6 +164,7 @@ class SiteRequest(Document):
 		which the verify route surfaces. Restores the session user in `finally` so
 		fulfilment never leaves the request running as someone else."""
 		previous = frappe.session.user
+		# nosemgrep: frappe-setuser -- insert the Site AS the verified user so Frappe stamps owner = user (Contract C); reverted in the finally below
 		frappe.set_user(user)
 		try:
 			return frappe.get_doc(
@@ -173,4 +175,5 @@ class SiteRequest(Document):
 				}
 			).insert()
 		finally:
+			# nosemgrep: frappe-setuser -- restore the original session user after insert
 			frappe.set_user(previous)

--- a/atlas/atlas/doctype/ssh_key/ssh_key.py
+++ b/atlas/atlas/doctype/ssh_key/ssh_key.py
@@ -18,6 +18,7 @@ import binascii
 import hashlib
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 # OpenSSH public-key type prefixes we accept. Covers the modern defaults
@@ -52,13 +53,13 @@ def fingerprint(public_key: str) -> str:
 	key stored now is an opaque SSH failure at provision time later."""
 	parts = (public_key or "").split()
 	if len(parts) < 2:
-		frappe.throw("Not an OpenSSH public key: expected '<type> <base64-key> [comment]'.")
+		frappe.throw(_("Not an OpenSSH public key: expected '<type> <base64-key> [comment]'."))
 	key_type, blob = parts[0], parts[1]
 	if key_type not in KNOWN_KEY_TYPES:
 		frappe.throw(f"Unsupported SSH key type {key_type!r}.")
 	try:
 		raw = base64.b64decode(blob, validate=True)
 	except binascii.Error, ValueError:
-		frappe.throw("SSH key body is not valid base64.")
+		frappe.throw(_("SSH key body is not valid base64."))
 	digest = base64.b64encode(hashlib.sha256(raw).digest()).decode().rstrip("=")
 	return f"SHA256:{digest}"

--- a/atlas/atlas/doctype/task/task.py
+++ b/atlas/atlas/doctype/task/task.py
@@ -2,6 +2,7 @@ import json
 from typing import ClassVar
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 IMMUTABLE_AFTER_INSERT = ("server", "virtual_machine", "script", "variables", "triggered_by")
@@ -65,7 +66,7 @@ class Task(Document):
 	@variables_dict.setter
 	def variables_dict(self, value: dict) -> None:
 		if not isinstance(value, dict):
-			frappe.throw("Task.variables_dict must be a dict")
+			frappe.throw(_("Task.variables_dict must be a dict"))
 		self.variables = json.dumps(value, sort_keys=True)
 
 	def before_insert(self) -> None:
@@ -74,7 +75,7 @@ class Task(Document):
 
 	def validate(self) -> None:
 		if not self.variables:
-			frappe.throw("variables is required")
+			frappe.throw(_("variables is required"))
 		self._validate_variables_json()
 		self._validate_immutability()
 
@@ -119,7 +120,7 @@ class Task(Document):
 		except json.JSONDecodeError as exception:
 			frappe.throw(f"variables must be valid JSON: {exception}")
 		if not isinstance(parsed, dict):
-			frappe.throw("variables must be a JSON object")
+			frappe.throw(_("variables must be a JSON object"))
 
 	def _validate_immutability(self) -> None:
 		if self.is_new():

--- a/atlas/atlas/doctype/tls_certificate/tls_certificate.py
+++ b/atlas/atlas/doctype/tls_certificate/tls_certificate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pathlib
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import dns, proxy, tls
@@ -98,7 +99,7 @@ class TLSCertificate(Document):
 		that can't be reached is logged and skipped — one wedged guest never wedges
 		the fan-out (mirrors `proxy.reconcile_region`)."""
 		if not self.fullchain_path or not self.privkey_path:
-			frappe.throw("TLS Certificate has no PEM paths; issue it first")
+			frappe.throw(_("TLS Certificate has no PEM paths; issue it first"))
 		fullchain = _read_pem(self.fullchain_path)
 		privkey = _read_pem(self.privkey_path)
 		region = frappe.db.get_value("Root Domain", self.root_domain, "region")

--- a/atlas/atlas/doctype/tls_provider/tls_provider.py
+++ b/atlas/atlas/doctype/tls_provider/tls_provider.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import dataclasses
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas import tls
@@ -35,7 +36,7 @@ class TLSProvider(Document):
 	def archive(self) -> None:
 		"""Flip is_active=0. Existing Root Domain FKs survive."""
 		if not self.is_active:
-			frappe.throw("TLS Provider is already archived")
+			frappe.throw(_("TLS Provider is already archived"))
 		frappe.db.set_value(self.doctype, self.name, "is_active", 0)
 
 	@frappe.whitelist()

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.js
@@ -454,7 +454,7 @@ function render_status_intro(frm) {
 
 function expand_networking_for_pending(frm) {
 	if (frm.doc.status !== "Pending" || !frm.doc.ipv6_address) return;
-	const section = (cur_frm?.layout?.sections || []).find(
+	const section = (frm?.layout?.sections || []).find(
 		(s) => s.df && s.df.fieldname === "section_break_networking"
 	);
 	if (section && typeof section.collapse === "function") {

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -2,6 +2,7 @@ import ipaddress
 import uuid
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas.networking import (
@@ -200,7 +201,7 @@ class VirtualMachine(Document):
 		if self.status not in ("Running", "Paused"):
 			frappe.throw(f"Cannot stop from {self.status}")
 		if self.stop_protection:
-			frappe.throw("Disable stop protection before stopping this VM")
+			frappe.throw(_("Disable stop protection before stopping this VM"))
 		if memory_snapshot is None:
 			memory_snapshot = bool(self.memory_snapshot_on_stop)
 		# frm.call / REST send a JSON/stringy value; normalize to bool.
@@ -521,10 +522,10 @@ class VirtualMachine(Document):
 		}
 		if source_type == "snapshot":
 			if not source:
-				frappe.throw("Rebuild from snapshot requires a snapshot")
+				frappe.throw(_("Rebuild from snapshot requires a snapshot"))
 			snapshot = frappe.get_doc("Virtual Machine Snapshot", source)
 			if snapshot.virtual_machine != self.name:
-				frappe.throw("Snapshot belongs to a different Virtual Machine")
+				frappe.throw(_("Snapshot belongs to a different Virtual Machine"))
 			if snapshot.status != "Available":
 				frappe.throw(f"Snapshot is not Available (status is {snapshot.status})")
 			# data_rootfs_path is empty when the snapshot captured no data disk;
@@ -591,7 +592,7 @@ class VirtualMachine(Document):
 		if new_data_disk != self.data_disk_gigabytes:
 			if not self.data_disk_gigabytes:
 				# fmt: off
-				frappe.throw("This VM has no data disk; recreate the VM to add one (resize only grows an existing data disk)")
+				frappe.throw(_("This VM has no data disk; recreate the VM to add one (resize only grows an existing data disk)"))
 				# fmt: on
 			if new_data_disk < self.data_disk_gigabytes:
 				frappe.throw(
@@ -671,9 +672,9 @@ class VirtualMachine(Document):
 	@frappe.whitelist()
 	def terminate(self) -> str:
 		if self.status == "Terminated":
-			frappe.throw("VM is already terminated")
+			frappe.throw(_("VM is already terminated"))
 		if self.termination_protection:
-			frappe.throw("Disable termination protection before terminating this VM")
+			frappe.throw(_("Disable termination protection before terminating this VM"))
 		task = run_task(
 			server=self.server,
 			script="terminate-vm.py",

--- a/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.py
+++ b/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 IMMUTABLE_AFTER_INSERT = (
@@ -89,7 +90,7 @@ class VirtualMachineImage(Document):
 		"""Decommission this image. Sets is_active=0; the row stays in the
 		DB so historical Task references remain queryable."""
 		if not self.is_active:
-			frappe.throw("Image is already archived")
+			frappe.throw(_("Image is already archived"))
 		frappe.db.set_value(self.doctype, self.name, "is_active", 0)
 
 	@frappe.whitelist()
@@ -180,6 +181,7 @@ class VirtualMachineImage(Document):
 		)
 		task.variables_dict = variables
 		task.insert(ignore_permissions=True)
+		# nosemgrep: frappe-manual-commit -- persist the Pending sync Task before enqueuing execute_task so the background job can find it cross-transaction
 		frappe.db.commit()
 
 		frappe.enqueue(

--- a/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.py
+++ b/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.py
@@ -1,6 +1,7 @@
 import re
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas.ssh import run_task
@@ -230,21 +231,20 @@ class VirtualMachineSnapshot(Document):
 			frappe.throw(f"Snapshot is not Available (status is {self.status})")
 		if self.kind == "Warm":
 			frappe.throw(
-				"A warm snapshot cannot be promoted to an image — its value is the frozen "
-				"memory pair clones resume, which a cold-booting base image discards. "
-				"Promote a cold snapshot, or clone this one with Clone to new VM."
+				_(
+					"A warm snapshot cannot be promoted to an image — its value is the frozen memory pair clones resume, which a cold-booting base image discards. Promote a cold snapshot, or clone this one with Clone to new VM."
+				)
 			)
 		if self.data_disk_gigabytes:
 			frappe.throw(
-				"This snapshot has a data disk; a base image captures only the root disk "
-				"(the image has no data-disk fields), so promoting would silently drop it. "
-				"Clone this snapshot with Clone to new VM to keep the data disk, or promote "
-				"a data-less snapshot."
+				_(
+					"This snapshot has a data disk; a base image captures only the root disk (the image has no data-disk fields), so promoting would silently drop it. Clone this snapshot with Clone to new VM to keep the data disk, or promote a data-less snapshot."
+				)
 			)
 		if not self.source_image:
 			# The kernel is inherited from source_image; a snapshot with no recorded
 			# source image (a malformed row) has no kernel to point the image at.
-			frappe.throw("Snapshot has no source image to inherit a kernel from; cannot promote.")
+			frappe.throw(_("Snapshot has no source image to inherit a kernel from; cannot promote."))
 
 		image_name = (image_name or "").strip().lower()
 		if not _IMAGE_NAME_RE.match(image_name):

--- a/atlas/atlas/local_task.py
+++ b/atlas/atlas/local_task.py
@@ -73,6 +73,7 @@ def _execute_local(
 	task.status = "Running"
 	task.started = frappe.utils.now_datetime()
 	task.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- background job: persist the Running state before the long-running local subprocess so a crash mid-run is observable and the Task isn't stuck Queued
 	frappe.db.commit()
 
 	start = time.monotonic()
@@ -133,6 +134,7 @@ def _finalize(
 	task.ended = frappe.utils.now_datetime()
 	task.duration_milliseconds = elapsed_ms
 	task.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- persist the Task outcome before run_local_task re-raises so the final status survives the raise
 	frappe.db.commit()
 
 

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -11,6 +11,7 @@ never runs for them.
 """
 
 import frappe
+from frappe import _
 
 
 class NoCapacityError(frappe.ValidationError):
@@ -41,9 +42,9 @@ def default_image() -> str:
 		ignore_permissions=True,
 	)
 	if not active:
-		frappe.throw("No image is available — contact your operator.")
+		frappe.throw(_("No image is available — contact your operator."))
 	if len(active) > 1:
-		frappe.throw("Several images are active — ask your operator to set a default image.")
+		frappe.throw(_("Several images are active — ask your operator to set a default image."))
 	return active[0]
 
 
@@ -73,13 +74,13 @@ def default_server(required_vcpus: float) -> str:
 		ignore_permissions=True,
 	)
 	if not servers:
-		frappe.throw("No capacity available — contact your operator.", NoCapacityError)
+		frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
 	for server in servers:
 		capacity = capacity_for_server(server)
 		budget = capacity["effective_vcpus"]
 		if budget is None or capacity["used_vcpus"] + required_vcpus <= budget:
 			return server
-	frappe.throw("No capacity available — contact your operator.", NoCapacityError)
+	frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
 
 
 def apply_user_defaults(virtual_machine) -> None:
@@ -109,7 +110,7 @@ def default_bench_snapshot() -> str:
 	is unset or no longer Available — a Site can't be provisioned without it."""
 	configured = frappe.db.get_single_value("Atlas Settings", "default_bench_snapshot")
 	if not configured:
-		frappe.throw("No golden bench snapshot is configured — contact your operator.")
+		frappe.throw(_("No golden bench snapshot is configured — contact your operator."))
 	status = frappe.db.get_value("Virtual Machine Snapshot", configured, "status")
 	if status is None:
 		frappe.throw(f"Configured bench snapshot {configured} does not exist — contact your operator.")
@@ -156,7 +157,7 @@ def active_root_domain() -> "frappe.model.document.Document":
 		ignore_permissions=True,
 	)
 	if not active:
-		frappe.throw("No domain is configured — contact your operator.")
+		frappe.throw(_("No domain is configured — contact your operator."))
 	if len(active) > 1:
-		frappe.throw("Several domains are active — ask your operator to set a single active domain.")
+		frappe.throw(_("Several domains are active — ask your operator to set a single active domain."))
 	return frappe.get_doc("Root Domain", active[0]["name"])

--- a/atlas/atlas/providers/fake.py
+++ b/atlas/atlas/providers/fake.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 
 import frappe
+from frappe import _
 
 from atlas.atlas.providers import register
 from atlas.atlas.providers.base import (
@@ -64,7 +65,7 @@ def require_developer_mode() -> None:
 	"""Throw unless the site is in developer_mode. The gate that keeps a Fake
 	provider inert on a production site."""
 	if not frappe.conf.developer_mode:
-		frappe.throw("The Fake provider is only available when developer_mode is enabled")
+		frappe.throw(_("The Fake provider is only available when developer_mode is enabled"))
 
 
 @register

--- a/atlas/atlas/providers/self_managed.py
+++ b/atlas/atlas/providers/self_managed.py
@@ -9,6 +9,7 @@ what the operator typed, `destroy()` is a no-op.
 from __future__ import annotations
 
 import frappe
+from frappe import _
 
 from atlas.atlas.providers import register
 from atlas.atlas.providers.base import (
@@ -34,7 +35,7 @@ class SelfManagedProvider(Provider):
 
 	def provision(self, request: ProvisionRequest) -> ProvisionResult:
 		if request.prebuilt_networking is None:
-			frappe.throw("Self-Managed provision requires prebuilt_networking")
+			frappe.throw(_("Self-Managed provision requires prebuilt_networking"))
 		return ProvisionResult(
 			provider_resource_id="",
 			size="",
@@ -82,8 +83,10 @@ class SelfManagedProvider(Provider):
 
 	def allocate_reserved_ip(self) -> ReservedIp:
 		frappe.throw(
-			"Self-Managed has no reserved-IP API; create the Reserved IP row "
-			"with an operator-supplied address instead of allocating one"
+			_(
+				"Self-Managed has no reserved-IP API; create the Reserved IP row "
+				"with an operator-supplied address instead of allocating one"
+			)
 		)
 
 	def assign_reserved_ip(self, provider_resource_id: str, droplet_resource_id: str) -> None:

--- a/atlas/atlas/providers/worker.py
+++ b/atlas/atlas/providers/worker.py
@@ -98,6 +98,7 @@ def finish_provisioning(server_name: str) -> None:
 	server.reload()
 	server.status = "Active"
 	server.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- background job: persist the final Active state so it is durable and observers see provisioning completed
 	frappe.db.commit()
 	frappe.logger("atlas").info(f"finish_provisioning: server {server_name} is Active")
 

--- a/atlas/atlas/subdomain_label.py
+++ b/atlas/atlas/subdomain_label.py
@@ -14,6 +14,7 @@ after verifying.
 """
 
 import frappe
+from frappe import _
 
 # A subdomain label that is not the user's to take. `www admin api …` are the
 # operational names a fleet reserves; everything else is taken at insert by the
@@ -51,17 +52,17 @@ def validate_label(subdomain: str | None) -> None:
 	trailing hyphen, length cap. Throws a clear, field-specific message."""
 	label = normalize(subdomain)
 	if not label:
-		frappe.throw("A subdomain is required")
+		frappe.throw(_("A subdomain is required"))
 	if "." in label:
-		frappe.throw("Subdomain must be a single label with no dots")
+		frappe.throw(_("Subdomain must be a single label with no dots"))
 	if label != label.lower():
-		frappe.throw("Subdomain must be lowercase")
+		frappe.throw(_("Subdomain must be lowercase"))
 	if len(label) > LABEL_MAX_LENGTH:
 		frappe.throw(f"Subdomain must be at most {LABEL_MAX_LENGTH} characters")
 	if label.startswith("-") or label.endswith("-"):
-		frappe.throw("Subdomain must not start or end with a hyphen")
+		frappe.throw(_("Subdomain must not start or end with a hyphen"))
 	if not all((c.isascii() and c.isalnum()) or c == "-" for c in label):
-		frappe.throw("Subdomain may only contain lowercase letters, digits, and hyphens")
+		frappe.throw(_("Subdomain may only contain lowercase letters, digits, and hyphens"))
 
 
 def validate_reserved(subdomain: str | None) -> None:

--- a/atlas/atlas/tls/letsencrypt.py
+++ b/atlas/atlas/tls/letsencrypt.py
@@ -13,6 +13,7 @@ line, which we parse back into an `IssuedCert`.
 from __future__ import annotations
 
 import frappe
+from frappe import _
 
 from atlas.atlas.dns.base import DnsProvider
 from atlas.atlas.local_task import run_local_task
@@ -44,9 +45,9 @@ class LetsEncryptProvider(TlsProvider):
 
 	def issue(self, domain: str, dns_provider: DnsProvider) -> IssuedCert:
 		if not self.agree_tos:
-			frappe.throw("Lets Encrypt Settings: agree_tos must be checked before issuing")
+			frappe.throw(_("Lets Encrypt Settings: agree_tos must be checked before issuing"))
 		if not self.account_email:
-			frappe.throw("Lets Encrypt Settings: account_email is required")
+			frappe.throw(_("Lets Encrypt Settings: account_email is required"))
 
 		variables = {
 			"DOMAIN": domain,

--- a/atlas/atlas/tls/self_managed.py
+++ b/atlas/atlas/tls/self_managed.py
@@ -11,6 +11,7 @@ vendor.
 from __future__ import annotations
 
 import frappe
+from frappe import _
 
 from atlas.atlas.dns.base import DnsProvider
 from atlas.atlas.tls import register
@@ -26,6 +27,8 @@ class SelfManagedTlsProvider(TlsProvider):
 
 	def issue(self, domain: str, dns_provider: DnsProvider) -> IssuedCert:
 		frappe.throw(
-			"Self-Managed TLS does not issue certificates. Place fullchain.pem and "
-			"privkey.pem at the TLS Certificate's paths, then use Push to Proxies."
+			_(
+				"Self-Managed TLS does not issue certificates. Place fullchain.pem and "
+				"privkey.pem at the TLS Certificate's paths, then use Push to Proxies."
+			)
 		)

--- a/atlas/atlas/tls/zerossl.py
+++ b/atlas/atlas/tls/zerossl.py
@@ -10,6 +10,7 @@ than "no implementation for provider_type".
 from __future__ import annotations
 
 import frappe
+from frappe import _
 
 from atlas.atlas.dns.base import DnsProvider
 from atlas.atlas.tls import register
@@ -24,4 +25,4 @@ class ZeroSslProvider(TlsProvider):
 		return AuthResult(ok=False, error="ZeroSSL is not implemented yet")
 
 	def issue(self, domain: str, dns_provider: DnsProvider) -> IssuedCert:
-		frappe.throw("ZeroSSL issuance is not implemented yet")
+		frappe.throw(_("ZeroSSL issuance is not implemented yet"))

--- a/atlas/bootstrap.py
+++ b/atlas/bootstrap.py
@@ -145,6 +145,7 @@ import time
 
 import frappe
 import frappe.utils.password
+from frappe import _
 
 PROVIDER_NAME = "bootstrap-provider"
 IMAGE_NAME = "ubuntu-24.04"
@@ -284,9 +285,11 @@ def run_self_serve(force_bake: bool = False) -> None:
 	tls_config = _read_tls_config()
 	if tls_config is None:
 		frappe.throw(
-			"run_self_serve needs the TLS config (atlas_tls_domain + Route53 + ACME keys) — "
-			"the signup flow routes through the regional wildcard. Set them, or use run() for "
-			"compute-only bootstrap."
+			_(
+				"run_self_serve needs the TLS config (atlas_tls_domain + Route53 + ACME keys) — "
+				"the signup flow routes through the regional wildcard. Set them, or use run() for "
+				"compute-only bootstrap."
+			)
 		)
 
 	# 1. Compute: settings → provider → server → base images (no smoke VM — the
@@ -374,6 +377,7 @@ def restore_credentials() -> None:
 			require_config("atlas_scw_secret_key"),
 			"secret_key",
 		)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist restored credentials so later bootstrap steps and enqueued jobs can read them
 	frappe.db.commit()
 	print(f"[bootstrap] restored Atlas/{provider_type} credentials from site config")
 
@@ -461,6 +465,7 @@ def ensure_provider() -> "frappe.model.document.Document":
 	elif provider_type == "Scaleway":
 		_seed_scaleway_settings()
 
+	# nosemgrep: frappe-manual-commit -- persist provider + seeded catalog before returning
 	frappe.db.commit()
 	return frappe.get_doc("Provider", PROVIDER_NAME)
 
@@ -512,8 +517,8 @@ def _seed_scaleway_settings() -> None:
 		frappe.db.set_single_value(
 			"Atlas Settings", "ssh_key_id", frappe.conf.get("atlas_ssh_key_id"), update_modified=False
 		)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist Scaleway Settings before the load-bearing discover() call that needs them
 	frappe.db.commit()
-
 	# Discover the live per-zone catalog (the offer_id / os_id UUIDs). Load-bearing —
 	# let the exception propagate so a bad key/zone fails the bootstrap loudly here
 	# rather than at the first opaque provision().
@@ -522,6 +527,7 @@ def _seed_scaleway_settings() -> None:
 
 	capabilities = ScalewayProvider().discover()
 	upsert_catalog("Scaleway", capabilities)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist discovered catalog rows so the default size/image Link targets exist below
 	frappe.db.commit()
 
 	size_name = f"Scaleway/{size_slug}"
@@ -538,6 +544,7 @@ def _seed_scaleway_settings() -> None:
 		)
 	frappe.db.set_single_value("Scaleway Settings", "default_size", size_name, update_modified=False)
 	frappe.db.set_single_value("Scaleway Settings", "default_image", image_name, update_modified=False)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist default size/image so subsequent provision() calls read them off Scaleway Settings
 	frappe.db.commit()
 	print(f"[bootstrap] seeded Scaleway Settings (zone={zone}, size={size_name}, image={image_name})")
 
@@ -592,6 +599,7 @@ def provision_server(provider: "frappe.model.document.Document") -> str:
 		# is async — the Server lands Pending and the worker polls describe() to
 		# Active, which wait_for_active_server already handles via its longer timeout.)
 		server_name = provider.provision_server(title)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the Server row so the enqueued boot job sees it cross-transaction
 	frappe.db.commit()
 	print(f"[bootstrap] provisioning Server {title!r} (name={server_name!r}; background job enqueued)")
 	return server_name
@@ -635,6 +643,7 @@ def ensure_image() -> "frappe.model.document.Document":
 	image = frappe.get_doc({"doctype": "Virtual Machine Image", **DEFAULT_IMAGE, "is_active": 1}).insert(
 		ignore_permissions=True
 	)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the base image row before later provisioning steps reference it
 	frappe.db.commit()
 	print(f"[bootstrap] created Virtual Machine Image {image.name!r}")
 	return image
@@ -696,6 +705,7 @@ def provision_virtual_machine(server_name: str) -> str:
 			"ssh_public_key": load_vm_ssh_public_key(),
 		}
 	).insert(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the VM row so the after_insert boot job sees it cross-transaction
 	frappe.db.commit()
 	print(f"[bootstrap] created Virtual Machine {virtual_machine.name!r}")
 	task_name = _wait_for_provision_task(virtual_machine.name)
@@ -815,6 +825,7 @@ def ensure_tls_layer(config: dict) -> None:
 		print(f"[bootstrap] created Root Domain {config['domain']!r} (region {config['region']!r})")
 	else:
 		print(f"[bootstrap] reusing Root Domain {config['domain']!r}")
+	# nosemgrep: frappe-manual-commit -- persist TLS/Domain rows before the cert issue step
 	frappe.db.commit()
 
 
@@ -824,6 +835,7 @@ def issue_certificate(domain: str) -> str:
 	the region. Returns the TLS Certificate name."""
 	print(f"[bootstrap] issuing *.{domain} via Let's Encrypt over Route 53 DNS-01 ...")
 	cert_name = frappe.get_doc("Root Domain", domain).issue_certificate()
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the issued TLS Certificate before reading its status/expiry back below
 	frappe.db.commit()
 	status, expires_on = frappe.db.get_value("TLS Certificate", cert_name, ["status", "expires_on"])
 	if status != "Active":
@@ -844,6 +856,7 @@ def push_certificate_to_proxies(domain: str) -> list[str]:
 	if not cert_name:
 		frappe.throw(f"no Active TLS Certificate for {domain!r} to push — issue it first")
 	pushed = frappe.get_doc("TLS Certificate", cert_name).push_to_proxies()
+	# nosemgrep: frappe-manual-commit -- persist cert push + published wildcard DNS state
 	frappe.db.commit()
 	print(f"[bootstrap] pushed {cert_name} + published wildcard for *.{domain} to {pushed or '(no proxies)'}")
 	return pushed
@@ -896,16 +909,19 @@ def bake_golden_image(server_name: str, force: bool = False) -> str:
 	print("[bootstrap] bench built in the guest; stopping + snapshotting ...")
 
 	vm.stop()
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the stop request before polling the DB for the Stopped status set by the boot job
 	frappe.db.commit()
 	_wait_for_vm_status(vm.name, "Stopped", timeout_seconds=180)
 	vm.reload()
 	snapshot_name = vm.snapshot(title=GOLDEN_SNAPSHOT_TITLE)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the snapshot row before polling the DB for the Available status set by the snapshot job
 	frappe.db.commit()
 	_wait_for_snapshot_available(snapshot_name, timeout_seconds=600)
 
 	frappe.db.set_single_value(
 		"Atlas Settings", "default_bench_snapshot", snapshot_name, update_modified=False
 	)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist default_bench_snapshot so self-serve clones find the freshly baked golden
 	frappe.db.commit()
 	print(f"[bootstrap] golden bench snapshot {snapshot_name} baked + wired as default_bench_snapshot")
 	return snapshot_name
@@ -974,8 +990,10 @@ def _ensure_reserved_ipv4(server_name: str, vm_name: str) -> str:
 		return attached[0]
 
 	reserved = reserved_ip_module.allocate(server_name)
+	# nosemgrep: frappe-manual-commit -- persist the allocated Reserved IP before the attach
 	frappe.db.commit()
 	frappe.get_doc("Reserved IP", reserved).attach(vm_name)
+	# nosemgrep: frappe-manual-commit -- persist the attach (vendor assign + NAT) state
 	frappe.db.commit()
 	ipv4 = frappe.db.get_value("Reserved IP", reserved, "ip_address")
 	print(f"[bootstrap] reserved IPv4 {ipv4} attached to proxy {vm_name} ({reserved})")
@@ -1005,9 +1023,11 @@ def _provision_durable_vm(
 	public_key = frappe.db.get_single_value("Atlas Settings", "ssh_public_key")
 	if not public_key:
 		frappe.throw(
-			"Atlas Settings.ssh_public_key is unset — a build/proxy VM needs the fleet key in "
-			"authorized_keys for the control plane to SSH in. Run ensure_provider / restore_credentials "
-			"first (they derive it from the private key)."
+			_(
+				"Atlas Settings.ssh_public_key is unset — a build/proxy VM needs the fleet key in "
+				"authorized_keys for the control plane to SSH in. Run ensure_provider / restore_credentials "
+				"first (they derive it from the private key)."
+			)
 		)
 	fields = {
 		"doctype": "Virtual Machine",
@@ -1023,6 +1043,7 @@ def _provision_durable_vm(
 		fields["is_proxy"] = 1
 		fields["region"] = region
 	vm = frappe.get_doc(fields).insert(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the VM row so the after_insert boot job sees it cross-transaction
 	frappe.db.commit()
 	print(f"[bootstrap] inserted VM {vm.name!r} ({title}); waiting for boot ...")
 	_wait_for_vm_running(vm.name)
@@ -1169,6 +1190,7 @@ def ensure_default_bench_snapshot() -> None:
 		frappe.db.set_single_value(
 			"Atlas Settings", "default_bench_snapshot", configured, update_modified=False
 		)
+		# nosemgrep: frappe-manual-commit -- bootstrap script: persist the configured default_bench_snapshot setting so self-serve clones find it
 		frappe.db.commit()
 		print(f"[bootstrap] default_bench_snapshot = {configured} (configured)")
 		return
@@ -1190,6 +1212,7 @@ def ensure_default_bench_snapshot() -> None:
 		return
 	snapshot = candidates[0]["name"]
 	frappe.db.set_single_value("Atlas Settings", "default_bench_snapshot", snapshot, update_modified=False)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the adopted default_bench_snapshot setting so self-serve clones find it
 	frappe.db.commit()
 	print(f"[bootstrap] default_bench_snapshot = {snapshot} (adopted newest Available golden-bench)")
 
@@ -1234,6 +1257,7 @@ def ensure_outbound_email() -> None:
 		}
 	)
 	account.save(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- bootstrap script: persist the outbound Email Account so verification emails can be sent
 	frappe.db.commit()
 	print(f"[bootstrap] outbound Email Account {name!r} configured ({from_address} via {host}:{port})")
 
@@ -1279,6 +1303,7 @@ def load_key(value: str) -> str:
 	path = os.path.expanduser(value)
 	if not os.path.isfile(path):
 		frappe.throw(f"key file not found at {path!r}")
+	# nosemgrep: frappe-security-file-traversal -- operator-supplied key path from site config (atlas_*_ssh_key), not untrusted web input
 	with open(path) as handle:
 		return handle.read().strip()
 
@@ -1293,5 +1318,6 @@ def load_vm_ssh_public_key() -> str:
 			"no SSH public key for the VM. Set atlas_vm_ssh_public_key in site "
 			f"config or place one at {default_path!r}"
 		)
+	# nosemgrep: frappe-security-file-traversal -- fixed ~/.ssh default path
 	with open(default_path) as handle:
 		return handle.read().strip()

--- a/atlas/patches/v1_0/migrate_workspace_to_onboarding.py
+++ b/atlas/patches/v1_0/migrate_workspace_to_onboarding.py
@@ -21,6 +21,7 @@ def _fixture_content() -> str:
 	"""Load the canonical workspace content from the on-disk fixture."""
 	app_path = frappe.get_app_path("atlas")
 	fixture_path = os.path.join(app_path, "atlas", "workspace", "atlas", "atlas.json")
+	# nosemgrep: frappe-security-file-traversal -- fixed fixture path derived from frappe.get_app_path("atlas"), not untrusted web input
 	with open(fixture_path) as handle:
 		fixture = json.load(handle)
 	return fixture["content"]

--- a/atlas/patches/v1_0/rename_server_to_uuid.py
+++ b/atlas/patches/v1_0/rename_server_to_uuid.py
@@ -55,12 +55,14 @@ def execute() -> None:
 def _assign_uuid_names() -> None:
 	"""For every Server row whose `name` is not already a UUID, mint a
 	new UUID, update the row, and rewrite every FK pointer in raw SQL."""
+	# nosemgrep: frappe-sql-format-injection -- static query literal, no string interpolation
 	rows = frappe.db.sql("SELECT name FROM `tabServer`", as_dict=True)
 	for row in rows:
 		old_name = row["name"]
 		if _is_uuid(old_name):
 			continue
 		new_name = str(uuid.uuid4())
+		# nosemgrep: frappe-sql-format-injection -- %s-parameterized query, no interpolation
 		frappe.db.sql(
 			"UPDATE `tabServer` SET `name` = %s WHERE `name` = %s",
 			(new_name, old_name),
@@ -68,6 +70,7 @@ def _assign_uuid_names() -> None:
 		for table, column in FK_TARGETS:
 			if not _table_exists(table):
 				continue
+			# nosemgrep: frappe-sql-format-injection -- table/column identifiers from the hardcoded FK_TARGETS constant; SQL identifiers can't be %s-parameterized (the values are)
 			frappe.db.sql(
 				f"UPDATE `{table}` SET `{column}` = %s WHERE `{column}` = %s",
 				(new_name, old_name),
@@ -85,6 +88,7 @@ def _is_uuid(value: str) -> bool:
 
 def _table_exists(table: str) -> bool:
 	return bool(
+		# nosemgrep: frappe-sql-format-injection -- %s-parameterized query, no interpolation
 		frappe.db.sql(
 			"SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = %s",
 			(table,),

--- a/atlas/www/dashboard.py
+++ b/atlas/www/dashboard.py
@@ -45,8 +45,10 @@ def _render_built_index(boot: dict) -> str | None:
 	"""The built SPA shell with its boot block expanded, or None before
 	`bench build --app atlas` has run."""
 	try:
+		# nosemgrep: frappe-security-file-traversal -- fixed SPA_INDEX path derived from the app dir, not untrusted web input
 		with open(SPA_INDEX) as handle:
 			shell = handle.read()
 	except FileNotFoundError:
 		return None
+	# nosemgrep: frappe-ssti -- template is the app's own built SPA shell read from disk, not user input
 	return frappe.render_template(shell, {"boot": boot})

--- a/bench/atlas-warm-freshen.py
+++ b/bench/atlas-warm-freshen.py
@@ -79,6 +79,7 @@ def _fetch_identity() -> dict | None:
 
 def _adopted_uuid() -> str:
 	try:
+		# nosemgrep: frappe-security-file-traversal -- guest script; reads the fixed VM_UUID_PATH marker, not untrusted web input
 		with open(VM_UUID_PATH) as handle:
 			return handle.read().strip()
 	except OSError:
@@ -90,6 +91,7 @@ def _reseed_rng(uuid: str) -> None:
 	Writing to /dev/urandom mixes without crediting entropy; RNDRESEEDCRNG then
 	makes the CRNG consume it immediately, so the very next getrandom() output
 	already diverges per clone."""
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed /dev/urandom device, not untrusted web input
 	with open("/dev/urandom", "wb") as handle:
 		handle.write(f"{uuid}:{time.time_ns()}".encode() + os.urandom(32))
 		fcntl.ioctl(handle, RNDRESEEDCRNG)
@@ -128,6 +130,7 @@ def _apply(identity: dict) -> None:
 	)
 	_run("systemctl", "try-restart", "ssh.service")
 	_run("systemctl", "try-restart", "ssh.socket")
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed /root/.ssh/authorized_keys path, not untrusted web input
 	with open("/root/.ssh/authorized_keys", "w") as handle:
 		handle.write(identity["ssh_public_key"] + "\n")
 
@@ -137,16 +140,20 @@ def _apply(identity: dict) -> None:
 	# sees the clone's.
 	for machine_id_path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
 		_run("sh", "-c", f"echo {identity['machine_id']} > {machine_id_path}")
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed /etc/hostname path, not untrusted web input
 	with open("/etc/hostname", "w") as handle:
 		handle.write(hostname + "\n")
 	_run("hostname", hostname)
+	# nosemgrep: frappe-security-file-traversal -- guest script; reads the fixed /etc/hosts path, not untrusted web input
 	with open("/etc/hosts") as handle:
 		existing = handle.read()
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed /etc/hosts path, not untrusted web input
 	with open("/etc/hosts", "w") as handle:
 		handle.write(hosts_lines(existing, hostname))
 
 	# 3. The on-disk network env, so a later plain reboot of this clone brings
 	# its own addresses up through the ordinary atlas-network.service path.
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed NETWORK_ENV_PATH, not untrusted web input
 	with open(NETWORK_ENV_PATH, "w") as handle:
 		handle.write(network_env(identity))
 
@@ -172,6 +179,7 @@ def _apply(identity: dict) -> None:
 
 	# 7. The applied marker, last — also what tells a plain reboot of this clone
 	# (and an idempotent re-poll) that there is nothing left to adopt.
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed VM_UUID_PATH marker, not untrusted web input
 	with open(VM_UUID_PATH, "w") as handle:
 		handle.write(identity["uuid"] + "\n")
 	print(f"freshen: adopted identity {identity['uuid']} ({hostname})", flush=True)

--- a/bench/deploy-site.py
+++ b/bench/deploy-site.py
@@ -174,6 +174,7 @@ def _await_freshen(warm_vm_uuid: str, timeout_seconds: int = 60) -> None:
 	deadline = time.monotonic() + timeout_seconds
 	while time.monotonic() < deadline:
 		try:
+			# nosemgrep: frappe-security-file-traversal -- guest script; reads the fixed /etc/atlas-vm-uuid path, not untrusted web input
 			with open("/etc/atlas-vm-uuid") as handle:
 				if handle.read().strip() == warm_vm_uuid:
 					return
@@ -265,6 +266,7 @@ def _set_admin_domain(fqdn: str) -> None:
 	TOML library in the guest, stdlib-only) then run `bench setup nginx`. Idempotent:
 	re-running rewrites the same line. Fails loud if the admin domain line is absent
 	(a clone from the wrong/old snapshot)."""
+	# nosemgrep: frappe-security-file-traversal -- guest script; reads the fixed BENCH_TOML path, not untrusted web input
 	with open(BENCH_TOML) as f:
 		text = f.read()
 	out_lines = []
@@ -278,6 +280,7 @@ def _set_admin_domain(fqdn: str) -> None:
 			out_lines.append(line)
 	if not replaced:
 		sys.exit(f"no [admin].domain line in {BENCH_TOML}; this VM was not baked from an admin-mode golden")
+	# nosemgrep: frappe-security-file-traversal -- guest script; writes the fixed BENCH_TOML path, not untrusted web input
 	with open(BENCH_TOML, "w") as f:
 		f.write("".join(out_lines))
 	_bench("setup", "nginx")

--- a/scripts/lib/atlas/_run.py
+++ b/scripts/lib/atlas/_run.py
@@ -108,6 +108,7 @@ def install_file(content: str, dest: str, *, mode: str = "0644", sudo: bool = Tr
 	spooled regular file is seekable, so install copies it 30/30."""
 	with tempfile.NamedTemporaryFile("w", prefix="atlas-install-", delete=False) as spool:
 		spool.write(content)
+		# nosemgrep: tempfile-without-flush -- false positive: the file is closed (and flushed) by the with-block exit before install reads src below
 		src = spool.name
 	try:
 		argv = (["sudo"] if sudo else []) + ["install", "-m", mode, src, dest]

--- a/scripts/lib/atlas/hostinfo.py
+++ b/scripts/lib/atlas/hostinfo.py
@@ -62,6 +62,7 @@ def parse_firecracker_version(output: str) -> str:
 def host_signature() -> dict:
 	"""The live host's signature: CPU identity + kernel + Firecracker version.
 	Compared by plain dict equality against the captured one."""
+	# nosemgrep: frappe-security-file-traversal -- host script; reads the fixed CPUINFO_PATH (/proc/cpuinfo), not web input
 	with open(CPUINFO_PATH) as handle:
 		signature = parse_cpu_signature(handle.read())
 	signature["kernel"] = platform.release()

--- a/scripts/lib/atlas/network_env.py
+++ b/scripts/lib/atlas/network_env.py
@@ -69,6 +69,7 @@ def read_network_env(path: str) -> NetworkEnv:
 	"""Read and parse a network.env file. Raises if the file is unreadable —
 	a missing env at disk-up/network-up time is a real failure (the VM was never
 	provisioned), so unlike the down path we do not tolerate absence here."""
+	# nosemgrep: frappe-security-file-traversal -- host/guest script; reads a per-VM network.env path derived from the VM name, not untrusted web input
 	with open(path) as handle:
 		return NetworkEnv.parse(handle.read())
 

--- a/scripts/vm-reserved-ip.py
+++ b/scripts/vm-reserved-ip.py
@@ -60,6 +60,7 @@ def main() -> None:
 	guest_ipv4 = env.require("IPV4_GUEST_CIDR").split("/", 1)[0]
 	host_veth = env.require("HOST_VETH")
 
+	# nosemgrep: frappe-security-file-traversal -- host script; reads the per-VM network.env path derived from the VM name, not untrusted web input
 	with open(paths.network_env) as handle:
 		current = handle.read()
 

--- a/scripts/vm-restore.py
+++ b/scripts/vm-restore.py
@@ -93,6 +93,7 @@ def _signature_mismatch(paths: VirtualMachinePaths) -> str:
 	if not os.path.exists(paths.memory_snapshot_signature):
 		return ""
 	try:
+		# nosemgrep: frappe-security-file-traversal -- host script; reads the per-VM snapshot signature path derived from the VM name, not untrusted web input
 		with open(paths.memory_snapshot_signature) as handle:
 			captured = json.load(handle)
 	except (OSError, ValueError) as error:
@@ -110,6 +111,7 @@ def _stage_mmds(paths: VirtualMachinePaths) -> None:
 	"""PUT the staged identity payload (if any) into the metadata service."""
 	if not os.path.exists(paths.metadata_file):
 		return
+	# nosemgrep: frappe-security-file-traversal -- host script; reads the per-VM metadata file path derived from the VM name, not untrusted web input
 	with open(paths.metadata_file) as handle:
 		payload = handle.read()
 	firecracker_api(paths.api_socket_directory, paths.api_socket_name, "PUT", "/mmds", payload)


### PR DESCRIPTION
## Summary

Brings the app into compliance with the `frappe-semgrep-rules` ruleset, with no behavioural change:

- Wraps user-facing `frappe.throw` strings in `_()` for translation.
- Annotates legitimate `frappe.db.commit()` calls (background jobs, bootstrap script, demo seeders) with justified `# nosemgrep: frappe-manual-commit` comments.
- Annotates trusted file reads (operator-supplied / fixed paths) with `# nosemgrep: frappe-security-file-traversal`.
- Annotates the public signup on-ramp with `# nosemgrep: guest-whitelisted-method` (validated, capped, rate-limited).
- Suppresses a `tempfile-without-flush` false positive in `_run.install_file`.
- Minor fix: use `frm` instead of `cur_frm` in `virtual_machine.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)