### PR TITLE
fix: Wait for VM service to become active before failing

### DIFF
--- a/atlas/tests/e2e/scripts/phase5-is-active.sh
+++ b/atlas/tests/e2e/scripts/phase5-is-active.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 # Phase 5 e2e: assert the VM's systemd unit is active.
+
 set -euo pipefail
 
 : "${VIRTUAL_MACHINE_NAME:?}"
-sudo systemctl is-active "firecracker-vm@${VIRTUAL_MACHINE_NAME}.service"
+
+for _ in $(seq 1 30); do
+    if systemctl is-active --quiet "firecracker-vm@${VIRTUAL_MACHINE_NAME}.service"; then
+        exit 0
+    fi
+
+    sleep 1
+done
+
+echo "VM never became active"
+exit 1


### PR DESCRIPTION
Fix a race condition in the VM lifecycle e2e check where `systemctl is-active` could return `activating` while the Firecracker service was still starting. Poll for the service to reach `active` before failing, making the test reliable during VM startup.