### PR TITLE
fix(central): Update API method references to include 'atlas' prefix

### DIFF
--- a/atlas/atlas/central.py
+++ b/atlas/atlas/central.py
@@ -5,14 +5,14 @@ many Atlas instances; Atlas is the *client*. This is the inverse of the Provider
 relationship — so the client mirrors atlas/atlas/digitalocean.py: a thin
 requests wrapper, one *Error type, dataclasses for the typed responses.
 
-Atlas calls Central's whitelisted methods at `<url>/api/method/central.api.<name>`
+Atlas calls Central's whitelisted methods at `<url>/api/method/central.api.atlas.<name>`
 with a `token <api_key>:<api_secret>` header (spec/16-central.md § "The wire
 contract"). Central owns the `Atlas Instance` registry: the operator pre-creates
 one row per region (with this Atlas's callback `api_key`/`api_secret`), and:
 
-- **ping** — `central.api.ping` returns `{label}`; a credential + reachability
+- **ping** — `central.api.atlas.ping` returns `{label}`; a credential + reachability
   check for the Test Connection toast.
-- **register** — `central.api.register` matches the operator-created row by
+- **register** — `central.api.atlas.register` matches the operator-created row by
   region and stamps a stable `atlas_id`, which Atlas then stores and reports on
   every event so Central can route them to this cluster.
 
@@ -32,11 +32,11 @@ DEFAULT_TIMEOUT = 30
 # Central method routes. Pinned in one place — the wire contract from
 # spec/16-central.md § "The wire contract".
 _ROUTES = {
-	"ping": "central.api.ping",
-	"register": "central.api.register",
-	"sizes": "central.api.sizes",
-	"images": "central.api.images",
-	"event": "central.api.event",
+	"ping": "central.api.atlas.ping",
+	"register": "central.api.atlas.register",
+	"sizes": "central.api.atlas.sizes",
+	"images": "central.api.atlas.images",
+	"event": "central.api.atlas.event",
 }
 
 

--- a/atlas/atlas/doctype/central_settings/central_settings.py
+++ b/atlas/atlas/doctype/central_settings/central_settings.py
@@ -74,7 +74,7 @@ class CentralSettings(Document):
 		"""The registration payload Central matches against its operator-created
 		Atlas Instance row. Central keys on region; base_url is sent so the operator
 		can confirm the row points at this Atlas. Field names match Central's
-		`central.api.register` contract."""
+		`central.api.atlas.register` contract."""
 		region = self.region or frappe.conf.get("atlas_do_region")
 		if not region:
 			frappe.throw("Set a Region (or atlas_do_region in site config) before registering")

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -46,7 +46,7 @@ class TestCentralClient(IntegrationTestCase):
 			self.client.ping()
 		args, kwargs = request.call_args
 		self.assertEqual(args[0], "GET")
-		self.assertEqual(args[1], "https://central.example/api/method/central.api.ping")
+		self.assertEqual(args[1], "https://central.example/api/method/central.api.atlas.ping")
 		self.assertEqual(kwargs["headers"]["Authorization"], "token ak:secret")
 
 	def test_ping_ok(self) -> None:

--- a/spec/16-central.md
+++ b/spec/16-central.md
@@ -124,16 +124,16 @@ drained by a minutely `scheduler_events` job for at-least-once delivery.
 ## The wire contract
 
 Atlas calls Central's whitelisted methods at
-`<url>/api/method/central.api.<name>` with
+`<url>/api/method/central.api.atlas.<name>` with
 `Authorization: token <api_key>:<api_secret>`. The methods Atlas expects:
 
 | Atlas call | Central method | Returns |
 | --- | --- | --- |
-| `ping` | `central.api.ping` | `{ label }` |
-| `register` | `central.api.register` | `{ atlas_id, label }` |
-| `fetch_sizes` | `central.api.sizes` | `[ { slug, title, vcpus, cpu_max_cores, memory_megabytes, disk_gigabytes, monthly_cost_usd } ]` |
-| `fetch_images` | `central.api.images` | `[ { image_name, title, series } ]` |
-| `post_event` | `central.api.event` | (ignored) |
+| `ping` | `central.api.atlas.ping` | `{ label }` |
+| `register` | `central.api.atlas.register` | `{ atlas_id, label }` |
+| `fetch_sizes` | `central.api.atlas.sizes` | `[ { slug, title, vcpus, cpu_max_cores, memory_megabytes, disk_gigabytes, monthly_cost_usd } ]` |
+| `fetch_images` | `central.api.atlas.images` | `[ { image_name, title, series } ]` |
+| `post_event` | `central.api.atlas.event` | (ignored) |
 
 The route names and payloads are the single external dependency; the whole
 contract is absorbed in `atlas/atlas/central.py` (`CentralClient`), so a change


### PR DESCRIPTION
Modified Central API method calls in central.py, central_settings.py, and test_central.py to reflect the new 'atlas' namespace. Updated documentation in 16-central.md to ensure consistency with the new method paths.