### PR TITLE
fix: Restore valid exception syntax for Python 3.12 compatibility

### DIFF
--- a/atlas/atlas/_ssh/transport.py
+++ b/atlas/atlas/_ssh/transport.py
@@ -333,5 +333,5 @@ def forget_host(host: str) -> None:
 			timeout=15,
 			check=False,
 		)
-	except FileNotFoundError, subprocess.SubprocessError:
+	except (FileNotFoundError, subprocess.SubprocessError):
 		pass

--- a/atlas/atlas/deploy_site.py
+++ b/atlas/atlas/deploy_site.py
@@ -233,7 +233,7 @@ def _http_ok(ipv6_address: str, host_header: str, port: int, path: str) -> bool:
 		conn = http.client.HTTPConnection(ipv6_address, port, timeout=10)
 		conn.request("GET", path, headers={"Host": host_header})
 		return conn.getresponse().status == 200
-	except OSError, http.client.HTTPException:
+	except (OSError, http.client.HTTPException):
 		return False
 	finally:
 		if conn is not None:

--- a/atlas/atlas/doctype/port_mapping/port_mapping.py
+++ b/atlas/atlas/doctype/port_mapping/port_mapping.py
@@ -103,7 +103,7 @@ def port_pool() -> tuple[int, int]:
 	try:
 		low_str, high_str = str(raw).split("-", 1)
 		low, high = int(low_str), int(high_str)
-	except ValueError, AttributeError:
+	except (ValueError, AttributeError):
 		frappe.throw(f"Atlas Settings.{PORT_POOL_FIELD} must be 'LOW-HIGH' (e.g. 10000-19999), got {raw!r}")
 	if low > high:
 		frappe.throw(f"Atlas Settings.{PORT_POOL_FIELD} range is inverted: {raw!r}")

--- a/atlas/atlas/doctype/ssh_key/ssh_key.py
+++ b/atlas/atlas/doctype/ssh_key/ssh_key.py
@@ -59,7 +59,7 @@ def fingerprint(public_key: str) -> str:
 		frappe.throw(f"Unsupported SSH key type {key_type!r}.")
 	try:
 		raw = base64.b64decode(blob, validate=True)
-	except binascii.Error, ValueError:
+	except (binascii.Error, ValueError):
 		frappe.throw(_("SSH key body is not valid base64."))
 	digest = base64.b64encode(hashlib.sha256(raw).digest()).decode().rstrip("=")
 	return f"SHA256:{digest}"

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -205,7 +205,7 @@ def _fake_disk_bytes(variables: dict) -> int:
 	"""A plausible rootfs size: the VM's disk in bytes, defaulting to ~4 GB."""
 	try:
 		gigabytes = int(variables.get("DISK_GB") or 4)
-	except TypeError, ValueError:
+	except (TypeError, ValueError):
 		gigabytes = 4
 	return gigabytes * 1024 * 1024 * 1024
 

--- a/atlas/atlas/providers/scaleway.py
+++ b/atlas/atlas/providers/scaleway.py
@@ -469,7 +469,7 @@ def _metadata_value(doctype: str, name: str, key: str) -> str | None:
 		return None
 	try:
 		return json.loads(raw).get(key)
-	except ValueError, TypeError:
+	except (ValueError, TypeError):
 		return None
 
 

--- a/atlas/patches/v1_0/rename_server_to_uuid.py
+++ b/atlas/patches/v1_0/rename_server_to_uuid.py
@@ -82,7 +82,7 @@ def _is_uuid(value: str) -> bool:
 	try:
 		uuid.UUID(value)
 		return True
-	except ValueError, AttributeError, TypeError:
+	except (ValueError, AttributeError, TypeError):
 		return False
 
 

--- a/scripts/lib/atlas/lvm.py
+++ b/scripts/lib/atlas/lvm.py
@@ -175,7 +175,7 @@ class LogicalVolume:
 	def _node_is_block_device(self) -> bool:
 		try:
 			return stat.S_ISBLK(os.stat(self.device_path).st_mode)
-		except FileNotFoundError, PermissionError:
+		except (FileNotFoundError, PermissionError):
 			return False
 
 


### PR DESCRIPTION
**Problem**
[Commit](https://github.com/adityahase/atlas/commit/164bcef92b11c0fb5d8e27d9fd36fd437ef843e3) introduced 3.14 python syntax that led to server bootstrap crashes.

**Solution**
Fix only the syntax changes.