### PR TITLE
feat: WireGuard VPN broker + per-VM public firewall

### DIFF
--- a/atlas/atlas/api/firewall.py
+++ b/atlas/atlas/api/firewall.py
@@ -1,0 +1,106 @@
+"""The per-VM firewall API — a VM owner (or Central) sets which public ports are
+open (spec/20-firewall.md).
+
+The user-facing write half of the firewall, mirroring `tunnel.request_tunnel`: it
+is owner-scoped and Central-callable as the service user (the caller must be an
+operator or own the VM), runs with `ignore_permissions` after the explicit access
+check, and reconciles the one per-VM `Firewall` row before pushing it to the host.
+
+The VPN tunnel always bypasses the firewall (full access); this only governs the
+public surface. An empty rule set is a valid deny-all-public (VPN-only) firewall.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+from atlas.atlas.permissions import _is_operator
+
+
+@frappe.whitelist()
+def set_firewall(
+	virtual_machine: str,
+	rules: list | str | None = None,
+	enabled: bool = True,
+	label: str | None = None,
+) -> dict:
+	"""Create or update the VM's firewall and apply it on the host.
+
+	`rules` is a list of `{"protocol": "tcp"|"udp", "port": int}` (or `"tcp/443"`
+	tokens), JSON-encoded when called over HTTP. An empty/omitted list with
+	`enabled` is a deny-all-public firewall."""
+	_assert_can_access_vm(virtual_machine)
+	parsed = _parse_rules(rules)
+
+	name = frappe.db.get_value("Firewall", {"virtual_machine": virtual_machine})
+	firewall = frappe.get_doc("Firewall", name) if name else frappe.new_doc("Firewall")
+	if not name:
+		firewall.virtual_machine = virtual_machine
+	if label is not None:
+		firewall.label = label
+	firewall.enabled = 1 if frappe.utils.sbool(enabled) else 0
+	firewall.set("rules", [{"protocol": protocol, "port": port} for (protocol, port) in parsed])
+	firewall.save(ignore_permissions=True)  # validates rules + immutability
+	firewall.sync()  # apply (or clear, if disabled) on the host
+	return _state(firewall)
+
+
+@frappe.whitelist()
+def get_firewall(virtual_machine: str) -> dict | None:
+	"""The VM's current firewall, or None if it has none (fully public)."""
+	_assert_can_access_vm(virtual_machine)
+	name = frappe.db.get_value("Firewall", {"virtual_machine": virtual_machine})
+	return _state(frappe.get_doc("Firewall", name)) if name else None
+
+
+@frappe.whitelist()
+def remove_firewall(virtual_machine: str) -> dict:
+	"""Delete the VM's firewall, reopening it to the public internet. The row's
+	on_trash clears the nft block on the host. A no-op if none exists."""
+	_assert_can_access_vm(virtual_machine)
+	name = frappe.db.get_value("Firewall", {"virtual_machine": virtual_machine})
+	if name:
+		frappe.get_doc("Firewall", name).delete(ignore_permissions=True)
+	return {"virtual_machine": virtual_machine, "status": "Disabled", "enabled": False, "rules": []}
+
+
+def _assert_can_access_vm(virtual_machine: str) -> None:
+	"""Operator, or the VM's owner — the `tunnel.request_tunnel` access model."""
+	if not frappe.db.exists("Virtual Machine", virtual_machine):
+		frappe.throw(_("Virtual Machine {0} not found").format(virtual_machine))
+	user = frappe.session.user
+	if _is_operator(user):
+		return
+	if frappe.db.get_value("Virtual Machine", virtual_machine, "owner") != user:
+		raise frappe.PermissionError(_("You do not have access to this Virtual Machine"))
+
+
+def _parse_rules(rules) -> list[tuple[str, int]]:
+	"""Normalize the `rules` argument (JSON string, list of dicts, or proto/port
+	tokens) to `(protocol, port)` tuples. Shape only — the Firewall row's validate()
+	is the single source of truth for valid protocols and port ranges."""
+	if not rules:
+		return []
+	if isinstance(rules, str):
+		rules = frappe.parse_json(rules)
+	parsed: list[tuple[str, int]] = []
+	for rule in rules:
+		if isinstance(rule, str):
+			protocol, _, port = rule.partition("/")
+		else:
+			protocol, port = rule.get("protocol"), rule.get("port")
+		parsed.append((protocol, int(port)))
+	return parsed
+
+
+def _state(firewall) -> dict:
+	"""The firewall's public shape: identity, host status, and the allowed ports."""
+	return {
+		"name": firewall.name,
+		"virtual_machine": firewall.virtual_machine,
+		"server": firewall.server,
+		"enabled": bool(firewall.enabled),
+		"status": firewall.status,
+		"rules": [f"{rule.protocol}/{rule.port}" for rule in firewall.rules],
+	}

--- a/atlas/atlas/api/test_firewall.py
+++ b/atlas/atlas/api/test_firewall.py
@@ -1,0 +1,117 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.api import firewall as module
+from atlas.atlas.doctype.firewall import firewall as controller
+from atlas.atlas.doctype.virtual_machine.test_virtual_machine import (
+	_ensure_test_image,
+	_ensure_test_server,
+	_new_vm,
+)
+from atlas.tests._mocks import fake_task
+from atlas.tests.test_ssh_key import _ensure_atlas_user_role, _make_user
+
+INTRUDER = "firewall-intruder@example.com"
+OWNER = "firewall-owner@example.com"
+
+
+def _purge() -> None:
+	with patch.object(controller, "run_task", return_value=fake_task(name="fw")):
+		for name in frappe.get_all("Firewall", pluck="name"):
+			frappe.delete_doc("Firewall", name, force=1, ignore_permissions=True)
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestFirewallApi(IntegrationTestCase):
+	def setUp(self) -> None:
+		_ensure_test_server()
+		_ensure_test_image()
+		_ensure_atlas_user_role()
+		_purge()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def test_sets_and_applies(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")) as run_task:
+			state = module.set_firewall(vm.name, rules=[{"protocol": "tcp", "port": 443}], label="web")
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(state["status"], "Active")
+		self.assertEqual(state["rules"], ["tcp/443"])
+		self.assertEqual(kwargs["variables"]["ACTION"], "apply")
+		self.assertEqual(kwargs["variables"]["RULE"], ["tcp/443"])
+		row = frappe.get_doc("Firewall", state["name"])
+		self.assertEqual(row.label, "web")
+
+	def test_accepts_token_rules(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")):
+			state = module.set_firewall(vm.name, rules=["tcp/443", "udp/1194"])
+		self.assertEqual(state["rules"], ["tcp/443", "udp/1194"])
+
+	def test_empty_rules_is_deny_all_public(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")) as run_task:
+			state = module.set_firewall(vm.name, rules=[])
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(state["status"], "Active")
+		self.assertEqual(state["rules"], [])
+		self.assertEqual(kwargs["variables"]["RULE"], [])
+
+	def test_disabled_clears(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")) as run_task:
+			state = module.set_firewall(vm.name, rules=["tcp/443"], enabled=False)
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(state["status"], "Disabled")
+		self.assertEqual(kwargs["variables"]["ACTION"], "clear")
+
+	def test_update_reuses_the_one_row(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")):
+			first = module.set_firewall(vm.name, rules=["tcp/443"])
+			second = module.set_firewall(vm.name, rules=["tcp/80", "tcp/443"])
+		self.assertEqual(first["name"], second["name"])
+		self.assertEqual(second["rules"], ["tcp/80", "tcp/443"])
+		names = frappe.get_all("Firewall", filters={"virtual_machine": vm.name}, pluck="name")
+		self.assertEqual(len(names), 1)
+
+	def test_get_firewall_none_when_absent(self) -> None:
+		vm = _new_vm()
+		self.assertIsNone(module.get_firewall(vm.name))
+
+	def test_remove_firewall_deletes_and_clears(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")) as run_task:
+			module.set_firewall(vm.name, rules=["tcp/443"])
+			run_task.reset_mock()
+			result = module.remove_firewall(vm.name)
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(result["status"], "Disabled")
+		self.assertEqual(kwargs["variables"]["ACTION"], "clear")
+		self.assertEqual(frappe.get_all("Firewall", filters={"virtual_machine": vm.name}), [])
+
+	def test_rejects_unknown_vm(self) -> None:
+		with self.assertRaises(frappe.ValidationError) as raised:
+			module.set_firewall("00000000-0000-0000-0000-000000000000", rules=["tcp/443"])
+		self.assertIn("not found", str(raised.exception))
+
+	def test_owner_may_set(self) -> None:
+		vm = _new_vm()
+		frappe.db.set_value("Virtual Machine", vm.name, "owner", OWNER)
+		_make_user(OWNER, role="Atlas User")
+		frappe.set_user(OWNER)
+		with patch.object(controller, "run_task", return_value=fake_task(name="fw")):
+			state = module.set_firewall(vm.name, rules=["tcp/443"])
+		self.assertEqual(state["status"], "Active")
+
+	def test_non_owner_is_denied(self) -> None:
+		vm = _new_vm()  # owned by Administrator
+		_make_user(INTRUDER, role="Atlas User")
+		frappe.set_user(INTRUDER)
+		with self.assertRaises(frappe.PermissionError):
+			module.set_firewall(vm.name, rules=["tcp/443"])
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.get_all("Firewall", filters={"virtual_machine": vm.name}), [])

--- a/atlas/atlas/api/test_tunnel.py
+++ b/atlas/atlas/api/test_tunnel.py
@@ -1,0 +1,93 @@
+import base64
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.api import tunnel as module
+from atlas.atlas.doctype.virtual_machine.test_virtual_machine import (
+	_ensure_test_image,
+	_ensure_test_server,
+	_new_vm,
+)
+from atlas.atlas.doctype.vpn_tunnel import vpn_tunnel as controller
+from atlas.atlas.networking import TUNNEL_PORT_BASE
+from atlas.tests._mocks import fake_task
+from atlas.tests.test_ssh_key import _ensure_atlas_user_role, _make_user
+
+CLIENT_PUB = base64.standard_b64encode(b"\x22" * 32).decode()
+SERVER_PUB = base64.standard_b64encode(b"\x33" * 32).decode()
+INTRUDER = "tunnel-intruder@example.com"
+OWNER = "tunnel-owner@example.com"
+
+
+def _up_task():
+	return fake_task(name="task-up", stdout=f'ATLAS_RESULT={{"server_public_key": "{SERVER_PUB}"}}')
+
+
+def _purge() -> None:
+	for name in frappe.get_all("VPN Tunnel", pluck="name"):
+		frappe.delete_doc("VPN Tunnel", name, force=1, ignore_permissions=True)
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestRequestTunnel(IntegrationTestCase):
+	def setUp(self) -> None:
+		_ensure_test_server()
+		_ensure_test_image()
+		_ensure_atlas_user_role()
+		_purge()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def test_returns_a_ready_client_config(self) -> None:
+		vm = _new_vm()
+		with patch.object(controller, "run_task", return_value=_up_task()):
+			config = module.request_tunnel(vm.name, CLIENT_PUB, label="laptop")
+		server_ipv4 = frappe.db.get_value("Server", vm.server, "ipv4_address")
+		self.assertEqual(config["server_public_key"], SERVER_PUB)
+		self.assertEqual(config["allowed_ips"], f"{vm.ipv6_address}/128")
+		self.assertEqual(config["endpoint"], f"{server_ipv4}:{TUNNEL_PORT_BASE}")
+		self.assertTrue(config["client_address"].endswith("/128"))
+		# The config is ready to paste, with the client's own key left blank and
+		# the host key + endpoint + scoped AllowedIPs filled in.
+		self.assertIn("PrivateKey = <your client private key>", config["config"])
+		self.assertIn(SERVER_PUB, config["config"])
+		self.assertIn(config["endpoint"], config["config"])
+		self.assertIn(f"{vm.ipv6_address}/128", config["config"])
+		self.assertIn("wg genkey", config["instructions"])
+		# The row landed Active.
+		tunnel = frappe.get_doc("VPN Tunnel", config["name"])
+		self.assertEqual(tunnel.status, "Active")
+		self.assertEqual(tunnel.label, "laptop")
+
+	def test_rejects_invalid_client_key(self) -> None:
+		vm = _new_vm()
+		with self.assertRaises(frappe.ValidationError) as raised:
+			module.request_tunnel(vm.name, "not-a-key")
+		self.assertIn("valid WireGuard public key", str(raised.exception))
+		# Nothing was created.
+		self.assertEqual(frappe.get_all("VPN Tunnel", filters={"virtual_machine": vm.name}), [])
+
+	def test_rejects_unknown_vm(self) -> None:
+		with self.assertRaises(frappe.ValidationError) as raised:
+			module.request_tunnel("00000000-0000-0000-0000-000000000000", CLIENT_PUB)
+		self.assertIn("not found", str(raised.exception))
+
+	def test_owner_may_request(self) -> None:
+		vm = _new_vm()
+		frappe.db.set_value("Virtual Machine", vm.name, "owner", OWNER)
+		_make_user(OWNER, role="Atlas User")
+		frappe.set_user(OWNER)
+		with patch.object(controller, "run_task", return_value=_up_task()):
+			config = module.request_tunnel(vm.name, CLIENT_PUB)
+		self.assertEqual(config["server_public_key"], SERVER_PUB)
+
+	def test_non_owner_is_denied(self) -> None:
+		vm = _new_vm()  # owned by Administrator
+		_make_user(INTRUDER, role="Atlas User")
+		frappe.set_user(INTRUDER)
+		with self.assertRaises(frappe.PermissionError):
+			module.request_tunnel(vm.name, CLIENT_PUB)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.get_all("VPN Tunnel", filters={"virtual_machine": vm.name}), [])

--- a/atlas/atlas/api/tunnel.py
+++ b/atlas/atlas/api/tunnel.py
@@ -1,0 +1,104 @@
+"""The VPN-broker API — a VM owner (or Central) asks Atlas for a tunnel.
+
+The user-facing write half of the broker (spec/19-vpn-broker.md). Like
+`provision.create_vm`, it is owner-scoped and Central-callable as the service
+user: the caller must be an operator or own the target VM. The client mints its
+own keypair and sends only its public key; the response carries everything to
+assemble a ready WireGuard config (the host public key, the endpoint, the
+AllowedIPs scoped to the one VM, the assigned overlay address) plus a copy-paste
+template and setup steps.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+from atlas.atlas.networking import tunnel_endpoint_address
+from atlas.atlas.permissions import _is_operator
+from atlas.atlas.wireguard import is_valid_public_key
+
+_INSTRUCTIONS = (
+	"1. Generate a keypair (the private key stays on your machine):\n"
+	"     wg genkey | tee privatekey | wg pubkey > publickey\n"
+	"2. Request the tunnel with the PUBLIC key (this call).\n"
+	"3. Paste the returned `config` into /etc/wireguard/atlas.conf and fill in\n"
+	"   PrivateKey with the contents of `privatekey`.\n"
+	"4. Bring it up and reach the VM at its IPv6:\n"
+	"     wg-quick up atlas && ssh root@<vm-ipv6>"
+)
+
+
+@frappe.whitelist()
+def request_tunnel(virtual_machine: str, client_public_key: str, label: str | None = None) -> dict:
+	"""Provision a WireGuard tunnel to `virtual_machine` for the caller's client key.
+
+	Validates the client key, authorizes access to the VM, creates the `VPN Tunnel`
+	row (allocating its slot/port/overlay), brings it up on the host (which mints
+	the host key and returns its public half), and returns the client config. Runs
+	with `ignore_permissions` after the explicit access check — operator
+	orchestration authorized by ownership, the `provision.create_vm` pattern."""
+	if not is_valid_public_key(client_public_key):
+		frappe.throw(_("client_public_key is not a valid WireGuard public key"))
+	_assert_can_access_vm(virtual_machine)
+
+	tunnel = frappe.get_doc(
+		{
+			"doctype": "VPN Tunnel",
+			"virtual_machine": virtual_machine,
+			"client_public_key": client_public_key,
+			"label": label or "",
+		}
+	).insert(ignore_permissions=True)
+	tunnel.bring_up()
+	return _client_config(tunnel)
+
+
+def _assert_can_access_vm(virtual_machine: str) -> None:
+	"""Operator, or the VM's owner. Mirrors the SPA's owner scoping
+	(`permissions.owner_only`) and lets Central through as the service user that
+	owns the VMs it created."""
+	if not frappe.db.exists("Virtual Machine", virtual_machine):
+		frappe.throw(_("Virtual Machine {0} not found").format(virtual_machine))
+	user = frappe.session.user
+	if _is_operator(user):
+		return
+	if frappe.db.get_value("Virtual Machine", virtual_machine, "owner") != user:
+		raise frappe.PermissionError(_("You do not have access to this Virtual Machine"))
+
+
+def _client_config(tunnel) -> dict:
+	"""The ready-to-use client payload: the host public key, the endpoint, the
+	AllowedIPs scoped to the one VM, the client's overlay address, a copy-paste
+	`config`, and setup steps."""
+	virtual_machine_ipv6 = frappe.db.get_value("Virtual Machine", tunnel.virtual_machine, "ipv6_address")
+	endpoint = f"{tunnel_endpoint_address(tunnel.server)}:{tunnel.listen_port}"
+	allowed_ips = f"{virtual_machine_ipv6}/128"
+	client_address = f"{tunnel.client_address}/128"
+	return {
+		"name": tunnel.name,
+		"interface": tunnel.interface_name,
+		"server_public_key": tunnel.server_public_key,
+		"endpoint": endpoint,
+		"allowed_ips": allowed_ips,
+		"client_address": client_address,
+		"config": _render_config(tunnel.server_public_key, endpoint, allowed_ips, client_address),
+		"instructions": _INSTRUCTIONS,
+	}
+
+
+def _render_config(server_public_key: str, endpoint: str, allowed_ips: str, client_address: str) -> str:
+	"""A WireGuard .conf with a PrivateKey placeholder — the client fills in its own
+	private key (Atlas never sees it). PersistentKeepalive keeps the path open for a
+	client behind NAT (common for a v4 client)."""
+	return (
+		"[Interface]\n"
+		"PrivateKey = <your client private key>\n"
+		f"Address = {client_address}\n"
+		"\n"
+		"[Peer]\n"
+		f"PublicKey = {server_public_key}\n"
+		f"Endpoint = {endpoint}\n"
+		f"AllowedIPs = {allowed_ips}\n"
+		"PersistentKeepalive = 25\n"
+	)

--- a/atlas/atlas/doctype/firewall/firewall.js
+++ b/atlas/atlas/doctype/firewall/firewall.js
@@ -29,7 +29,9 @@ function render_intro(frm) {
 	}
 	if (!frm.doc.enabled) {
 		frm.set_intro(
-			__("Disabled — the VM is fully public. Tick Enabled and Apply to host to restrict it."),
+			__(
+				"Disabled — the VM is fully public. Tick Enabled and Apply to host to restrict it."
+			),
 			"orange"
 		);
 		return;
@@ -54,7 +56,10 @@ function render_intro(frm) {
 			"green"
 		);
 	} else {
-		frm.set_intro(__("Edited but not yet pushed. Click Apply to host to enforce these rules."), "orange");
+		frm.set_intro(
+			__("Edited but not yet pushed. Click Apply to host to enforce these rules."),
+			"orange"
+		);
 	}
 }
 

--- a/atlas/atlas/doctype/firewall/firewall.js
+++ b/atlas/atlas/doctype/firewall/firewall.js
@@ -17,11 +17,7 @@ function render_intro(frm) {
 	if (frm.is_new()) {
 		frm.set_intro(
 			__(
-				"A firewall restricts this VM's <b>public</b> inbound to the ports you list — everything " +
-					"else from the internet is dropped. The VPN tunnel always bypasses it (full access). " +
-					"Pick the VM, add the allowed ports, Save, then Apply to host. An empty list with " +
-					"Enabled on means <b>deny all public</b> (VPN-only). Deleting the firewall reopens the " +
-					"VM to the public internet."
+				"A firewall restricts this VM's <b>public</b> inbound to the ports you list — everything else from the internet is dropped. The VPN tunnel always bypasses it (full access). Pick the VM, add the allowed ports, Save, then Apply to host. An empty list with Enabled on means <b>deny all public</b> (VPN-only). Deleting the firewall reopens the VM to the public internet."
 			),
 			"blue"
 		);
@@ -39,8 +35,7 @@ function render_intro(frm) {
 	if (!(frm.doc.rules || []).length) {
 		frm.set_intro(
 			__(
-				"Deny all public — no public port is open, so only the VPN tunnel reaches this VM. " +
-					"Add ports and Apply to host to open them."
+				"Deny all public — no public port is open, so only the VPN tunnel reaches this VM. Add ports and Apply to host to open them."
 			),
 			frm.doc.status === "Active" ? "green" : "orange"
 		);
@@ -49,8 +44,7 @@ function render_intro(frm) {
 	if (frm.doc.status === "Active") {
 		frm.set_intro(
 			__(
-				"Enforced on {0}. Public traffic reaches only the listed ports; the VPN tunnel bypasses " +
-					"this. Edit and Apply to host to change.",
+				"Enforced on {0}. Public traffic reaches only the listed ports; the VPN tunnel bypasses this. Edit and Apply to host to change.",
 				[frm.doc.server]
 			),
 			"green"

--- a/atlas/atlas/doctype/firewall/firewall.js
+++ b/atlas/atlas/doctype/firewall/firewall.js
@@ -1,0 +1,80 @@
+frappe.ui.form.on("Firewall", {
+	refresh(frm) {
+		render_intro(frm);
+		if (frm.is_new()) {
+			return;
+		}
+		// Identity is frozen after insert (validate() enforces it).
+		frm.set_df_property("virtual_machine", "read_only", 1);
+		// Apply is the explicit verb — a plain Save never touches the host, so the
+		// host only changes when the operator/owner asks for it (the bring_up model).
+		frappe.atlas.add_primary(frm, "Apply to host", () => apply_to_host(frm));
+	},
+});
+
+function render_intro(frm) {
+	frm.set_intro("");
+	if (frm.is_new()) {
+		frm.set_intro(
+			__(
+				"A firewall restricts this VM's <b>public</b> inbound to the ports you list — everything " +
+					"else from the internet is dropped. The VPN tunnel always bypasses it (full access). " +
+					"Pick the VM, add the allowed ports, Save, then Apply to host. An empty list with " +
+					"Enabled on means <b>deny all public</b> (VPN-only). Deleting the firewall reopens the " +
+					"VM to the public internet."
+			),
+			"blue"
+		);
+		return;
+	}
+	if (!frm.doc.enabled) {
+		frm.set_intro(
+			__("Disabled — the VM is fully public. Tick Enabled and Apply to host to restrict it."),
+			"orange"
+		);
+		return;
+	}
+	if (!(frm.doc.rules || []).length) {
+		frm.set_intro(
+			__(
+				"Deny all public — no public port is open, so only the VPN tunnel reaches this VM. " +
+					"Add ports and Apply to host to open them."
+			),
+			frm.doc.status === "Active" ? "green" : "orange"
+		);
+		return;
+	}
+	if (frm.doc.status === "Active") {
+		frm.set_intro(
+			__(
+				"Enforced on {0}. Public traffic reaches only the listed ports; the VPN tunnel bypasses " +
+					"this. Edit and Apply to host to change.",
+				[frm.doc.server]
+			),
+			"green"
+		);
+	} else {
+		frm.set_intro(__("Edited but not yet pushed. Click Apply to host to enforce these rules."), "orange");
+	}
+}
+
+function apply_to_host(frm) {
+	const run_sync = () =>
+		frm.call("sync").then(({ message }) => {
+			if (!message) {
+				// sync returns "" when the VM is Terminated (host state already gone).
+				frappe.show_alert({
+					message: __("Nothing to apply — the VM is terminated."),
+					indicator: "orange",
+				});
+				return;
+			}
+			frappe.atlas.task_started(frm, __("Apply firewall"), message);
+		});
+	// Apply what's on screen: persist any pending edits first, then push.
+	if (frm.is_dirty()) {
+		frm.save().then(run_sync);
+	} else {
+		run_sync();
+	}
+}

--- a/atlas/atlas/doctype/firewall/firewall.json
+++ b/atlas/atlas/doctype/firewall/firewall.json
@@ -39,7 +39,8 @@
    "in_standard_filter": 1,
    "label": "Virtual Machine",
    "options": "Virtual Machine",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "description": "The host the VM runs on; the nft rules are applied here. Denormalized from the VM.",

--- a/atlas/atlas/doctype/firewall/firewall.json
+++ b/atlas/atlas/doctype/firewall/firewall.json
@@ -1,0 +1,142 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-06-24 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "tab_overview",
+  "label",
+  "virtual_machine",
+  "server",
+  "tenant",
+  "column_break_header",
+  "enabled",
+  "status",
+  "section_break_rules",
+  "rules"
+ ],
+ "fields": [
+  {
+   "fieldname": "tab_overview",
+   "fieldtype": "Tab Break",
+   "label": "Overview"
+  },
+  {
+   "description": "Optional user-facing name for this firewall.",
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label"
+  },
+  {
+   "description": "The VM whose PUBLIC inbound this firewall restricts. The VPN tunnel always bypasses it (full access). One firewall per VM.",
+   "fieldname": "virtual_machine",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Virtual Machine",
+   "options": "Virtual Machine",
+   "reqd": 1
+  },
+  {
+   "description": "The host the VM runs on; the nft rules are applied here. Denormalized from the VM.",
+   "fieldname": "server",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Server",
+   "options": "Server",
+   "read_only": 1
+  },
+  {
+   "fieldname": "tenant",
+   "fieldtype": "Link",
+   "label": "Tenant",
+   "options": "Tenant",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_header",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "description": "When off, the firewall is cleared on the host and the VM reverts to fully public (the rules are kept for re-enabling).",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Enabled"
+  },
+  {
+   "default": "Disabled",
+   "description": "Whether the rules are currently enforced on the host.",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Active\nDisabled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_rules",
+   "fieldtype": "Section Break",
+   "label": "Allowed Public Ports"
+  },
+  {
+   "description": "Ports reachable from the public internet. Anything not listed is dropped for public traffic. Empty means deny all public (VPN-only). The VPN tunnel is never affected.",
+   "fieldname": "rules",
+   "fieldtype": "Table",
+   "label": "Rules",
+   "options": "Firewall Rule"
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Atlas",
+ "name": "Firewall",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 0,
+   "cancel": 0,
+   "create": 1,
+   "delete": 1,
+   "export": 1,
+   "import": 0,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 0,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1,
+   "read": 1,
+   "role": "Atlas User",
+   "write": 1
+  }
+ ],
+ "search_fields": "virtual_machine,server,status",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "title": "Active",
+   "color": "Green"
+  },
+  {
+   "title": "Disabled",
+   "color": "Gray"
+  }
+ ],
+ "title_field": "label",
+ "track_changes": 1
+}

--- a/atlas/atlas/doctype/firewall/firewall.py
+++ b/atlas/atlas/doctype/firewall/firewall.py
@@ -22,7 +22,9 @@ class Firewall(Document):
 
 	def _assert_one_per_virtual_machine(self) -> None:
 		"""One firewall per VM (the per-VM model): a VM's public surface is a single
-		set of allowed ports, not several overlapping ones."""
+		set of allowed ports, not several overlapping ones. The real guarantee is the
+		`unique` index on `virtual_machine` (firewall.json) — this check only turns the
+		race-safe DB constraint into a friendly message on the common, non-racing path."""
 		if frappe.db.exists("Firewall", {"virtual_machine": self.virtual_machine}):
 			frappe.throw(_("A Firewall already exists for {0}").format(self.virtual_machine))
 

--- a/atlas/atlas/doctype/firewall/firewall.py
+++ b/atlas/atlas/doctype/firewall/firewall.py
@@ -1,0 +1,108 @@
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from atlas.atlas.ssh import run_task
+
+# Identity is frozen once written; the rules and the enabled toggle stay editable.
+IMMUTABLE_AFTER_INSERT = ("virtual_machine", "server", "tenant")
+
+PROTOCOLS = ("tcp", "udp")
+
+
+class Firewall(Document):
+	def before_insert(self) -> None:
+		self._derive_from_virtual_machine()
+		self._assert_one_per_virtual_machine()
+
+	def _derive_from_virtual_machine(self) -> None:
+		vm = frappe.get_doc("Virtual Machine", self.virtual_machine)
+		self.server = vm.server
+		self.tenant = vm.tenant
+
+	def _assert_one_per_virtual_machine(self) -> None:
+		"""One firewall per VM (the per-VM model): a VM's public surface is a single
+		set of allowed ports, not several overlapping ones."""
+		if frappe.db.exists("Firewall", {"virtual_machine": self.virtual_machine}):
+			frappe.throw(_("A Firewall already exists for {0}").format(self.virtual_machine))
+
+	def validate(self) -> None:
+		self._validate_rules()
+		if self.is_new():
+			return
+		original = self.get_doc_before_save()
+		if not original:
+			return
+		for field in IMMUTABLE_AFTER_INSERT:
+			old_value = getattr(original, field)
+			if old_value and old_value != getattr(self, field):
+				frappe.throw(_("{0} is immutable after insert").format(field))
+
+	def _validate_rules(self) -> None:
+		"""Ports in range, protocols known, no duplicate proto/port row (a duplicate
+		would just be a redundant nft accept, but it signals a mistake)."""
+		seen: set[tuple[str, int]] = set()
+		for rule in self.rules:
+			if rule.protocol not in PROTOCOLS:
+				frappe.throw(_("Rule protocol must be one of {0}").format(", ".join(PROTOCOLS)))
+			if not 1 <= (rule.port or 0) <= 65535:
+				frappe.throw(_("Rule port {0} is out of range 1-65535").format(rule.port))
+			key = (rule.protocol, rule.port)
+			if key in seen:
+				frappe.throw(_("Duplicate rule {0}/{1}").format(rule.protocol, rule.port))
+			seen.add(key)
+
+	def on_trash(self) -> None:
+		"""Deleting the firewall must open the VM back up, or its nft block would
+		outlive the row (orphaned, still blocking). Skipped for a terminated VM, whose
+		host state vm-network-down already tore down."""
+		self._clear_on_host()
+		self.db_set("status", "Disabled")
+
+	@frappe.whitelist()
+	def sync(self) -> str:
+		"""Push the declared state to the host: `enabled` → apply the rules (an empty
+		list is a valid deny-all-public), disabled → clear them (VM reverts to public).
+		The explicit apply verb, like VPN Tunnel.bring_up — never fired on save, so a
+		plain edit does not SSH. Returns the dispatched Task name, or "" when skipped
+		(terminated VM, whose host state is already gone)."""
+		if self._virtual_machine_terminated():
+			self.db_set("status", "Disabled")
+			return ""
+		task = self._apply_on_host() if self.enabled else self._clear_on_host()
+		self.db_set("status", "Active" if self.enabled else "Disabled")
+		return task
+
+	def _apply_on_host(self) -> str:
+		"""Run firewall-apply.py --action apply: write the durable sidecar and install
+		the nft public_filter block."""
+		return run_task(
+			server=self.server,
+			script="firewall-apply.py",
+			variables={
+				"VIRTUAL_MACHINE_NAME": self.virtual_machine,
+				"ACTION": "apply",
+				"RULE": [f"{rule.protocol}/{rule.port}" for rule in self.rules],
+			},
+			virtual_machine=self.virtual_machine,
+			timeout_seconds=60,
+		).name
+
+	def _clear_on_host(self) -> str:
+		"""Run firewall-apply.py --action clear: remove the nft block + sidecar so the
+		VM is fully public again. Skipped for a terminated VM (host already torn down)."""
+		if self._virtual_machine_terminated():
+			return ""
+		return run_task(
+			server=self.server,
+			script="firewall-apply.py",
+			variables={
+				"VIRTUAL_MACHINE_NAME": self.virtual_machine,
+				"ACTION": "clear",
+			},
+			virtual_machine=self.virtual_machine,
+			timeout_seconds=60,
+		).name
+
+	def _virtual_machine_terminated(self) -> bool:
+		return frappe.db.get_value("Virtual Machine", self.virtual_machine, "status") == "Terminated"

--- a/atlas/atlas/doctype/firewall/test_firewall.py
+++ b/atlas/atlas/doctype/firewall/test_firewall.py
@@ -1,0 +1,128 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.doctype.firewall import firewall as module
+from atlas.atlas.doctype.virtual_machine.test_virtual_machine import (
+	_ensure_test_image,
+	_ensure_test_server,
+	_new_vm,
+)
+from atlas.tests._mocks import fake_task
+
+
+def _make_firewall(vm: str, rules=(), enabled: int = 1, **overrides):
+	doc = {
+		"doctype": "Firewall",
+		"virtual_machine": vm,
+		"enabled": enabled,
+		"rules": [{"protocol": protocol, "port": port} for (protocol, port) in rules],
+	}
+	doc.update(overrides)
+	return frappe.get_doc(doc).insert(ignore_permissions=True)
+
+
+def _purge() -> None:
+	# delete fires on_trash -> _clear_on_host -> run_task; mock it so teardown never
+	# reaches the (real, unreachable) test server.
+	with patch.object(module, "run_task", return_value=fake_task(name="fw-purge")):
+		for name in frappe.get_all("Firewall", pluck="name"):
+			frappe.delete_doc("Firewall", name, force=1, ignore_permissions=True)
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestFirewall(IntegrationTestCase):
+	def setUp(self) -> None:
+		_ensure_test_server()
+		_ensure_test_image()
+		_purge()
+
+	def test_insert_derives_from_vm_and_defaults_disabled(self) -> None:
+		# Inserting alone never touches the host (no on_save dispatch) — apply is the
+		# explicit sync() verb, like VPN Tunnel.bring_up.
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443)])
+		self.assertEqual(firewall.server, vm.server)
+		self.assertEqual(firewall.tenant, vm.tenant)
+		self.assertEqual(firewall.status, "Disabled")
+
+	def test_sync_applies_rules(self) -> None:
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443), ("udp", 1194)])
+		with patch.object(module, "run_task", return_value=fake_task(name="fw")) as run_task:
+			firewall.sync()
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(kwargs["script"], "firewall-apply.py")
+		self.assertEqual(kwargs["variables"]["ACTION"], "apply")
+		self.assertEqual(kwargs["variables"]["VIRTUAL_MACHINE_NAME"], vm.name)
+		self.assertEqual(kwargs["variables"]["RULE"], ["tcp/443", "udp/1194"])
+		firewall.reload()
+		self.assertEqual(firewall.status, "Active")
+
+	def test_sync_empty_rules_is_deny_all_public(self) -> None:
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[])
+		with patch.object(module, "run_task", return_value=fake_task(name="fw")) as run_task:
+			firewall.sync()
+			(_, kwargs) = run_task.call_args
+		# Applied with an empty RULE list -> deny all public (VPN-only).
+		self.assertEqual(kwargs["variables"]["ACTION"], "apply")
+		self.assertEqual(kwargs["variables"]["RULE"], [])
+
+	def test_sync_disabled_clears(self) -> None:
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443)], enabled=0)
+		with patch.object(module, "run_task", return_value=fake_task(name="fw")) as run_task:
+			firewall.sync()
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(kwargs["variables"]["ACTION"], "clear")
+		firewall.reload()
+		self.assertEqual(firewall.status, "Disabled")
+
+	def test_one_firewall_per_vm(self) -> None:
+		vm = _new_vm()
+		_make_firewall(vm.name, rules=[("tcp", 443)])
+		with self.assertRaises(frappe.ValidationError) as raised:
+			_make_firewall(vm.name, rules=[("tcp", 80)])
+		self.assertIn("already exists", str(raised.exception))
+
+	def test_duplicate_rule_throws(self) -> None:
+		vm = _new_vm()
+		with self.assertRaises(frappe.ValidationError) as raised:
+			_make_firewall(vm.name, rules=[("tcp", 443), ("tcp", 443)])
+		self.assertIn("Duplicate", str(raised.exception))
+
+	def test_out_of_range_port_throws(self) -> None:
+		vm = _new_vm()
+		with self.assertRaises(frappe.ValidationError) as raised:
+			_make_firewall(vm.name, rules=[("tcp", 70000)])
+		self.assertIn("out of range", str(raised.exception))
+
+	def test_virtual_machine_is_immutable(self) -> None:
+		vm = _new_vm()
+		other = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443)])
+		firewall.virtual_machine = other.name
+		with self.assertRaises(frappe.ValidationError) as raised:
+			firewall.save(ignore_permissions=True)
+		self.assertIn("immutable", str(raised.exception))
+
+	def test_trash_clears_on_host(self) -> None:
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443)])
+		with patch.object(module, "run_task", return_value=fake_task(name="fw")) as run_task:
+			firewall.delete(ignore_permissions=True)
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(kwargs["variables"]["ACTION"], "clear")
+
+	def test_sync_skips_terminated_vm(self) -> None:
+		vm = _new_vm()
+		firewall = _make_firewall(vm.name, rules=[("tcp", 443)])
+		frappe.db.set_value("Virtual Machine", vm.name, "status", "Terminated")
+		with patch.object(module, "run_task", return_value=fake_task(name="fw")) as run_task:
+			firewall.sync()
+		firewall.reload()
+		self.assertEqual(firewall.status, "Disabled")
+		run_task.assert_not_called()

--- a/atlas/atlas/doctype/firewall_rule/firewall_rule.json
+++ b/atlas/atlas/doctype/firewall_rule/firewall_rule.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "creation": "2026-06-24 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "protocol",
+  "port",
+  "description"
+ ],
+ "fields": [
+  {
+   "default": "tcp",
+   "description": "The transport protocol this rule opens.",
+   "fieldname": "protocol",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Protocol",
+   "options": "tcp\nudp",
+   "reqd": 1
+  },
+  {
+   "description": "The destination port allowed from the public internet (1-65535), e.g. 443.",
+   "fieldname": "port",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Port",
+   "reqd": 1
+  },
+  {
+   "description": "Optional note for the operator (e.g. 'HTTPS').",
+   "fieldname": "description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Description"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-06-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Atlas",
+ "name": "Firewall Rule",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/atlas/atlas/doctype/firewall_rule/firewall_rule.py
+++ b/atlas/atlas/doctype/firewall_rule/firewall_rule.py
@@ -1,0 +1,5 @@
+from frappe.model.document import Document
+
+
+class FirewallRule(Document):
+	pass

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -685,9 +685,23 @@ class VirtualMachine(Document):
 		self.status = "Terminated"
 		self.save()
 		self._detach_reserved_ip()
+		self._revoke_tunnels()
 		self._delete_subdomains()
 		self._delete_snapshots()
 		return task.name
+
+	def _revoke_tunnels(self) -> None:
+		"""Revoke every VPN Tunnel to this VM on terminate (spec/19-vpn-broker.md).
+		terminate-vm.py tears down the VM's netns/veth but the tunnel's wg interface
+		lives in the host ROOT netns and survives that, so each tunnel's revoke()
+		runs the host down Task to remove it. Idempotent: a VM with no tunnels is a
+		no-op; already-Revoked tunnels are skipped."""
+		for name in frappe.get_all(
+			"VPN Tunnel",
+			filters={"virtual_machine": self.name, "status": ["!=", "Revoked"]},
+			pluck="name",
+		):
+			frappe.get_doc("VPN Tunnel", name).revoke()
 
 	def _detach_reserved_ip(self) -> None:
 		"""Release the VM's attached public IPv4 (if any) back to its Server's

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine_dashboard.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine_dashboard.py
@@ -7,5 +7,6 @@ def get_data():
 		"transactions": [
 			{"label": _("Operations"), "items": ["Task"]},
 			{"label": _("Disk"), "items": ["Virtual Machine Snapshot"]},
+			{"label": _("Network access"), "items": ["VPN Tunnel", "Firewall"]},
 		],
 	}

--- a/atlas/atlas/doctype/vpn_tunnel/test_vpn_tunnel.py
+++ b/atlas/atlas/doctype/vpn_tunnel/test_vpn_tunnel.py
@@ -1,0 +1,141 @@
+import base64
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.doctype.virtual_machine.test_virtual_machine import (
+	_ensure_test_image,
+	_ensure_test_server,
+	_new_vm,
+)
+from atlas.atlas.doctype.vpn_tunnel import vpn_tunnel as module
+from atlas.atlas.networking import TUNNEL_PORT_BASE, tunnel_overlay_link
+from atlas.tests._mocks import fake_task
+
+# A syntactically valid client public key (32 bytes, standard base64).
+CLIENT_PUB = base64.standard_b64encode(b"\x22" * 32).decode()
+SERVER_PUB = base64.standard_b64encode(b"\x33" * 32).decode()
+
+
+def _up_task():
+	return fake_task(name="task-up", stdout=f'ATLAS_RESULT={{"server_public_key": "{SERVER_PUB}"}}')
+
+
+def _make_tunnel(vm: str, **overrides) -> "frappe.model.document.Document":
+	doc = {"doctype": "VPN Tunnel", "virtual_machine": vm, "client_public_key": CLIENT_PUB}
+	doc.update(overrides)
+	return frappe.get_doc(doc).insert(ignore_permissions=True)
+
+
+def _purge() -> None:
+	for name in frappe.get_all("VPN Tunnel", pluck="name"):
+		frappe.delete_doc("VPN Tunnel", name, force=1, ignore_permissions=True)
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestVPNTunnel(IntegrationTestCase):
+	def setUp(self) -> None:
+		_ensure_test_server()
+		_ensure_test_image()
+		_purge()
+
+	def test_insert_allocates_slot_and_derives_from_vm(self) -> None:
+		vm = _new_vm()
+		tunnel = _make_tunnel(vm.name)
+		self.assertEqual(tunnel.status, "Pending")
+		self.assertEqual(tunnel.transport, "public-ipv4")
+		self.assertEqual(tunnel.server, vm.server)
+		self.assertEqual(tunnel.slot_index, 0)
+		self.assertEqual(tunnel.listen_port, TUNNEL_PORT_BASE)
+		self.assertTrue(tunnel.interface_name.startswith("wg-"))
+		# client_address is the client end of slot 0's /127 overlay.
+		_, client_cidr = tunnel_overlay_link(0)
+		self.assertEqual(tunnel.client_address, client_cidr.split("/", 1)[0])
+
+	def test_second_tunnel_takes_next_slot(self) -> None:
+		first = _make_tunnel(_new_vm().name)
+		second = _make_tunnel(_new_vm().name)
+		self.assertEqual((first.slot_index, second.slot_index), (0, 1))
+		self.assertEqual(second.listen_port, TUNNEL_PORT_BASE + 1)
+
+	def test_revoked_slot_is_reused(self) -> None:
+		first = _make_tunnel(_new_vm().name)
+		with patch.object(module, "run_task", return_value=fake_task(name="t")):
+			first.revoke()
+		# Slot 0 is back in the pool now the only tunnel is Revoked.
+		second = _make_tunnel(_new_vm().name)
+		self.assertEqual(second.slot_index, 0)
+
+	def test_bring_up_dispatches_up_task_and_stores_pubkey(self) -> None:
+		vm = _new_vm()
+		tunnel = _make_tunnel(vm.name)
+		with patch.object(module, "run_task", return_value=_up_task()) as run_task:
+			tunnel.bring_up()
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(kwargs["script"], "vm-tunnel.py")
+		variables = kwargs["variables"]
+		self.assertEqual(variables["ACTION"], "up")
+		self.assertEqual(variables["TUNNEL_NAME"], tunnel.name)
+		self.assertEqual(variables["VIRTUAL_MACHINE_NAME"], vm.name)
+		self.assertEqual(variables["INTERFACE"], tunnel.interface_name)
+		self.assertEqual(variables["LISTEN_PORT"], str(tunnel.listen_port))
+		self.assertEqual(variables["CLIENT_PUBLIC_KEY"], CLIENT_PUB)
+		self.assertEqual(variables["CLIENT_ADDRESS"], tunnel.client_address)
+		self.assertEqual(variables["HOST_ADDRESS"], tunnel_overlay_link(0)[0])
+		tunnel.reload()
+		self.assertEqual(tunnel.status, "Active")
+		self.assertEqual(tunnel.server_public_key, SERVER_PUB)
+
+	def test_revoke_dispatches_down_task_and_marks_revoked(self) -> None:
+		tunnel = _make_tunnel(_new_vm().name)
+		with patch.object(module, "run_task", return_value=fake_task(name="t-down")) as run_task:
+			tunnel.revoke()
+			(_, kwargs) = run_task.call_args
+		self.assertEqual(kwargs["script"], "vm-tunnel.py")
+		self.assertEqual(kwargs["variables"]["ACTION"], "down")
+		self.assertEqual(kwargs["variables"]["INTERFACE"], tunnel.interface_name)
+		tunnel.reload()
+		self.assertEqual(tunnel.status, "Revoked")
+
+	def test_revoke_twice_throws(self) -> None:
+		tunnel = _make_tunnel(_new_vm().name)
+		with patch.object(module, "run_task", return_value=fake_task(name="t")):
+			tunnel.revoke()
+			with self.assertRaises(frappe.ValidationError) as raised:
+				tunnel.revoke()
+		self.assertIn("already revoked", str(raised.exception))
+
+	def test_bring_up_on_revoked_throws(self) -> None:
+		tunnel = _make_tunnel(_new_vm().name)
+		with patch.object(module, "run_task", return_value=fake_task(name="t")):
+			tunnel.revoke()
+			with self.assertRaises(frappe.ValidationError) as raised:
+				tunnel.bring_up()
+		self.assertIn("revoked", str(raised.exception))
+
+	def test_client_public_key_is_immutable(self) -> None:
+		tunnel = _make_tunnel(_new_vm().name)
+		tunnel.client_public_key = SERVER_PUB
+		with self.assertRaises(frappe.ValidationError) as raised:
+			tunnel.save(ignore_permissions=True)
+		self.assertIn("client_public_key is immutable", str(raised.exception))
+
+	def test_terminate_revokes_tunnels(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_module
+
+		vm = _new_vm()
+		vm.status = "Running"
+		vm.last_started = frappe.utils.now_datetime()
+		vm.save(ignore_permissions=True)
+		tunnel = _make_tunnel(vm.name)
+		# terminate-vm.py (vm_module.run_task) AND the tunnel down Task
+		# (module.run_task) both fire; patch both.
+		with (
+			patch.object(vm_module, "run_task", return_value=fake_task(name="t-term")),
+			patch.object(module, "run_task", return_value=fake_task(name="t-down")),
+		):
+			vm.terminate()
+		tunnel.reload()
+		self.assertEqual(tunnel.status, "Revoked")

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
@@ -47,15 +47,22 @@ function render_intro(frm) {
 	}
 	const status = frm.doc.status;
 	if (status === "Pending") {
-		frm.set_intro(__("Saved but not yet on the host. Click Bring up to open the tunnel."), "orange");
+		frm.set_intro(
+			__("Saved but not yet on the host. Click Bring up to open the tunnel."),
+			"orange"
+		);
 	} else if (status === "Active") {
 		frm.set_intro(
-			__("Tunnel is live. Click Show client config for the connection details and setup steps."),
+			__(
+				"Tunnel is live. Click Show client config for the connection details and setup steps."
+			),
 			"green"
 		);
 	} else if (status === "Revoked") {
 		frm.set_intro(
-			__("This tunnel was revoked and torn down on the host. Create a new tunnel to reconnect."),
+			__(
+				"This tunnel was revoked and torn down on the host. Create a new tunnel to reconnect."
+			),
 			"red"
 		);
 	}
@@ -89,7 +96,10 @@ function open_config_dialog(frm, cfg) {
 						"below as <code>/etc/wireguard/atlas.conf</code> and replace " +
 						"<code>&lt;your client private key&gt;</code> with the contents of your " +
 						"<code>privatekey</code> file — Atlas never sees it.",
-					[frappe.utils.escape_html(frm.doc.virtual_machine), frappe.utils.escape_html(cfg.allowed_ips)]
+					[
+						frappe.utils.escape_html(frm.doc.virtual_machine),
+						frappe.utils.escape_html(cfg.allowed_ips),
+					]
 				)}</p>`,
 			},
 			{
@@ -102,12 +112,11 @@ function open_config_dialog(frm, cfg) {
 			{
 				fieldname: "instructions",
 				fieldtype: "HTML",
-				options:
-					`<div class="text-muted small" style="margin-top: var(--margin-sm)"><b>${__(
-						"Setup"
-					)}</b><pre style="white-space: pre-wrap; margin-top: var(--margin-xs)">${frappe.utils.escape_html(
-						cfg.instructions
-					)}</pre></div>`,
+				options: `<div class="text-muted small" style="margin-top: var(--margin-sm)"><b>${__(
+					"Setup"
+				)}</b><pre style="white-space: pre-wrap; margin-top: var(--margin-xs)">${frappe.utils.escape_html(
+					cfg.instructions
+				)}</pre></div>`,
 			},
 		],
 		primary_action_label: __("Copy config"),

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
@@ -1,0 +1,140 @@
+frappe.ui.form.on("VPN Tunnel", {
+	refresh(frm) {
+		render_intro(frm);
+		if (frm.is_new()) {
+			return;
+		}
+		// Identity is frozen on the host after bring-up (validate() enforces it).
+		// Lock it in the UI too so an existing tunnel reads as immutable.
+		frm.set_df_property("virtual_machine", "read_only", 1);
+		frm.set_df_property("client_public_key", "read_only", 1);
+		add_buttons(frm);
+	},
+});
+
+function add_buttons(frm) {
+	const status = frm.doc.status;
+	if (status === "Pending") {
+		// Saved Frappe-side but not yet on the host. Bring up mints the host key
+		// and opens the WireGuard interface scoped to this one VM.
+		frappe.atlas.add_primary(frm, "Bring up", () => bring_up(frm));
+		frappe.atlas.add_danger(frm, "Revoke", () => confirm_revoke(frm));
+	} else if (status === "Active") {
+		// Live. The client needs the connection details (Atlas never had the
+		// client's private key, so the config carries a placeholder).
+		frappe.atlas.add_primary(frm, "Show client config", () => show_client_config(frm));
+		// Re-apply re-runs bring-up: re-mints/reuses the host key and re-lays the
+		// nft isolation, e.g. after a host reboot left the interface gone.
+		frappe.atlas.add_success(frm, "Re-apply", () => bring_up(frm));
+		frappe.atlas.add_danger(frm, "Revoke", () => confirm_revoke(frm));
+	}
+	// Revoked: terminal, no actions — only the intro.
+}
+
+function render_intro(frm) {
+	frm.set_intro("");
+	if (frm.is_new()) {
+		frm.set_intro(
+			__(
+				"On your machine run <code>wg genkey | tee privatekey | wg pubkey > publickey</code>, " +
+					"paste the <b>public</b> key below, pick the VM, and Save. Then Bring up opens the " +
+					"tunnel and Show client config gives you the connection details. Your private key " +
+					"never leaves your machine."
+			),
+			"blue"
+		);
+		return;
+	}
+	const status = frm.doc.status;
+	if (status === "Pending") {
+		frm.set_intro(__("Saved but not yet on the host. Click Bring up to open the tunnel."), "orange");
+	} else if (status === "Active") {
+		frm.set_intro(
+			__("Tunnel is live. Click Show client config for the connection details and setup steps."),
+			"green"
+		);
+	} else if (status === "Revoked") {
+		frm.set_intro(
+			__("This tunnel was revoked and torn down on the host. Create a new tunnel to reconnect."),
+			"red"
+		);
+	}
+}
+
+function bring_up(frm) {
+	frm.call("bring_up").then(({ message }) => {
+		frappe.atlas.task_started(frm, __("Bring up tunnel"), message);
+	});
+}
+
+function show_client_config(frm) {
+	frm.call("client_config").then(({ message }) => {
+		if (!message) {
+			return;
+		}
+		open_config_dialog(frm, message);
+	});
+}
+
+function open_config_dialog(frm, cfg) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("WireGuard client config"),
+		size: "large",
+		fields: [
+			{
+				fieldname: "summary",
+				fieldtype: "HTML",
+				options: `<p class="text-muted small">${__(
+					"This tunnel reaches <b>{0}</b> at <code>{1}</code> and nothing else. Save the block " +
+						"below as <code>/etc/wireguard/atlas.conf</code> and replace " +
+						"<code>&lt;your client private key&gt;</code> with the contents of your " +
+						"<code>privatekey</code> file — Atlas never sees it.",
+					[frappe.utils.escape_html(frm.doc.virtual_machine), frappe.utils.escape_html(cfg.allowed_ips)]
+				)}</p>`,
+			},
+			{
+				fieldname: "config",
+				fieldtype: "Code",
+				label: __("atlas.conf"),
+				options: "Properties",
+				read_only: 1,
+			},
+			{
+				fieldname: "instructions",
+				fieldtype: "HTML",
+				options:
+					`<div class="text-muted small" style="margin-top: var(--margin-sm)"><b>${__(
+						"Setup"
+					)}</b><pre style="white-space: pre-wrap; margin-top: var(--margin-xs)">${frappe.utils.escape_html(
+						cfg.instructions
+					)}</pre></div>`,
+			},
+		],
+		primary_action_label: __("Copy config"),
+		primary_action() {
+			frappe.utils.copy_to_clipboard(cfg.config);
+		},
+	});
+	dialog.show();
+	// Set the Code field after show so the ACE editor is mounted.
+	dialog.set_value("config", cfg.config);
+	return dialog;
+}
+
+function confirm_revoke(frm) {
+	frappe.atlas.confirm_destructive({
+		title: __("Revoke this tunnel?"),
+		body_html: `<p>${__(
+			"Tears down the WireGuard interface on the host and frees its slot. The client " +
+				"loses access immediately. This cannot be undone — issue a new tunnel to reconnect."
+		)}</p>`,
+		match_string: frm.doc.virtual_machine,
+		match_label: __("Type the Virtual Machine name to confirm"),
+		proceed_label: __("Revoke"),
+		proceed() {
+			frm.call("revoke").then(({ message }) => {
+				frappe.atlas.task_started(frm, __("Revoke tunnel"), message);
+			});
+		},
+	});
+}

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.js
@@ -36,10 +36,7 @@ function render_intro(frm) {
 	if (frm.is_new()) {
 		frm.set_intro(
 			__(
-				"On your machine run <code>wg genkey | tee privatekey | wg pubkey > publickey</code>, " +
-					"paste the <b>public</b> key below, pick the VM, and Save. Then Bring up opens the " +
-					"tunnel and Show client config gives you the connection details. Your private key " +
-					"never leaves your machine."
+				"On your machine run <code>wg genkey | tee privatekey | wg pubkey > publickey</code>, paste the <b>public</b> key below, pick the VM, and Save. Then Bring up opens the tunnel and Show client config gives you the connection details. Your private key never leaves your machine."
 			),
 			"blue"
 		);
@@ -92,10 +89,7 @@ function open_config_dialog(frm, cfg) {
 				fieldname: "summary",
 				fieldtype: "HTML",
 				options: `<p class="text-muted small">${__(
-					"This tunnel reaches <b>{0}</b> at <code>{1}</code> and nothing else. Save the block " +
-						"below as <code>/etc/wireguard/atlas.conf</code> and replace " +
-						"<code>&lt;your client private key&gt;</code> with the contents of your " +
-						"<code>privatekey</code> file — Atlas never sees it.",
+					"This tunnel reaches <b>{0}</b> at <code>{1}</code> and nothing else. Save the block below as <code>/etc/wireguard/atlas.conf</code> and replace <code>&lt;your client private key&gt;</code> with the contents of your <code>privatekey</code> file — Atlas never sees it.",
 					[
 						frappe.utils.escape_html(frm.doc.virtual_machine),
 						frappe.utils.escape_html(cfg.allowed_ips),
@@ -134,8 +128,7 @@ function confirm_revoke(frm) {
 	frappe.atlas.confirm_destructive({
 		title: __("Revoke this tunnel?"),
 		body_html: `<p>${__(
-			"Tears down the WireGuard interface on the host and frees its slot. The client " +
-				"loses access immediately. This cannot be undone — issue a new tunnel to reconnect."
+			"Tears down the WireGuard interface on the host and frees its slot. The client loses access immediately. This cannot be undone — issue a new tunnel to reconnect."
 		)}</p>`,
 		match_string: frm.doc.virtual_machine,
 		match_label: __("Type the Virtual Machine name to confirm"),

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
@@ -1,0 +1,184 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-06-23 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "tab_overview",
+  "label",
+  "virtual_machine",
+  "server",
+  "tenant",
+  "column_break_header",
+  "status",
+  "transport",
+  "section_break_wireguard",
+  "client_public_key",
+  "server_public_key",
+  "interface_name",
+  "column_break_wireguard",
+  "slot_index",
+  "listen_port",
+  "client_address"
+ ],
+ "fields": [
+  {
+   "fieldname": "tab_overview",
+   "fieldtype": "Tab Break",
+   "label": "Overview"
+  },
+  {
+   "description": "Optional user-facing name for this tunnel (e.g. the device it is for).",
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label"
+  },
+  {
+   "description": "The VM this tunnel reaches. The tunnel is scoped to this one VM's IPv6 and nothing else.",
+   "fieldname": "virtual_machine",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Virtual Machine",
+   "options": "Virtual Machine",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "description": "The host the VM runs on; the tunnel terminates here. Denormalized from the VM.",
+   "fieldname": "server",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Server",
+   "options": "Server",
+   "read_only": 1
+  },
+  {
+   "fieldname": "tenant",
+   "fieldtype": "Link",
+   "label": "Tenant",
+   "options": "Tenant",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_header",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending\nActive\nRevoked",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "default": "public-ipv4",
+   "description": "Where the client dials the tunnel: the server's public IPv4 today; the seam for a private VPC address later.",
+   "fieldname": "transport",
+   "fieldtype": "Select",
+   "label": "Transport",
+   "options": "public-ipv4\nprivate-vpc",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_wireguard",
+   "fieldtype": "Section Break",
+   "label": "WireGuard"
+  },
+  {
+   "description": "The client's WireGuard public key. The client keeps its private key; Atlas never sees it.",
+   "fieldname": "client_public_key",
+   "fieldtype": "Data",
+   "label": "Client Public Key",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "description": "The host-side public key, returned by the host on bring-up. The private half stays on the host only.",
+   "fieldname": "server_public_key",
+   "fieldtype": "Data",
+   "label": "Server Public Key",
+   "read_only": 1
+  },
+  {
+   "fieldname": "interface_name",
+   "fieldtype": "Data",
+   "label": "Interface Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_wireguard",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Per-server slot; drives the listen port and the overlay link. Released on revoke.",
+   "fieldname": "slot_index",
+   "fieldtype": "Int",
+   "label": "Slot Index",
+   "read_only": 1
+  },
+  {
+   "fieldname": "listen_port",
+   "fieldtype": "Int",
+   "label": "Listen Port",
+   "read_only": 1
+  },
+  {
+   "description": "The overlay address assigned to the client (its WireGuard interface address).",
+   "fieldname": "client_address",
+   "fieldtype": "Data",
+   "label": "Client Address",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-23 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Atlas",
+ "name": "VPN Tunnel",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 0,
+   "cancel": 0,
+   "create": 1,
+   "delete": 1,
+   "export": 1,
+   "import": 0,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 0,
+   "write": 1
+  }
+ ],
+ "search_fields": "virtual_machine,server,status",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "title": "Pending",
+   "color": "Gray"
+  },
+  {
+   "title": "Active",
+   "color": "Green"
+  },
+  {
+   "title": "Revoked",
+   "color": "Red"
+  }
+ ],
+ "title_field": "label",
+ "track_changes": 1
+}

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
@@ -160,6 +160,14 @@
    "share": 1,
    "submit": 0,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1,
+   "read": 1,
+   "role": "Atlas User",
+   "write": 1
   }
  ],
  "search_fields": "virtual_machine,server,status",

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.json
@@ -45,7 +45,6 @@
    "in_standard_filter": 1,
    "label": "Virtual Machine",
    "options": "Virtual Machine",
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -98,7 +97,6 @@
    "fieldname": "client_public_key",
    "fieldtype": "Data",
    "label": "Client Public Key",
-   "read_only": 1,
    "reqd": 1
   },
   {

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.py
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.py
@@ -1,0 +1,140 @@
+import uuid
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from atlas.atlas.networking import (
+	allocate_tunnel_slot,
+	derive_tunnel_interface,
+	tunnel_listen_port,
+	tunnel_overlay_link,
+)
+from atlas.atlas.ssh import run_task
+from atlas.atlas.task_results import parse_result
+
+# Identity and the WireGuard parameters the host applied — frozen once written.
+# transport is locked too: a tunnel's endpoint family is fixed for its lifetime.
+IMMUTABLE_AFTER_INSERT = (
+	"virtual_machine",
+	"server",
+	"tenant",
+	"transport",
+	"client_public_key",
+	"slot_index",
+	"listen_port",
+	"interface_name",
+	"client_address",
+)
+
+TRANSPORT_PUBLIC_IPV4 = "public-ipv4"
+
+
+class VPNTunnel(Document):
+	def autoname(self) -> None:
+		# UUID-named like Virtual Machine: derive_tunnel_interface parses the name
+		# as a UUID, and a stable per-tunnel id needs no allocator.
+		self.name = str(uuid.uuid4())
+
+	def before_insert(self) -> None:
+		# Name-independent derivations (the VM link, the slot). interface_name needs
+		# self.name, set by autoname AFTER before_insert, so it is derived in
+		# before_validate — mirroring how Virtual Machine derives mac/tap.
+		self._derive_from_virtual_machine()
+		self._set_defaults()
+		self._allocate_slot()
+
+	def _derive_from_virtual_machine(self) -> None:
+		vm = frappe.get_doc("Virtual Machine", self.virtual_machine)
+		self.server = vm.server
+		self.tenant = vm.tenant
+
+	def _set_defaults(self) -> None:
+		if not self.status:
+			self.status = "Pending"
+		if not self.transport:
+			self.transport = TRANSPORT_PUBLIC_IPV4
+
+	def _allocate_slot(self) -> None:
+		slot = allocate_tunnel_slot(self.server)
+		self.slot_index = slot
+		self.listen_port = tunnel_listen_port(slot)
+		# The client end of the /127 overlay — the client's wg interface address and
+		# the host peer's allowed-ip. The host end is recomputed at dispatch.
+		_, client_cidr = tunnel_overlay_link(slot)
+		self.client_address = client_cidr.split("/", 1)[0]
+
+	def before_validate(self) -> None:
+		if not self.is_new():
+			return
+		if not self.interface_name:
+			self.interface_name = derive_tunnel_interface(self.name)
+
+	def validate(self) -> None:
+		if self.is_new():
+			return
+		original = self.get_doc_before_save()
+		if not original:
+			return
+		for field in IMMUTABLE_AFTER_INSERT:
+			old_value = getattr(original, field)
+			if old_value and old_value != getattr(self, field):
+				frappe.throw(f"{field} is immutable after insert")
+
+	@frappe.whitelist()
+	def bring_up(self) -> str:
+		"""Run vm-tunnel.py --action up on the host: mint/reuse the host key, write
+		the durable sidecars, apply the wg interface + nft isolation. Store the
+		returned host public key and mark Active. run_task raises on failure, so the
+		row only goes Active once the host actually applied the tunnel."""
+		if self.status == "Revoked":
+			frappe.throw(_("Cannot bring up a revoked tunnel"))
+		# The host end of the overlay /127 (index 0); the client end was stored at
+		# insert. Indexed, not unpacked, so the throwaway doesn't shadow gettext `_`.
+		host_cidr = tunnel_overlay_link(self.slot_index)[0]
+		task = run_task(
+			server=self.server,
+			script="vm-tunnel.py",
+			variables={
+				"TUNNEL_NAME": self.name,
+				"VIRTUAL_MACHINE_NAME": self.virtual_machine,
+				"INTERFACE": self.interface_name,
+				"ACTION": "up",
+				"LISTEN_PORT": str(self.listen_port),
+				"CLIENT_PUBLIC_KEY": self.client_public_key,
+				"CLIENT_ADDRESS": self.client_address,
+				"HOST_ADDRESS": host_cidr,
+			},
+			virtual_machine=self.virtual_machine,
+			timeout_seconds=60,
+		)
+		self.server_public_key = parse_result(task.stdout)["server_public_key"]
+		self.status = "Active"
+		self.save(ignore_permissions=True)
+		return task.name
+
+	@frappe.whitelist()
+	def revoke(self) -> str:
+		"""Tear the tunnel down on the host and mark Revoked, releasing its slot.
+
+		Always runs the host down Task — UNLIKE Reserved IP.detach, which skips a
+		Terminated VM. terminate-vm.py tears down the VM's netns/veth but the wg
+		interface lives in the host ROOT netns and survives that, so the down Task is
+		what removes it (the VM row still exists — VMs are never deleted)."""
+		if self.status == "Revoked":
+			frappe.throw(_("Tunnel is already revoked"))
+		task = run_task(
+			server=self.server,
+			script="vm-tunnel.py",
+			variables={
+				"TUNNEL_NAME": self.name,
+				"VIRTUAL_MACHINE_NAME": self.virtual_machine,
+				"INTERFACE": self.interface_name,
+				"ACTION": "down",
+			},
+			virtual_machine=self.virtual_machine,
+			timeout_seconds=60,
+		)
+		self.status = "Revoked"
+		self.save(ignore_permissions=True)
+		return task.name

--- a/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.py
+++ b/atlas/atlas/doctype/vpn_tunnel/vpn_tunnel.py
@@ -114,6 +114,19 @@ class VPNTunnel(Document):
 		return task.name
 
 	@frappe.whitelist()
+	def client_config(self) -> dict:
+		"""The ready-to-use client payload (host public key, endpoint, AllowedIPs,
+		overlay address, copy-paste `config`, setup steps) for an Active tunnel.
+
+		Only meaningful once the host has minted its key on bring-up, so it is
+		guarded on Active. Lazy import to avoid a controller↔api cycle at load."""
+		if self.status != "Active":
+			frappe.throw(_("Client config is only available once the tunnel is Active"))
+		from atlas.atlas.api.tunnel import _client_config
+
+		return _client_config(self)
+
+	@frappe.whitelist()
 	def revoke(self) -> str:
 		"""Tear the tunnel down on the host and mark Revoked, releasing its slot.
 

--- a/atlas/atlas/networking.py
+++ b/atlas/atlas/networking.py
@@ -308,6 +308,28 @@ def tunnel_listen_port(slot_index: int) -> int:
 	return TUNNEL_PORT_BASE + slot_index
 
 
+def allocate_tunnel_slot(server_name: str) -> int:
+	"""Lowest unused per-server tunnel slot index. Scans the server's VPN Tunnel
+	rows whose status is not Revoked — a Revoked tunnel has released its slot back
+	to the pool (its port + overlay are free to reuse), exactly as a Terminated VM
+	releases its /128. Locks the Server row for the scan so two concurrent requests
+	cannot claim the same slot, mirroring allocate_ipv6."""
+	frappe.get_doc("Server", server_name, for_update=True)
+	used = {
+		index
+		for index in frappe.get_all(
+			"VPN Tunnel",
+			filters={"server": server_name, "status": ["!=", "Revoked"]},
+			pluck="slot_index",
+		)
+		if index is not None
+	}
+	index = 0
+	while index in used:
+		index += 1
+	return index
+
+
 def tunnel_overlay_link(slot_index: int) -> tuple[str, str]:
 	"""(host_side, client_side) /127 overlay CIDRs for a tunnel, indexed by its
 	per-server slot. A point-to-point link inside ATLAS_TUNNEL_SUPERNET: the host

--- a/atlas/atlas/networking.py
+++ b/atlas/atlas/networking.py
@@ -308,6 +308,18 @@ def tunnel_listen_port(slot_index: int) -> int:
 	return TUNNEL_PORT_BASE + slot_index
 
 
+def tunnel_endpoint_address(server_name: str) -> str:
+	"""The address a tunnel client dials — the single seam for the private-VPC
+	future (spec/19-vpn-broker.md). Today the server's public IPv4, so an
+	IPv4-only client can connect and reach the v6-only VM over the tunnel; later a
+	private VPC address, swapped here with the Server's `transport`. Fails loud if
+	the server has no v4 (a misconfigured/Self-Managed host without one)."""
+	address = frappe.db.get_value("Server", server_name, "ipv4_address")
+	if not address:
+		raise frappe.ValidationError(f"Server {server_name} has no ipv4_address for a tunnel endpoint")
+	return address
+
+
 def allocate_tunnel_slot(server_name: str) -> int:
 	"""Lowest unused per-server tunnel slot index. Scans the server's VPN Tunnel
 	rows whose status is not Revoked — a Revoked tunnel has released its slot back

--- a/atlas/atlas/networking.py
+++ b/atlas/atlas/networking.py
@@ -325,7 +325,14 @@ def allocate_tunnel_slot(server_name: str) -> int:
 	rows whose status is not Revoked — a Revoked tunnel has released its slot back
 	to the pool (its port + overlay are free to reuse), exactly as a Terminated VM
 	releases its /128. Locks the Server row for the scan so two concurrent requests
-	cannot claim the same slot, mirroring allocate_ipv6."""
+	cannot claim the same slot, mirroring allocate_ipv6.
+
+	This row lock — not a DB `unique` index — is what makes slot allocation
+	race-safe, and a static unique (server, slot_index) index would be *wrong*: a
+	reused slot collides with the lingering Revoked row that still carries it (revoke
+	keeps slot_index; it does not delete the row). Contrast the Firewall unique index
+	on virtual_machine, which is safe only because remove_firewall deletes the row
+	outright, leaving nothing to collide with."""
 	frappe.get_doc("Server", server_name, for_update=True)
 	used = {
 		index

--- a/atlas/atlas/networking.py
+++ b/atlas/atlas/networking.py
@@ -52,6 +52,23 @@ MAX_OPEN_FILES = 1024
 # uplink and is never visible on the wire — it only needs to be unique per host.
 IPV4_EGRESS_SUPERNET = "100.64.0.0/16"
 
+# WireGuard VPN broker (spec/19-vpn-broker.md). Each tunnel terminates on the
+# host with its own wg interface; a per-server slot index gives each one a UDP
+# listen port and a private overlay link, in the spirit of allocate_ipv6 /
+# derive_ipv4_link. The slot SCAN lives with the VPN Tunnel controller (it
+# queries the doctype); the derivations below are pure functions of the slot.
+
+# First UDP port for tunnel listeners (WireGuard's default port). Slot 0 -> 51820,
+# slot 1 -> 51821, … The host has no input firewall (the `inet atlas` table is
+# forward + nat only), so the port is reachable on the host's public address.
+TUNNEL_PORT_BASE = 51820
+
+# Fixed ULA supernet for per-tunnel overlay links — the private v6 addresses the
+# host and client ends of a tunnel carry so the VM has a return path. Like the
+# NAT44 egress supernet, the overlay is private, routed into one interface, and
+# never appears on the public wire, so it only has to be unique per host.
+ATLAS_TUNNEL_SUPERNET = "fd00:a71a:5000::/48"
+
 
 def carve_virtual_machine_range(host_address: str, prefix_cidr: str) -> str:
 	"""Return the /124 inside `prefix_cidr` that contains `host_address`.
@@ -270,6 +287,41 @@ def derive_ipv4_link(ipv6_address: str) -> tuple[str, str]:
 	link = ipaddress.IPv4Network((base, 30))
 	if not supernet.supernet_of(link):
 		raise frappe.ValidationError("No IPv4 egress capacity on server")
+	hosts = list(link.hosts())
+	return (
+		f"{hosts[0]}/{link.prefixlen}",
+		f"{hosts[1]}/{link.prefixlen}",
+	)
+
+
+def derive_tunnel_interface(tunnel_name: str) -> str:
+	"""wg-<first 11 hex of the tunnel UUID>. Length 14, IFNAMSIZ-safe (`wg-` (3) +
+	11 = 14), and distinct from a VM's `atlas-…` tap/veth names. Pure function of
+	the tunnel's UUID, like derive_tap — so the on-host interface is
+	reconstructible from the row with no allocator."""
+	hex_only = uuid.UUID(tunnel_name).hex
+	return f"wg-{hex_only[:11]}"
+
+
+def tunnel_listen_port(slot_index: int) -> int:
+	"""The UDP port a tunnel's wg interface listens on: TUNNEL_PORT_BASE + slot."""
+	return TUNNEL_PORT_BASE + slot_index
+
+
+def tunnel_overlay_link(slot_index: int) -> tuple[str, str]:
+	"""(host_side, client_side) /127 overlay CIDRs for a tunnel, indexed by its
+	per-server slot. A point-to-point link inside ATLAS_TUNNEL_SUPERNET: the host
+	end is the lower address (addresses the host's wg interface), the client end
+	the upper (the address the VM routes its replies back to, carried in the
+	client's wg `Address`). A /127 is the RFC 6164 point-to-point form — both
+	addresses are usable. Mirrors derive_ipv4_link's per-host-unique allocation.
+
+	Example: slot 0 -> ('fd00:a71a:5000::/127', 'fd00:a71a:5000::1/127')."""
+	supernet = ipaddress.IPv6Network(ATLAS_TUNNEL_SUPERNET)
+	base = int(supernet.network_address) + slot_index * 2
+	link = ipaddress.IPv6Network((base, 127))
+	if not supernet.supernet_of(link):
+		raise frappe.ValidationError("No tunnel overlay capacity on server")
 	hosts = list(link.hosts())
 	return (
 		f"{hosts[0]}/{link.prefixlen}",

--- a/atlas/atlas/permissions.py
+++ b/atlas/atlas/permissions.py
@@ -25,7 +25,14 @@ OPERATOR_ROLE = "System Manager"
 # DocTypes whose rows a user owns directly via Frappe's `owner` column. A
 # `Site Request` is created by a Guest and re-owned to the verified user at
 # fulfilment (spec/14-self-serve.md), so a user can see only their own requests.
-_OWNED_DOCTYPES = ("Virtual Machine", "Virtual Machine Snapshot", "SSH Key", "Site", "Site Request")
+_OWNED_DOCTYPES = (
+	"Virtual Machine",
+	"Virtual Machine Snapshot",
+	"SSH Key",
+	"Site",
+	"Site Request",
+	"VPN Tunnel",
+)
 
 
 def _is_operator(user: str) -> bool:

--- a/atlas/atlas/permissions.py
+++ b/atlas/atlas/permissions.py
@@ -32,6 +32,7 @@ _OWNED_DOCTYPES = (
 	"Site",
 	"Site Request",
 	"VPN Tunnel",
+	"Firewall",
 )
 
 

--- a/atlas/atlas/wireguard.py
+++ b/atlas/atlas/wireguard.py
@@ -1,60 +1,23 @@
-"""WireGuard key material, minted in the controller.
+"""WireGuard key validation at the controller boundary.
 
-The VPN broker (spec/19-vpn-broker.md) terminates each tunnel on the host with a
-**host-side** keypair. We mint it here — X25519 via `cryptography`, encoded in
-WireGuard's base64 form — so the keypair is created where Frappe is the source of
-truth (stored on the `VPN Tunnel` row, the private half encrypted) and pushed to
-the host, rather than generated on the host and scraped back (the principle-#2
-rule the Reserved IP anchor is the rare exception to).
+The VPN broker (spec/19-vpn-broker.md) terminates each tunnel on the host, and
+the **host** mints its own keypair (like a guest's SSH host keys — host-resident
+crypto identity, never routed through a Task and never stored in the Frappe DB).
+The client likewise mints its own keypair and sends only its public key.
 
-The client mints its OWN keypair and sends only its public key, so Atlas never
-holds a client private key; `is_valid_public_key` guards that input at the API
-boundary. Pure and host-free: unit-testable with bare `cryptography`, no Frappe,
-no SSH.
+So the controller never generates or holds a private key; its only key concern is
+to reject a malformed *client* public key before a Task is dispatched, which
+`is_valid_public_key` does. Pure and host-free.
 """
 
 from __future__ import annotations
 
 import base64
-from dataclasses import dataclass
-
-from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
-from cryptography.hazmat.primitives.serialization import (
-	Encoding,
-	NoEncryption,
-	PrivateFormat,
-	PublicFormat,
-)
 
 # A WireGuard key is a 32-byte value rendered in standard base64 — 44 chars,
 # '='-padded, exactly as `wg genkey` / `wg pubkey` emit it.
 KEY_BYTES = 32
 ENCODED_KEY_LENGTH = 44
-
-
-@dataclass(frozen=True)
-class WireGuardKeypair:
-	"""A host-side WireGuard keypair, base64-encoded as `wg` emits it."""
-
-	private_key: str
-	public_key: str
-
-
-def generate_keypair() -> WireGuardKeypair:
-	"""Mint a fresh X25519 keypair in WireGuard base64 form."""
-	private = X25519PrivateKey.generate()
-	return WireGuardKeypair(
-		private_key=_encode(private.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())),
-		public_key=_encode(private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)),
-	)
-
-
-def public_key_for(private_key: str) -> str:
-	"""Derive the public key for a base64 WireGuard private key. The inverse check
-	for a keypair, and the way a host private key alone reconstructs its public
-	half."""
-	private = X25519PrivateKey.from_private_bytes(_decode(private_key))
-	return _encode(private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
 
 
 def is_valid_public_key(key: str) -> bool:
@@ -70,11 +33,3 @@ def is_valid_public_key(key: str) -> bool:
 	except ValueError:
 		# binascii.Error (bad base64) is a ValueError subclass.
 		return False
-
-
-def _encode(raw: bytes) -> str:
-	return base64.standard_b64encode(raw).decode("ascii")
-
-
-def _decode(key: str) -> bytes:
-	return base64.b64decode(key, validate=True)

--- a/atlas/atlas/wireguard.py
+++ b/atlas/atlas/wireguard.py
@@ -1,0 +1,80 @@
+"""WireGuard key material, minted in the controller.
+
+The VPN broker (spec/19-vpn-broker.md) terminates each tunnel on the host with a
+**host-side** keypair. We mint it here — X25519 via `cryptography`, encoded in
+WireGuard's base64 form — so the keypair is created where Frappe is the source of
+truth (stored on the `VPN Tunnel` row, the private half encrypted) and pushed to
+the host, rather than generated on the host and scraped back (the principle-#2
+rule the Reserved IP anchor is the rare exception to).
+
+The client mints its OWN keypair and sends only its public key, so Atlas never
+holds a client private key; `is_valid_public_key` guards that input at the API
+boundary. Pure and host-free: unit-testable with bare `cryptography`, no Frappe,
+no SSH.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+	Encoding,
+	NoEncryption,
+	PrivateFormat,
+	PublicFormat,
+)
+
+# A WireGuard key is a 32-byte value rendered in standard base64 — 44 chars,
+# '='-padded, exactly as `wg genkey` / `wg pubkey` emit it.
+KEY_BYTES = 32
+ENCODED_KEY_LENGTH = 44
+
+
+@dataclass(frozen=True)
+class WireGuardKeypair:
+	"""A host-side WireGuard keypair, base64-encoded as `wg` emits it."""
+
+	private_key: str
+	public_key: str
+
+
+def generate_keypair() -> WireGuardKeypair:
+	"""Mint a fresh X25519 keypair in WireGuard base64 form."""
+	private = X25519PrivateKey.generate()
+	return WireGuardKeypair(
+		private_key=_encode(private.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())),
+		public_key=_encode(private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)),
+	)
+
+
+def public_key_for(private_key: str) -> str:
+	"""Derive the public key for a base64 WireGuard private key. The inverse check
+	for a keypair, and the way a host private key alone reconstructs its public
+	half."""
+	private = X25519PrivateKey.from_private_bytes(_decode(private_key))
+	return _encode(private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def is_valid_public_key(key: str) -> bool:
+	"""True iff `key` is a syntactically valid WireGuard public key — a 32-byte
+	value in standard base64. Guards the client-supplied public key at the API
+	boundary so a malformed key fails loud in the controller, not on the host."""
+	if not isinstance(key, str) or len(key) != ENCODED_KEY_LENGTH:
+		return False
+	try:
+		# validate=True rejects non-alphabet characters rather than silently
+		# discarding them (which could let a 44-char junk string decode short).
+		return len(base64.b64decode(key, validate=True)) == KEY_BYTES
+	except ValueError:
+		# binascii.Error (bad base64) is a ValueError subclass.
+		return False
+
+
+def _encode(raw: bytes) -> str:
+	return base64.standard_b64encode(raw).decode("ascii")
+
+
+def _decode(key: str) -> bytes:
+	return base64.b64decode(key, validate=True)

--- a/atlas/atlas/workspace/atlas/atlas.json
+++ b/atlas/atlas/workspace/atlas/atlas.json
@@ -105,7 +105,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Networking & TLS",
-   "link_count": 7,
+   "link_count": 9,
    "onboard": 0,
    "type": "Card Break"
   },
@@ -175,6 +175,26 @@
    "label": "Bench Routing Audit",
    "link_count": 0,
    "link_to": "Bench Routing Audit",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "VPN Tunnel",
+   "link_count": 0,
+   "link_to": "VPN Tunnel",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Firewall",
+   "link_count": 0,
+   "link_to": "Firewall",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -185,6 +185,7 @@ permission_query_conditions = {
 	"Site": "atlas.atlas.permissions.owner_only",
 	"Site Request": "atlas.atlas.permissions.owner_only",
 	"VPN Tunnel": "atlas.atlas.permissions.owner_only",
+	"Firewall": "atlas.atlas.permissions.owner_only",
 	"Task": "atlas.atlas.permissions.task_by_owned_vm",
 }
 

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -53,6 +53,8 @@ doctype_js = {
 	"Virtual Machine Image": "public/js/atlas_form_overrides.js",
 	"Virtual Machine Snapshot": "public/js/atlas_form_overrides.js",
 	"Reserved IP": "public/js/atlas_form_overrides.js",
+	"VPN Tunnel": "public/js/atlas_form_overrides.js",
+	"Firewall": "public/js/atlas_form_overrides.js",
 	"Task": "public/js/atlas_form_overrides.js",
 	"Route53 Settings": "public/js/atlas_form_overrides.js",
 	"Lets Encrypt Settings": "public/js/atlas_form_overrides.js",

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -184,6 +184,7 @@ permission_query_conditions = {
 	"SSH Key": "atlas.atlas.permissions.owner_only",
 	"Site": "atlas.atlas.permissions.owner_only",
 	"Site Request": "atlas.atlas.permissions.owner_only",
+	"VPN Tunnel": "atlas.atlas.permissions.owner_only",
 	"Task": "atlas.atlas.permissions.task_by_owned_vm",
 }
 

--- a/atlas/tests/e2e/use_cases/self_serve_site.py
+++ b/atlas/tests/e2e/use_cases/self_serve_site.py
@@ -297,7 +297,7 @@ def _assert_bench_self_routing(
 	_stdout, stderr, code = guest(f"atlas-route register {stray}")
 	assert code == 0, f"register for the stray case failed: {stderr[-500:]}"
 	assert frappe.db.exists("Subdomain", stray), "register did not reserve the stray label"
-	stdout, stderr, code = guest("atlas-route list")
+	_stdout, stderr, code = guest("atlas-route list")
 	assert code == 0, f"guest atlas-route list failed: {stderr[-500:]}"
 	assert not frappe.db.exists("Subdomain", stray), (
 		f"list did not clear the stray {stray} (stderr: {stderr[-500:]})"

--- a/atlas/tests/test_bench_routing_guest.py
+++ b/atlas/tests/test_bench_routing_guest.py
@@ -374,7 +374,14 @@ class TestCLIWrapper(_ClientTestCase):
 		self.addCleanup(lambda: __import__("shutil").rmtree(empty, ignore_errors=True))
 		self.client.BENCH_SITES_DIRECTORY = str(empty)
 		self.server.responses = {
-			"list": (200, {"message": {"domains": [{"label": "stray", "fqdn": "stray.blr1.frappe.dev", "active": True}]}}),
+			"list": (
+				200,
+				{
+					"message": {
+						"domains": [{"label": "stray", "fqdn": "stray.blr1.frappe.dev", "active": True}]
+					}
+				},
+			),
 			"deregister": (200, {"message": {"status": "ok"}}),
 		}
 		self._set_config(self.base)
@@ -393,7 +400,10 @@ class TestCLIWrapper(_ClientTestCase):
 		(sites / "keep.blr1.frappe.dev").mkdir()
 		self.client.BENCH_SITES_DIRECTORY = str(sites)
 		self.server.responses = {
-			"list": (200, {"message": {"domains": [{"label": "keep", "fqdn": "keep.blr1.frappe.dev", "active": True}]}}),
+			"list": (
+				200,
+				{"message": {"domains": [{"label": "keep", "fqdn": "keep.blr1.frappe.dev", "active": True}]}},
+			),
 			"deregister": (200, {"message": {"status": "ok"}}),
 		}
 		self._set_config(self.base)

--- a/atlas/tests/test_networking.py
+++ b/atlas/tests/test_networking.py
@@ -1,14 +1,17 @@
+import ipaddress
 import uuid
 
 import frappe
 from frappe.tests import IntegrationTestCase
 
 from atlas.atlas.networking import (
+	ATLAS_TUNNEL_SUPERNET,
 	CPU_MODE_RELAXED,
 	CPU_WEIGHT_MAX,
 	CPU_WEIGHT_MIN,
 	MAX_OPEN_FILES,
 	MEMORY_HEADROOM_MIB,
+	TUNNEL_PORT_BASE,
 	UID_BASE,
 	UID_SPAN,
 	allocate_ipv6,
@@ -18,9 +21,12 @@ from atlas.atlas.networking import (
 	derive_mac,
 	derive_netns,
 	derive_tap,
+	derive_tunnel_interface,
 	derive_uid,
 	derive_veth_pair,
 	resource_limit_args,
+	tunnel_listen_port,
+	tunnel_overlay_link,
 )
 from atlas.tests.fixtures import make_image, make_provider, make_server
 
@@ -182,6 +188,46 @@ class TestNetworking(IntegrationTestCase):
 			self.assertLessEqual(len(ns_veth), 15, ns_veth)
 			self.assertTrue(host_veth.startswith("atlas-h"))
 			self.assertTrue(ns_veth.startswith("atlas-n"))
+
+	def test_derive_tunnel_interface_stable_and_ifnamsiz_safe(self) -> None:
+		for _ in range(20):
+			name = str(uuid.uuid4())
+			interface = derive_tunnel_interface(name)
+			self.assertEqual(interface, derive_tunnel_interface(name))
+			self.assertTrue(interface.startswith("wg-"))
+			# IFNAMSIZ-safe (<= 15 chars) and distinct from the VM tap/veth names.
+			self.assertEqual(len(interface), len("wg-") + 11)
+			self.assertLessEqual(len(interface), 15, interface)
+			self.assertNotEqual(interface, derive_tap(name))
+			self.assertNotIn(interface, derive_veth_pair(name))
+
+	def test_tunnel_listen_port_indexes_from_base(self) -> None:
+		self.assertEqual(tunnel_listen_port(0), TUNNEL_PORT_BASE)
+		self.assertEqual(tunnel_listen_port(7), TUNNEL_PORT_BASE + 7)
+
+	def test_tunnel_overlay_link_point_to_point(self) -> None:
+		supernet = ipaddress.IPv6Network(ATLAS_TUNNEL_SUPERNET)
+		seen = set()
+		for slot in range(8):
+			host_cidr, client_cidr = tunnel_overlay_link(slot)
+			host = ipaddress.ip_interface(host_cidr)
+			client = ipaddress.ip_interface(client_cidr)
+			# /127 point-to-point: host is the lower address, client the upper,
+			# and the two sit in the same /127.
+			self.assertEqual(host.network.prefixlen, 127)
+			self.assertEqual(host.network, client.network)
+			self.assertLess(host.ip, client.ip)
+			# Inside the supernet and unique across slots (per-host uniqueness).
+			self.assertIn(host.ip, supernet)
+			self.assertIn(client.ip, supernet)
+			self.assertNotIn(host.ip, seen)
+			self.assertNotIn(client.ip, seen)
+			seen.update({host.ip, client.ip})
+		# Slot 0 anchors at the supernet base, ::1 is the client end.
+		self.assertEqual(
+			tunnel_overlay_link(0),
+			(f"{supernet.network_address}/127", f"{supernet.network_address + 1}/127"),
+		)
 
 	def test_cgroup_args_for_resource_triple(self) -> None:
 		# 2 cores' bandwidth, 1024 MiB RAM, 8 GiB disk. cpu_max_cores=2 →

--- a/atlas/tests/test_wireguard.py
+++ b/atlas/tests/test_wireguard.py
@@ -7,46 +7,28 @@ from frappe.tests import IntegrationTestCase
 from atlas.atlas.wireguard import (
 	ENCODED_KEY_LENGTH,
 	KEY_BYTES,
-	generate_keypair,
 	is_valid_public_key,
-	public_key_for,
 )
 
 
 class TestWireGuardKeys(IntegrationTestCase):
-	def test_generate_keypair_shape(self):
-		keypair = generate_keypair()
-		for key in (keypair.private_key, keypair.public_key):
-			self.assertEqual(len(key), ENCODED_KEY_LENGTH)
-			self.assertEqual(len(base64.b64decode(key, validate=True)), KEY_BYTES)
-		# Two halves of a keypair are never equal.
-		self.assertNotEqual(keypair.private_key, keypair.public_key)
+	def test_is_valid_public_key_accepts_a_real_wg_key(self):
+		# A 32-byte standard-base64 value, the shape `wg pubkey` emits.
+		key = base64.standard_b64encode(b"\x11" * KEY_BYTES).decode()
+		self.assertEqual(len(key), ENCODED_KEY_LENGTH)
+		self.assertTrue(is_valid_public_key(key))
 
-	def test_generate_keypair_is_random(self):
-		self.assertNotEqual(generate_keypair().private_key, generate_keypair().private_key)
-
-	def test_public_key_for_round_trips(self):
-		keypair = generate_keypair()
-		self.assertEqual(public_key_for(keypair.private_key), keypair.public_key)
-
-	def test_public_key_matches_wg_tool(self):
-		# Cross-check our base64/X25519 derivation against WireGuard's own
-		# `wg pubkey`, when the tool is on the controller. Skips cleanly without it
-		# (still host-free — a local subprocess, no remote host).
+	def test_is_valid_public_key_accepts_wg_tool_output(self):
+		# Cross-check against WireGuard's own key generation, when the tool is on
+		# the controller. Skips cleanly without it (still host-free — a local
+		# subprocess, no remote host).
 		if not shutil.which("wg"):
 			self.skipTest("wg not installed on the controller")
-		keypair = generate_keypair()
-		derived = subprocess.run(
-			["wg", "pubkey"],
-			input=keypair.private_key,
-			capture_output=True,
-			text=True,
-			check=True,
+		private = subprocess.run(["wg", "genkey"], capture_output=True, text=True, check=True).stdout.strip()
+		public = subprocess.run(
+			["wg", "pubkey"], input=private, capture_output=True, text=True, check=True
 		).stdout.strip()
-		self.assertEqual(derived, keypair.public_key)
-
-	def test_is_valid_public_key_accepts_real_key(self):
-		self.assertTrue(is_valid_public_key(generate_keypair().public_key))
+		self.assertTrue(is_valid_public_key(public))
 
 	def test_is_valid_public_key_rejects_malformed(self):
 		# Wrong length (short / long), a base64 value of the wrong byte count, and

--- a/atlas/tests/test_wireguard.py
+++ b/atlas/tests/test_wireguard.py
@@ -1,0 +1,62 @@
+import base64
+import shutil
+import subprocess
+
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.wireguard import (
+	ENCODED_KEY_LENGTH,
+	KEY_BYTES,
+	generate_keypair,
+	is_valid_public_key,
+	public_key_for,
+)
+
+
+class TestWireGuardKeys(IntegrationTestCase):
+	def test_generate_keypair_shape(self):
+		keypair = generate_keypair()
+		for key in (keypair.private_key, keypair.public_key):
+			self.assertEqual(len(key), ENCODED_KEY_LENGTH)
+			self.assertEqual(len(base64.b64decode(key, validate=True)), KEY_BYTES)
+		# Two halves of a keypair are never equal.
+		self.assertNotEqual(keypair.private_key, keypair.public_key)
+
+	def test_generate_keypair_is_random(self):
+		self.assertNotEqual(generate_keypair().private_key, generate_keypair().private_key)
+
+	def test_public_key_for_round_trips(self):
+		keypair = generate_keypair()
+		self.assertEqual(public_key_for(keypair.private_key), keypair.public_key)
+
+	def test_public_key_matches_wg_tool(self):
+		# Cross-check our base64/X25519 derivation against WireGuard's own
+		# `wg pubkey`, when the tool is on the controller. Skips cleanly without it
+		# (still host-free — a local subprocess, no remote host).
+		if not shutil.which("wg"):
+			self.skipTest("wg not installed on the controller")
+		keypair = generate_keypair()
+		derived = subprocess.run(
+			["wg", "pubkey"],
+			input=keypair.private_key,
+			capture_output=True,
+			text=True,
+			check=True,
+		).stdout.strip()
+		self.assertEqual(derived, keypair.public_key)
+
+	def test_is_valid_public_key_accepts_real_key(self):
+		self.assertTrue(is_valid_public_key(generate_keypair().public_key))
+
+	def test_is_valid_public_key_rejects_malformed(self):
+		# Wrong length (short / long), a base64 value of the wrong byte count, and
+		# a 44-char string with a character outside the base64 alphabet.
+		short = base64.standard_b64encode(b"\x00" * 16).decode()  # 24 chars
+		for bad in ("", "not a key", "x" * 43, "x" * 45, short, "!" + "A" * 43):
+			self.assertFalse(is_valid_public_key(bad), bad)
+
+	def test_is_valid_public_key_rejects_non_string(self):
+		# Defensive: the API boundary may hand us a non-str; the isinstance guard
+		# rejects it rather than raising.
+		for bad in (None, 1234):
+			self.assertFalse(is_valid_public_key(bad))  # type: ignore[arg-type]

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -141,6 +141,7 @@ PACKAGES = [
 	"nftables",
 	"squashfs-tools",
 	"thin-provisioning-tools",
+	"wireguard-tools",
 ]
 
 

--- a/scripts/firewall-apply.py
+++ b/scripts/firewall-apply.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Apply or clear a VM's public-ingress firewall on the host, with no reboot
+# (spec/20-firewall.md) — the live half of the Firewall feature, the firewall
+# analog of vm-tunnel.py.
+#
+# apply: write the firewall.env sidecar (durable; re-applied at cold boot by
+#        vm-network-up.py) and install the nft public_filter block restricting
+#        the VM's PUBLIC IPv6 to the listed proto/port rules. An empty rule list
+#        is a valid deny-all-public (the VM is then reachable only over its VPN).
+# clear: remove the nft block and delete the sidecar, reverting the VM to fully
+#        public.
+#
+# A Task (typed --flags), dispatched by Firewall.apply()/clear(). Imports the
+# per-task staged atlas package under /tmp/atlas/lib, like the other Task scripts.
+
+import os
+import sys
+import typing
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import install_file, run
+from atlas._task import TaskInputs
+from atlas.firewall import FirewallConfig, Rule, apply_firewall, remove_firewall
+from atlas.network_env import read_network_env
+from atlas.paths import VirtualMachinePaths
+
+
+@dataclass(frozen=True)
+class FirewallInputs(TaskInputs):
+	"""Apply or clear a VM's public-ingress firewall on the host."""
+
+	command: typing.ClassVar[str] = "firewall-apply"
+	virtual_machine_name: str  # the VM UUID — locates the VM dir + network.env
+	action: str = "apply"  # "apply" | "clear"
+	# A repeatable flag: --rule tcp/443 --rule udp/1194. Empty on a deny-all-public
+	# firewall; ignored on clear.
+	rule: list[str] = field(default_factory=list)
+
+
+def main() -> None:
+	inputs = FirewallInputs.from_args()
+	if inputs.action not in ("apply", "clear"):
+		sys.exit(f"action must be apply|clear, got {inputs.action!r}")
+
+	paths = VirtualMachinePaths(inputs.virtual_machine_name)
+
+	if inputs.action == "clear":
+		virtual_machine_ipv6 = read_network_env(paths.network_env).require("VIRTUAL_MACHINE_IPV6")
+		remove_firewall(virtual_machine_ipv6)
+		# Best-effort — a clear may run after terminate already rm -rf'd the dir.
+		run("sudo", "rm", "-f", paths.firewall_env, check=False)
+		print(f"Firewall cleared on {inputs.virtual_machine_name}; VM is fully public.")
+		return
+
+	virtual_machine_ipv6 = read_network_env(paths.network_env).require("VIRTUAL_MACHINE_IPV6")
+	config = FirewallConfig(
+		virtual_machine_ipv6=virtual_machine_ipv6,
+		rules=tuple(Rule.parse(token) for token in inputs.rule),
+	)
+	# The .env sidecar (0644) carries the durable metadata; vm-network-up.py
+	# re-applies it at cold boot.
+	install_file(config.to_env_text(), paths.firewall_env, mode="0644")
+	apply_firewall(config)
+	allowed = ", ".join(rule.token() for rule in config.rules) or "(deny all public)"
+	print(f"Firewall applied on {inputs.virtual_machine_name}: {allowed}.")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/lib/atlas/firewall.py
+++ b/scripts/lib/atlas/firewall.py
@@ -1,0 +1,194 @@
+"""Host-side public-ingress firewall for a VM (spec/20-firewall.md).
+
+A VM's public IPv6 is reachable from the whole internet by default (the
+`inet atlas forward` chain is `policy accept` with a broad per-VM accept). A
+Firewall restricts that **public** surface to a chosen set of ports — "only 443",
+say — while leaving two paths untouched:
+
+  - the VPN tunnel, which keeps FULL access to the whole VM, and
+  - the VM's own outbound connections (their return traffic is not new ingress).
+
+The mechanism is a SEPARATE, higher-priority base chain on the same hook:
+
+    chain public_filter {
+        type filter hook forward priority filter - 5; policy accept;
+        iifname <uplink> ip6 daddr <vm> ct state established,related accept
+        iifname <uplink> ip6 daddr <vm> tcp dport <p> accept   # one per allowed rule
+        iifname <uplink> ip6 daddr <vm> drop                   # public, not allowed -> DROP
+    }
+
+Why this shape gives "VPN bypasses the firewall" for free: every rule is scoped to
+`iifname <uplink>` (the host's public NIC). Tunnel traffic arrives on a `wg-…`
+interface, never the uplink, so it matches nothing here and falls through to the
+`forward` chain (where the tunnel's own accept/drop govern it). A `drop` in this
+earlier chain is terminal; an `accept` only ends THIS chain, so allowed traffic
+proceeds to `forward` and is delivered as before. The `established,related` accept
+turns conntrack on for the forward hook — the one real behavioral addition — so a
+reply to a connection the VM opened is never mistaken for new public ingress.
+
+No Firewall attached → no sidecar → no rules here → the VM stays fully public
+(opt-in, per spec/20). Everything is pure argv/string construction except
+`apply_firewall` / `remove_firewall` / `apply_persisted_firewall`, which touch the
+host; the rest is unit-testable with bare `python3 -m unittest`, like wireguard.py.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from atlas._run import run, run_ok
+from atlas.network_env import NetworkEnv, default_route_device
+
+TABLE = ("inet", "atlas")
+PUBLIC_FILTER = "public_filter"
+# Runs BEFORE the forward chain (priority 0), so its drop pre-empts forward's broad
+# per-VM accept. nft accepts arithmetic on the named base priority.
+PUBLIC_FILTER_PRIORITY = "filter - 5"
+PROTOCOLS = ("tcp", "udp")
+
+
+@dataclass(frozen=True)
+class Rule:
+	"""One allowed public ingress rule: a transport protocol and a destination port."""
+
+	protocol: str
+	port: int
+
+	@classmethod
+	def parse(cls, token: str) -> "Rule":
+		"""Parse a `proto/port` token (`tcp/443`), failing loud on anything invalid —
+		these come from a typed flag, but the host never trusts its input blindly."""
+		protocol, separator, port = token.partition("/")
+		if not separator or protocol not in PROTOCOLS:
+			raise SystemExit(f"firewall rule {token!r}: expected one of {PROTOCOLS} as proto/port")
+		try:
+			number = int(port)
+		except ValueError:
+			raise SystemExit(f"firewall rule {token!r}: port is not an integer")
+		if not 1 <= number <= 65535:
+			raise SystemExit(f"firewall rule {token!r}: port {number} out of range 1-65535")
+		return cls(protocol=protocol, port=number)
+
+	def token(self) -> str:
+		return f"{self.protocol}/{self.port}"
+
+
+@dataclass(frozen=True)
+class FirewallConfig:
+	"""One VM's durable public-firewall state — what `apply_firewall` needs and what
+	the `firewall.env` sidecar persists so a cold boot re-applies it (the network.env
+	pattern). An empty `rules` is meaningful: a firewall with no open ports denies all
+	public ingress (the VM is then reachable only over its VPN tunnel)."""
+
+	virtual_machine_ipv6: str
+	rules: tuple[Rule, ...]
+
+	@classmethod
+	def from_env(cls, env: NetworkEnv) -> "FirewallConfig":
+		"""Build from a parsed sidecar. RULES is a space-separated list of proto/port
+		tokens; absent or empty means deny-all-public."""
+		tokens = env.get("RULES").split()
+		return cls(
+			virtual_machine_ipv6=env.require("VIRTUAL_MACHINE_IPV6"),
+			rules=tuple(Rule.parse(token) for token in tokens),
+		)
+
+	def to_env_text(self) -> str:
+		"""Render the KEY=value sidecar (the inverse of from_env). Bare values, like
+		provision's network.env."""
+		rules = " ".join(rule.token() for rule in self.rules)
+		return f"VIRTUAL_MACHINE_IPV6={self.virtual_machine_ipv6}\nRULES={rules}\n"
+
+
+def ensure_chain_argv() -> str:
+	"""The single-string `add chain` form (matches vm-network-up's forward-chain
+	creation). Idempotency is the caller's `run_ok` guard, as elsewhere."""
+	return (
+		f"add chain inet atlas {PUBLIC_FILTER} "
+		f"{{ type filter hook forward priority {PUBLIC_FILTER_PRIORITY}; policy accept; }}"
+	)
+
+
+def established_rule_argv(uplink: str, virtual_machine_ipv6: str) -> list[str]:
+	"""Accept replies to connections the VM itself opened — they arrive from the
+	uplink destined to the VM but are not new public ingress. Must precede the drop."""
+	return [
+		"add", "rule", "inet", "atlas", PUBLIC_FILTER,
+		"iifname", uplink, "ip6", "daddr", virtual_machine_ipv6,
+		"ct", "state", "established,related", "accept",
+	]  # fmt: skip
+
+
+def port_rule_argv(uplink: str, virtual_machine_ipv6: str, rule: Rule) -> list[str]:
+	"""Accept new public ingress to one allowed protocol/port on the VM."""
+	return [
+		"add", "rule", "inet", "atlas", PUBLIC_FILTER,
+		"iifname", uplink, "ip6", "daddr", virtual_machine_ipv6,
+		rule.protocol, "dport", str(rule.port), "accept",
+	]  # fmt: skip
+
+
+def drop_rule_argv(uplink: str, virtual_machine_ipv6: str) -> list[str]:
+	"""Drop everything else arriving from the uplink for this VM — the closing rule
+	of the VM's block, so any public port not explicitly allowed is unreachable."""
+	return [
+		"add", "rule", "inet", "atlas", PUBLIC_FILTER,
+		"iifname", uplink, "ip6", "daddr", virtual_machine_ipv6, "drop",
+	]  # fmt: skip
+
+
+def apply_firewall(config: FirewallConfig) -> None:
+	"""Idempotently install this VM's public-ingress block. Discovers the host's v6
+	uplink fresh (like vm-network-up), ensures the chain exists, removes any existing
+	rules for this VM, then appends the block in order: established accept, one accept
+	per allowed rule, drop. Re-running (cold boot, edit, retry) converges to the same
+	block — the self-healing contract shared with apply_tunnel / reserved_ip_nat."""
+	uplink = default_route_device("-6")
+	if not run_ok("sudo", "nft", "list", "chain", *TABLE, PUBLIC_FILTER):
+		run("sudo", "nft", ensure_chain_argv())
+	_clear_vm_rules(config.virtual_machine_ipv6)
+	run("sudo", "nft", *established_rule_argv(uplink, config.virtual_machine_ipv6))
+	for rule in config.rules:
+		run("sudo", "nft", *port_rule_argv(uplink, config.virtual_machine_ipv6, rule))
+	run("sudo", "nft", *drop_rule_argv(uplink, config.virtual_machine_ipv6))
+
+
+def remove_firewall(virtual_machine_ipv6: str) -> None:
+	"""Delete this VM's block, reverting it to fully public (the forward chain's broad
+	accept takes over again). Best-effort and idempotent: a missing chain or absent
+	block is not an error — a detach may run after the VM is already gone, symmetric
+	with vm-network-down.py."""
+	if not run_ok("sudo", "nft", "list", "chain", *TABLE, PUBLIC_FILTER):
+		return
+	_clear_vm_rules(virtual_machine_ipv6)
+
+
+def apply_persisted_firewall(firewall_env_path: str) -> None:
+	"""Re-apply a VM's firewall at cold boot from its sidecar. Called by
+	vm-network-up.py AFTER the VM's /128 host route exists. No sidecar (no firewall
+	attached) is a no-op — the VM stays public. Fail-loud (apply raises) like the rest
+	of the unit's ExecStartPre."""
+	if not os.path.isfile(firewall_env_path):
+		return
+	# nosemgrep: frappe-security-file-traversal -- host script; reads a per-VM firewall sidecar path, not untrusted web input
+	with open(firewall_env_path) as handle:
+		config = FirewallConfig.from_env(NetworkEnv.parse(handle.read()))
+	apply_firewall(config)
+
+
+def _clear_vm_rules(virtual_machine_ipv6: str) -> None:
+	"""Delete every public_filter rule for this VM by handle. The chain is dedicated
+	to public filtering and every rule is daddr-scoped to one VM, so the VM's address
+	is an exact discriminator — the handle-scrape pattern from wireguard/reserved_ip."""
+	listing = run("sudo", "nft", "-a", "list", "chain", *TABLE, PUBLIC_FILTER, check=False)
+	for handle in _handles_for(listing, virtual_machine_ipv6):
+		run("sudo", "nft", "delete", "rule", "inet", "atlas", PUBLIC_FILTER, "handle", handle, check=False)
+
+
+def _handles_for(listing: str, virtual_machine_ipv6: str):
+	"""Trailing handle of every public_filter rule mentioning this VM's address.
+	`nft -a` prints `… # handle N`; the handle is the last token."""
+	for line in listing.splitlines():
+		if virtual_machine_ipv6 in line and "handle" in line:
+			yield line.split()[-1]

--- a/scripts/lib/atlas/paths.py
+++ b/scripts/lib/atlas/paths.py
@@ -52,6 +52,24 @@ class VirtualMachinePaths:
 		return f"{self.directory}/network.env"
 
 	@property
+	def tunnels_directory(self) -> str:
+		"""Per-VM directory of WireGuard tunnel sidecars (spec/19-vpn-broker.md).
+		vm-network-up.py re-applies every tunnel here at cold boot; vm-tunnel.py
+		writes/removes one per request. Inside the VM tree so terminate's rm -rf
+		sweeps it with the rest of the VM's host state."""
+		return f"{self.directory}/tunnels"
+
+	def tunnel_env(self, tunnel_name: str) -> str:
+		"""The KEY=value metadata sidecar for one tunnel (0644)."""
+		return f"{self.tunnels_directory}/{tunnel_name}.env"
+
+	def tunnel_key(self, tunnel_name: str) -> str:
+		"""The 0600 file holding the tunnel's host private key — `wg set` reads the
+		key from a path, never the command line, so the secret stays off the
+		process table and out of the Task audit row."""
+		return f"{self.tunnels_directory}/{tunnel_name}.key"
+
+	@property
 	def jail_chroot_base(self) -> str:
 		"""What the jailer's --chroot-base-dir points at."""
 		return f"{self.directory}/jail"

--- a/scripts/lib/atlas/paths.py
+++ b/scripts/lib/atlas/paths.py
@@ -52,6 +52,15 @@ class VirtualMachinePaths:
 		return f"{self.directory}/network.env"
 
 	@property
+	def firewall_env(self) -> str:
+		"""Sidecar carrying this VM's public-ingress firewall (spec/20-firewall.md):
+		its IPv6 and the allowed proto/port list. Read by vm-network-up.py to re-apply
+		the nft public_filter block at cold boot, and written/removed by
+		firewall-apply.py. Inside the VM tree so terminate's rm -rf sweeps it. Absent
+		for a VM with no firewall — which stays fully public."""
+		return f"{self.directory}/firewall.env"
+
+	@property
 	def tunnels_directory(self) -> str:
 		"""Per-VM directory of WireGuard tunnel sidecars (spec/19-vpn-broker.md).
 		vm-network-up.py re-applies every tunnel here at cold boot; vm-tunnel.py

--- a/scripts/lib/atlas/test_firewall.py
+++ b/scripts/lib/atlas/test_firewall.py
@@ -1,0 +1,149 @@
+"""Unit tests for the host-side public-ingress firewall (spec/20-firewall.md).
+
+Run with bare `python3 -m unittest atlas.test_firewall` from scripts/lib: no
+Frappe, no site, no host, no nft. These cover the rule parsing, the argv
+construction, the handle scrape that drives apply()/remove(), and the
+FirewallConfig sidecar (de)serialization.
+"""
+
+import unittest
+
+from atlas import firewall as fw
+from atlas.network_env import NetworkEnv
+
+UPLINK = "eth0"
+VM_V6 = "2400:6180:100:d0:0:1:5835:d003"
+
+
+class TestRuleParsing(unittest.TestCase):
+	def test_parses_proto_and_port(self):
+		self.assertEqual(fw.Rule.parse("tcp/443"), fw.Rule("tcp", 443))
+		self.assertEqual(fw.Rule.parse("udp/1194"), fw.Rule("udp", 1194))
+
+	def test_token_round_trips(self):
+		self.assertEqual(fw.Rule.parse("tcp/22").token(), "tcp/22")
+
+	def test_rejects_bad_protocol(self):
+		with self.assertRaises(SystemExit):
+			fw.Rule.parse("icmp/0")
+
+	def test_rejects_missing_separator(self):
+		with self.assertRaises(SystemExit):
+			fw.Rule.parse("443")
+
+	def test_rejects_non_integer_port(self):
+		with self.assertRaises(SystemExit):
+			fw.Rule.parse("tcp/https")
+
+	def test_rejects_out_of_range_port(self):
+		with self.assertRaises(SystemExit):
+			fw.Rule.parse("tcp/70000")
+		with self.assertRaises(SystemExit):
+			fw.Rule.parse("tcp/0")
+
+
+class TestRuleArgv(unittest.TestCase):
+	def test_established_rule_precedes_with_conntrack(self):
+		self.assertEqual(
+			fw.established_rule_argv(UPLINK, VM_V6),
+			[
+				"add",
+				"rule",
+				"inet",
+				"atlas",
+				"public_filter",
+				"iifname",
+				UPLINK,
+				"ip6",
+				"daddr",
+				VM_V6,
+				"ct",
+				"state",
+				"established,related",
+				"accept",
+			],  # fmt: skip
+		)
+
+	def test_port_rule_targets_proto_and_port(self):
+		self.assertEqual(
+			fw.port_rule_argv(UPLINK, VM_V6, fw.Rule("tcp", 443)),
+			[
+				"add",
+				"rule",
+				"inet",
+				"atlas",
+				"public_filter",
+				"iifname",
+				UPLINK,
+				"ip6",
+				"daddr",
+				VM_V6,
+				"tcp",
+				"dport",
+				"443",
+				"accept",
+			],  # fmt: skip
+		)
+
+	def test_drop_rule_closes_the_block(self):
+		self.assertEqual(
+			fw.drop_rule_argv(UPLINK, VM_V6),
+			[
+				"add",
+				"rule",
+				"inet",
+				"atlas",
+				"public_filter",
+				"iifname",
+				UPLINK,
+				"ip6",
+				"daddr",
+				VM_V6,
+				"drop",
+			],  # fmt: skip
+		)
+
+	def test_chain_runs_before_forward(self):
+		# priority filter - 5 is lower than forward's filter (0), so it is evaluated
+		# first and its drop pre-empts the broad per-VM accept in forward.
+		chain = fw.ensure_chain_argv()
+		self.assertIn("priority filter - 5", chain)
+		self.assertIn("public_filter", chain)
+
+
+_LISTING = f"""chain public_filter {{
+\ttype filter hook forward priority filter - 5; policy accept;
+\tiifname "eth0" ip6 daddr {VM_V6} ct state established,related accept # handle 20
+\tiifname "eth0" ip6 daddr {VM_V6} tcp dport 443 accept # handle 21
+\tiifname "eth0" ip6 daddr {VM_V6} drop # handle 22
+\tiifname "eth0" ip6 daddr 2400:6180:100:d0:0:1:5835:d004 drop # handle 30
+}}"""
+
+
+class TestHandleScrape(unittest.TestCase):
+	def test_handles_only_for_this_vm(self):
+		self.assertEqual(list(fw._handles_for(_LISTING, VM_V6)), ["20", "21", "22"])
+
+	def test_handles_skip_other_vm(self):
+		self.assertEqual(list(fw._handles_for(_LISTING, "2400:6180:100:d0:0:1:5835:d004")), ["30"])
+
+
+class TestFirewallConfigSidecar(unittest.TestCase):
+	def test_round_trips_through_env_text(self):
+		config = fw.FirewallConfig(VM_V6, (fw.Rule("tcp", 443), fw.Rule("udp", 1194)))
+		restored = fw.FirewallConfig.from_env(NetworkEnv.parse(config.to_env_text()))
+		self.assertEqual(restored, config)
+
+	def test_empty_rules_is_deny_all(self):
+		config = fw.FirewallConfig(VM_V6, ())
+		restored = fw.FirewallConfig.from_env(NetworkEnv.parse(config.to_env_text()))
+		self.assertEqual(restored.rules, ())
+		self.assertEqual(restored.virtual_machine_ipv6, VM_V6)
+
+	def test_from_env_fails_loud_on_missing_address(self):
+		with self.assertRaises(SystemExit):
+			fw.FirewallConfig.from_env(NetworkEnv.parse("RULES=tcp/443\n"))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/lib/atlas/test_firewall.py
+++ b/scripts/lib/atlas/test_firewall.py
@@ -61,7 +61,7 @@ class TestRuleArgv(unittest.TestCase):
 				"state",
 				"established,related",
 				"accept",
-			],  # fmt: skip
+			],
 		)
 
 	def test_port_rule_targets_proto_and_port(self):
@@ -82,7 +82,7 @@ class TestRuleArgv(unittest.TestCase):
 				"dport",
 				"443",
 				"accept",
-			],  # fmt: skip
+			],
 		)
 
 	def test_drop_rule_closes_the_block(self):
@@ -100,7 +100,7 @@ class TestRuleArgv(unittest.TestCase):
 				"daddr",
 				VM_V6,
 				"drop",
-			],  # fmt: skip
+			],
 		)
 
 	def test_chain_runs_before_forward(self):

--- a/scripts/lib/atlas/test_wireguard.py
+++ b/scripts/lib/atlas/test_wireguard.py
@@ -59,10 +59,12 @@ class TestCommandArgv(unittest.TestCase):
 		)
 
 	def test_accept_rule_targets_the_vm(self):
+		# `insert` (not `add`): the pair goes to the head of the forward chain, above
+		# the broad per-VM accepts that would otherwise shadow the drop below it.
 		self.assertEqual(
 			wg.accept_rule_argv(INTERFACE, VM_V6),
 			[
-				"add",
+				"insert",
 				"rule",
 				"inet",
 				"atlas",
@@ -77,10 +79,11 @@ class TestCommandArgv(unittest.TestCase):
 		)
 
 	def test_drop_rule_is_unconditional_for_the_interface(self):
-		# The isolation guarantee: anything else on this interface is dropped.
+		# The isolation guarantee: anything else on this interface is dropped. Inserted
+		# at the head so a per-VM accept for another VM cannot pre-empt it.
 		self.assertEqual(
 			wg.drop_rule_argv(INTERFACE),
-			["add", "rule", "inet", "atlas", "forward", "iifname", INTERFACE, "drop"],
+			["insert", "rule", "inet", "atlas", "forward", "iifname", INTERFACE, "drop"],
 		)
 
 

--- a/scripts/lib/atlas/test_wireguard.py
+++ b/scripts/lib/atlas/test_wireguard.py
@@ -1,0 +1,123 @@
+"""Unit tests for the host-side WireGuard tunnel plumbing (spec/19-vpn-broker.md).
+
+Run with bare `python3 -m unittest atlas.test_wireguard` from scripts/lib: no
+Frappe, no site, no host, no nft, no wg. These cover the argv construction, the
+substring/handle helpers that drive apply()/remove() without touching the host,
+and the TunnelConfig sidecar (de)serialization.
+"""
+
+import unittest
+
+from atlas import wireguard as wg
+from atlas.network_env import NetworkEnv
+
+INTERFACE = "wg-0a1b2c3d4e5"
+PORT = 51820
+KEY_PATH = "/var/lib/atlas/virtual-machines/uuid/tunnels/tun.key"
+CLIENT_PUB = "d8tf2yH/6dvuX9h98PFMN66l5dVfTlu2hakbGH6nnUo="
+CLIENT_ADDR = "fd00:a71a:5000::1"
+HOST_ADDR = "fd00:a71a:5000::/127"
+VM_V6 = "2001:db8::2"
+
+
+def _config() -> wg.TunnelConfig:
+	return wg.TunnelConfig(
+		interface=INTERFACE,
+		listen_port=PORT,
+		private_key_path=KEY_PATH,
+		client_public_key=CLIENT_PUB,
+		client_address=CLIENT_ADDR,
+		host_address=HOST_ADDR,
+		virtual_machine_ipv6=VM_V6,
+	)
+
+
+class TestCommandArgv(unittest.TestCase):
+	def test_link_argv(self):
+		self.assertEqual(wg.link_add_argv(INTERFACE), ["ip", "link", "add", INTERFACE, "type", "wireguard"])
+		self.assertEqual(wg.link_up_argv(INTERFACE), ["ip", "link", "set", INTERFACE, "up"])
+		self.assertEqual(wg.link_del_argv(INTERFACE), ["ip", "link", "del", INTERFACE])
+
+	def test_addr_add_argv_uses_host_cidr(self):
+		self.assertEqual(
+			wg.addr_add_argv(INTERFACE, HOST_ADDR),
+			["ip", "-6", "addr", "add", HOST_ADDR, "dev", INTERFACE],
+		)
+
+	def test_wg_set_interface_argv_reads_key_from_path(self):
+		# listen-port rendered as a string; the key comes from a file path, never
+		# inline on the command line.
+		self.assertEqual(
+			wg.wg_set_interface_argv(INTERFACE, PORT, KEY_PATH),
+			["wg", "set", INTERFACE, "listen-port", "51820", "private-key", KEY_PATH],
+		)
+
+	def test_wg_set_peer_argv_scopes_allowed_ips_to_128(self):
+		self.assertEqual(
+			wg.wg_set_peer_argv(INTERFACE, CLIENT_PUB, CLIENT_ADDR),
+			["wg", "set", INTERFACE, "peer", CLIENT_PUB, "allowed-ips", f"{CLIENT_ADDR}/128"],
+		)
+
+	def test_accept_rule_targets_the_vm(self):
+		self.assertEqual(
+			wg.accept_rule_argv(INTERFACE, VM_V6),
+			[
+				"add",
+				"rule",
+				"inet",
+				"atlas",
+				"forward",
+				"iifname",
+				INTERFACE,
+				"ip6",
+				"daddr",
+				VM_V6,
+				"accept",
+			],
+		)
+
+	def test_drop_rule_is_unconditional_for_the_interface(self):
+		# The isolation guarantee: anything else on this interface is dropped.
+		self.assertEqual(
+			wg.drop_rule_argv(INTERFACE),
+			["add", "rule", "inet", "atlas", "forward", "iifname", INTERFACE, "drop"],
+		)
+
+
+_LISTING = f"""chain forward {{
+\ttype filter hook forward priority filter; policy accept;
+\tiifname "{INTERFACE}" ip6 daddr {VM_V6} accept # handle 12
+\tiifname "{INTERFACE}" drop # handle 13
+\tiifname "atlas-hdeadbee" ip6 daddr 2001:db8::3 accept # handle 9
+}}"""
+
+
+class TestRulePresenceAndHandles(unittest.TestCase):
+	def test_has_accept_and_drop_match_this_interface(self):
+		self.assertTrue(wg._has_accept(_LISTING, INTERFACE, VM_V6))
+		self.assertTrue(wg._has_drop(_LISTING, INTERFACE))
+
+	def test_has_accept_false_for_other_vm_or_interface(self):
+		self.assertFalse(wg._has_accept(_LISTING, INTERFACE, "2001:db8::99"))
+		self.assertFalse(wg._has_accept(_LISTING, "wg-absent00000", VM_V6))
+
+	def test_handles_only_for_this_interface(self):
+		# 12 and 13 are this tunnel's rules; 9 belongs to another VM's veth rule.
+		self.assertEqual(list(wg._handles_for(_LISTING, INTERFACE)), ["12", "13"])
+		self.assertEqual(list(wg._handles_for(_LISTING, "atlas-hdeadbee")), ["9"])
+
+
+class TestTunnelConfigSidecar(unittest.TestCase):
+	def test_round_trips_through_env_text(self):
+		config = _config()
+		restored = wg.TunnelConfig.from_env(NetworkEnv.parse(config.to_env_text()))
+		self.assertEqual(restored, config)
+
+	def test_from_env_fails_loud_on_missing_key(self):
+		text = _config().to_env_text().replace(f"INTERFACE={INTERFACE}\n", "")
+		with self.assertRaises(SystemExit):
+			wg.TunnelConfig.from_env(NetworkEnv.parse(text))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/lib/atlas/test_wireguard.py
+++ b/scripts/lib/atlas/test_wireguard.py
@@ -79,11 +79,20 @@ class TestCommandArgv(unittest.TestCase):
 		)
 
 	def test_drop_rule_is_unconditional_for_the_interface(self):
-		# The isolation guarantee: anything else on this interface is dropped. Inserted
-		# at the head so a per-VM accept for another VM cannot pre-empt it.
+		# The transit isolation guarantee: anything else forwarded off this interface is
+		# dropped. Inserted at the head so a per-VM accept for another VM cannot pre-empt it.
 		self.assertEqual(
 			wg.drop_rule_argv(INTERFACE),
 			["insert", "rule", "inet", "atlas", "forward", "iifname", INTERFACE, "drop"],
+		)
+
+	def test_host_drop_rule_targets_the_input_chain(self):
+		# The host-local guarantee: a packet this tunnel addresses to the host itself
+		# takes the input path, which the forward drop never sees. Appended (`add`) to the
+		# dedicated input chain, which holds only per-tunnel drops, so nothing shadows it.
+		self.assertEqual(
+			wg.host_drop_rule_argv(INTERFACE),
+			["add", "rule", "inet", "atlas", "input", "iifname", INTERFACE, "drop"],
 		)
 
 
@@ -92,6 +101,11 @@ _LISTING = f"""chain forward {{
 \tiifname "{INTERFACE}" ip6 daddr {VM_V6} accept # handle 12
 \tiifname "{INTERFACE}" drop # handle 13
 \tiifname "atlas-hdeadbee" ip6 daddr 2001:db8::3 accept # handle 9
+}}"""
+
+_INPUT_LISTING = f"""chain input {{
+\ttype filter hook input priority filter; policy accept;
+\tiifname "{INTERFACE}" drop # handle 7
 }}"""
 
 
@@ -108,6 +122,11 @@ class TestRulePresenceAndHandles(unittest.TestCase):
 		# 12 and 13 are this tunnel's rules; 9 belongs to another VM's veth rule.
 		self.assertEqual(list(wg._handles_for(_LISTING, INTERFACE)), ["12", "13"])
 		self.assertEqual(list(wg._handles_for(_LISTING, "atlas-hdeadbee")), ["9"])
+
+	def test_input_drop_detected_and_handle_scraped(self):
+		# remove_tunnel scans the input chain too; apply skips re-adding a present drop.
+		self.assertTrue(wg._has_drop(_INPUT_LISTING, INTERFACE))
+		self.assertEqual(list(wg._handles_for(_INPUT_LISTING, INTERFACE)), ["7"])
 
 
 class TestTunnelConfigSidecar(unittest.TestCase):

--- a/scripts/lib/atlas/test_wireguard_e2e.py
+++ b/scripts/lib/atlas/test_wireguard_e2e.py
@@ -59,7 +59,8 @@ import unittest
 # scripts use). scripts/lib is two parents up from this file (lib/atlas/<this>).
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from atlas.wireguard import (  # noqa: E402  (after the sys.path insert)
+# Imported after the sys.path insert above so the package resolves either way.
+from atlas.wireguard import (
 	_handles_for,
 	accept_rule_argv,
 	addr_add_argv,
@@ -114,7 +115,9 @@ def _can_run() -> tuple[bool, str]:
 			return False, f"missing tool: {tool}"
 	# Load the module if it isn't already; a kernel without it can't make wg links.
 	subprocess.run(["modprobe", "wireguard"], capture_output=True)
-	probe = subprocess.run(["ip", "link", "add", "e2e-probe", "type", "wireguard"], capture_output=True, text=True)
+	probe = subprocess.run(
+		["ip", "link", "add", "e2e-probe", "type", "wireguard"], capture_output=True, text=True
+	)
 	if probe.returncode != 0:
 		return False, f"cannot create a wireguard interface: {probe.stderr.strip()}"
 	subprocess.run(["ip", "link", "del", "e2e-probe"], capture_output=True)
@@ -136,7 +139,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 		`check`, so a broken setup step fails loud with the kernel's own message."""
 		result = subprocess.run(argv, capture_output=True, text=True)
 		if check and result.returncode != 0:
-			raise RuntimeError(f"command failed ({result.returncode}): {' '.join(argv)}\n{result.stdout}{result.stderr}")
+			raise RuntimeError(
+				f"command failed ({result.returncode}): {' '.join(argv)}\n{result.stdout}{result.stderr}"
+			)
 		return result
 
 	@classmethod
@@ -193,7 +198,11 @@ class TunnelIsolationE2E(unittest.TestCase):
 			cls._ns(ns, "ip", "link", "set", "lo", "up")
 
 		# 2. veth pairs, created in the root ns then moved into place.
-		for a, b, ns_a, ns_b in ((TH, TC, HOST_NS, CLIENT_NS), (VH1, VN1, HOST_NS, VM1_NS), (VH2, VN2, HOST_NS, VM2_NS)):
+		for a, b, ns_a, ns_b in (
+			(TH, TC, HOST_NS, CLIENT_NS),
+			(VH1, VN1, HOST_NS, VM1_NS),
+			(VH2, VN2, HOST_NS, VM2_NS),
+		):
 			cls._sh(["ip", "link", "add", a, "type", "veth", "peer", "name", b])
 			cls._sh(["ip", "link", "set", a, "netns", ns_a])
 			cls._sh(["ip", "link", "set", b, "netns", ns_b])
@@ -221,7 +230,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 		# 6. The inet atlas scaffold + the broad per-VM forward accepts that
 		#    vm-network-up.py lays down (the rules the tunnel drop must beat).
 		cls._host("nft", "add table inet atlas")
-		cls._host("nft", "add chain inet atlas forward { type filter hook forward priority filter; policy accept; }")
+		cls._host(
+			"nft", "add chain inet atlas forward { type filter hook forward priority filter; policy accept; }"
+		)
 		for vh, vm_v6 in ((VH1, VM1_V6), (VH2, VM2_V6)):
 			cls._host("nft", f"add rule inet atlas forward ip6 daddr {vm_v6} oifname {vh} accept")
 			cls._host("nft", f"add rule inet atlas forward ip6 saddr {vm_v6} iifname {vh} accept")
@@ -237,7 +248,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 		cls._host(*link_up_argv(WG))
 		cls._host("nft", *drop_rule_argv(WG))
 		cls._host("nft", *accept_rule_argv(WG, VM1_V6))
-		cls._host("nft", "add chain inet atlas input { type filter hook input priority filter; policy accept; }")
+		cls._host(
+			"nft", "add chain inet atlas input { type filter hook input priority filter; policy accept; }"
+		)
 		cls._host("nft", *host_drop_rule_argv(WG))
 
 		# 8. The hostile client: AllowedIPs ::/0, routing vm1, vm2 AND the host overlay
@@ -276,7 +289,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 		with open(path, "w") as handle:
 			handle.write(priv + "\n")
 		os.chmod(path, 0o600)
-		pub = subprocess.run(["wg", "pubkey"], input=priv + "\n", capture_output=True, text=True, check=True).stdout.strip()
+		pub = subprocess.run(
+			["wg", "pubkey"], input=priv + "\n", capture_output=True, text=True, check=True
+		).stdout.strip()
 		return path, pub
 
 	@classmethod
@@ -335,7 +350,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 	def test_5_input_drop_is_what_blocks_the_host(self):
 		"""Causation: pull the input drop and the host becomes reachable; restore it
 		(with the shipping builder) and it's blocked again. Proves the fix is load-bearing."""
-		self.assertNotEqual(0, self._ping(HOST_OVERLAY), "host should be blocked with the input drop in place")
+		self.assertNotEqual(
+			0, self._ping(HOST_OVERLAY), "host should be blocked with the input drop in place"
+		)
 		listing = self._host("nft", "-a", "list", "chain", "inet", "atlas", "input").stdout
 		handles = list(_handles_for(listing, WG))
 		self.assertTrue(handles, "expected an input-chain drop for the tunnel interface")
@@ -359,7 +376,9 @@ class TunnelIsolationE2E(unittest.TestCase):
 		for handle in drop_handles:
 			self._host("nft", "delete", "rule", "inet", "atlas", "forward", "handle", handle)
 		try:
-			self.assertEqual(0, self._ping(VM2_V6), "WITHOUT the forward drop vm2 leaks via its own per-VM accept")
+			self.assertEqual(
+				0, self._ping(VM2_V6), "WITHOUT the forward drop vm2 leaks via its own per-VM accept"
+			)
 		finally:
 			self._host("nft", *drop_rule_argv(WG))  # restore the head-inserted drop
 		self.assertNotEqual(0, self._ping(VM2_V6), "re-applying the forward drop blocks vm2 again")

--- a/scripts/lib/atlas/test_wireguard_e2e.py
+++ b/scripts/lib/atlas/test_wireguard_e2e.py
@@ -1,0 +1,369 @@
+"""Live, on-the-wire isolation test for the VPN broker (spec/19-vpn-broker.md).
+
+Unlike `test_wireguard.py` (pure argv/string units, no host), this stands up a
+REAL WireGuard tunnel over real packets and proves the three isolation facts a
+tunnel client must not be able to violate:
+
+  1. it CAN reach its own VM,
+  2. it CANNOT reach a second VM (the `forward` chain's head-inserted drop), and
+  3. it CANNOT reach the host itself (the `input` chain drop — the fix this test
+     exists to validate; without it a client reaches host-local services).
+
+It reproduces the production host model with four network namespaces, all on one
+machine — no droplet, no Frappe, no cloud:
+
+      atlas-e2e-client                 atlas-e2e-host (the "server")
+    ┌────────────────┐   UDP/IPv4    ┌──────────────────────────────────────┐
+    │ wg-e2ec        │──10.77.0.0/24─│ e2e-th  10.77.0.1   (outer transport) │
+    │  overlay ::1   │               │ wg-e2e0 fd00:a71a:5000::/127 (tunnel) │
+    │  allowed ::/0  │               │   inet atlas: forward + input chains   │
+    │  (HOSTILE: routes              │ e2e-vh1 ── fd00:a71a:f00d::1  [vm1 ns] │
+    │   everything in)│               │ e2e-vh2 ── fd00:a71a:f00d::2  [vm2 ns] │
+    └────────────────┘               │ a service bound to :: (stands in for   │
+                                     │   sshd / the Frappe stack)             │
+                                     └──────────────────────────────────────┘
+
+The client's `AllowedIPs` is deliberately `::/0` — a hostile/over-broad client
+that tries to push packets to vm2 and the host through the tunnel. The guarantee
+is that the host drops them regardless of what the client attempts, so this is
+the configuration that actually exercises the host-side rules.
+
+The host tunnel is brought up with the SAME `atlas.wireguard` argv builders that
+`apply_tunnel` ships (`link_add_argv`, `wg_set_*_argv`, `drop_rule_argv`,
+`accept_rule_argv`, `host_drop_rule_argv`), in the same order — so this drives the
+real rule construction, not a paraphrase. The per-VM forward accepts that
+`vm-network-up.py` lays down are recreated too, so the test also proves the
+tunnel `drop` must be HEAD-inserted to win over them.
+
+Run it (needs root, the wireguard module, and `wg`/`nft`/`ip`):
+
+    cd scripts/lib && sudo python3 -m unittest atlas.test_wireguard_e2e -v
+
+Off-root or without the tools the whole class self-skips, so a plain
+`python3 -m unittest` (CI, the dev box) is unaffected. Everything it creates is
+namespaced under the `atlas-e2e-*` prefix and torn down in tearDownClass.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+# Make `import atlas...` work whether invoked as `-m atlas.test_wireguard_e2e`
+# from scripts/lib or as a direct path from anywhere (the sys.path dance the other
+# scripts use). scripts/lib is two parents up from this file (lib/atlas/<this>).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from atlas.wireguard import (  # noqa: E402  (after the sys.path insert)
+	_handles_for,
+	accept_rule_argv,
+	addr_add_argv,
+	drop_rule_argv,
+	host_drop_rule_argv,
+	link_add_argv,
+	link_up_argv,
+	wg_set_interface_argv,
+	wg_set_peer_argv,
+)
+
+# --- topology constants (all namespaced under atlas-e2e-*) -------------------
+HOST_NS = "atlas-e2e-host"
+VM1_NS = "atlas-e2e-vm1"
+VM2_NS = "atlas-e2e-vm2"
+CLIENT_NS = "atlas-e2e-client"
+ALL_NS = (HOST_NS, VM1_NS, VM2_NS, CLIENT_NS)
+
+WG = "wg-e2e0"  # host tunnel interface (the `wg-<id>` of production)
+WG_CLIENT = "wg-e2ec"  # client tunnel interface
+PORT = 51820
+
+# Outer transport: a v4 link client<->host (the "server public IPv4" stand-in).
+TH, TC = "e2e-th", "e2e-tc"
+TH_IP, TC_IP = "10.77.0.1", "10.77.0.2"
+ENDPOINT = f"{TH_IP}:{PORT}"
+
+# Overlay /127 — slot 0 of ATLAS_TUNNEL_SUPERNET (atlas/networking.py).
+HOST_OVERLAY_CIDR = "fd00:a71a:5000::/127"
+HOST_OVERLAY = "fd00:a71a:5000::"  # the host end the client shares the /127 with
+CLIENT_OVERLAY = "fd00:a71a:5000::1"  # the client's overlay /128
+
+# The two VMs' public /128s, each routed into its own netns like vm-network-up.py.
+VM1_V6 = "fd00:a71a:f00d::1"
+VM2_V6 = "fd00:a71a:f00d::2"
+VM_RANGE = "fd00:a71a:f00d::/64"  # the client routes this into the tunnel to try both
+OVERLAY_RANGE = "fd00:a71a:5000::/64"  # …and this, to try the host end
+
+VH1, VN1 = "e2e-vh1", "e2e-vn1"
+VH2, VN2 = "e2e-vh2", "e2e-vn2"
+LL_HOST, LL_VM = "fe80::1", "fe80::2"  # per-VM veth link-locals (VM gateway = fe80::1)
+
+SERVICE_PORT = 8080  # a host TCP service bound to :: — the "reach a host service" probe
+
+
+def _can_run() -> tuple[bool, str]:
+	"""Gate the whole class: root, the tooling, and a loadable wireguard module."""
+	if os.geteuid() != 0:
+		return False, "needs root (network namespaces + wg + nft)"
+	for tool in ("ip", "wg", "nft", "ping"):
+		if shutil.which(tool) is None:
+			return False, f"missing tool: {tool}"
+	# Load the module if it isn't already; a kernel without it can't make wg links.
+	subprocess.run(["modprobe", "wireguard"], capture_output=True)
+	probe = subprocess.run(["ip", "link", "add", "e2e-probe", "type", "wireguard"], capture_output=True, text=True)
+	if probe.returncode != 0:
+		return False, f"cannot create a wireguard interface: {probe.stderr.strip()}"
+	subprocess.run(["ip", "link", "del", "e2e-probe"], capture_output=True)
+	return True, ""
+
+
+_OK, _SKIP_REASON = _can_run()
+
+
+@unittest.skipUnless(_OK, _SKIP_REASON)
+class TunnelIsolationE2E(unittest.TestCase):
+	_keydir = ""
+	_service: "subprocess.Popen | None" = None
+
+	# --- small command helpers ------------------------------------------------
+	@staticmethod
+	def _sh(argv, check=True):
+		"""Run a command (no shell). Raise with captured output on failure when
+		`check`, so a broken setup step fails loud with the kernel's own message."""
+		result = subprocess.run(argv, capture_output=True, text=True)
+		if check and result.returncode != 0:
+			raise RuntimeError(f"command failed ({result.returncode}): {' '.join(argv)}\n{result.stdout}{result.stderr}")
+		return result
+
+	@classmethod
+	def _ns(cls, ns, *argv, check=True):
+		return cls._sh(["ip", "netns", "exec", ns, *argv], check=check)
+
+	@classmethod
+	def _host(cls, *argv, check=True):
+		return cls._ns(HOST_NS, *argv, check=check)
+
+	def _ping(self, addr):
+		"""Ping `addr` from the client over the tunnel; return the exit code (0 =
+		reachable). Two packets, 1s each — short, since a drop just times out."""
+		return subprocess.run(
+			["ip", "netns", "exec", CLIENT_NS, "ping", "-6", "-c", "2", "-W", "1", addr],
+			capture_output=True,
+			text=True,
+		).returncode
+
+	def _tcp_connect(self, addr, port):
+		"""Try a TCP connect from the client over the tunnel; return True on connect."""
+		code = (
+			"import socket,sys\n"
+			"s=socket.socket(socket.AF_INET6,socket.SOCK_STREAM); s.settimeout(2)\n"
+			f"sys.exit(0 if (lambda: (s.connect(('{addr}',{port})) or True))() else 1)\n"
+		)
+		result = subprocess.run(
+			["ip", "netns", "exec", CLIENT_NS, "python3", "-c", code], capture_output=True, text=True
+		)
+		return result.returncode == 0
+
+	# --- lifecycle ------------------------------------------------------------
+	@classmethod
+	def setUpClass(cls):
+		try:
+			cls._build()
+		except Exception:
+			cls._teardown()  # unittest does NOT call tearDownClass if setUpClass raises
+			raise
+
+	@classmethod
+	def tearDownClass(cls):
+		cls._teardown()
+
+	@classmethod
+	def _build(cls):
+		cls._keydir = tempfile.mkdtemp(prefix="atlas-e2e-keys-")
+		host_key_path, host_pub = cls._genkey("host")
+		client_key_path, client_pub = cls._genkey("client")
+
+		# 1. Namespaces. lo up in each so local sockets behave.
+		for ns in ALL_NS:
+			cls._sh(["ip", "netns", "add", ns])
+			cls._ns(ns, "ip", "link", "set", "lo", "up")
+
+		# 2. veth pairs, created in the root ns then moved into place.
+		for a, b, ns_a, ns_b in ((TH, TC, HOST_NS, CLIENT_NS), (VH1, VN1, HOST_NS, VM1_NS), (VH2, VN2, HOST_NS, VM2_NS)):
+			cls._sh(["ip", "link", "add", a, "type", "veth", "peer", "name", b])
+			cls._sh(["ip", "link", "set", a, "netns", ns_a])
+			cls._sh(["ip", "link", "set", b, "netns", ns_b])
+
+		# 3. Outer transport (client <-> host over IPv4).
+		cls._host("ip", "addr", "add", f"{TH_IP}/24", "dev", TH)
+		cls._host("ip", "link", "set", TH, "up")
+		cls._ns(CLIENT_NS, "ip", "addr", "add", f"{TC_IP}/24", "dev", TC)
+		cls._ns(CLIENT_NS, "ip", "link", "set", TC, "up")
+
+		# 4. The host forwards between the tunnel and the VM veths.
+		cls._host("sysctl", "-q", "-w", "net.ipv6.conf.all.forwarding=1")
+
+		# 5. Each VM in its own netns, with the host routing its /128 in over the
+		#    veth — the v6 half of vm-network-up.py (fe80::1 is the VM's gateway).
+		for vm_ns, vh, vn, vm_v6 in ((VM1_NS, VH1, VN1, VM1_V6), (VM2_NS, VH2, VN2, VM2_V6)):
+			cls._host("ip", "link", "set", vh, "up")
+			cls._host("ip", "-6", "addr", "add", f"{LL_HOST}/64", "dev", vh, "nodad")
+			cls._host("ip", "-6", "route", "replace", f"{vm_v6}/128", "via", LL_VM, "dev", vh)
+			cls._ns(vm_ns, "ip", "link", "set", vn, "up")
+			cls._ns(vm_ns, "ip", "-6", "addr", "add", f"{LL_VM}/64", "dev", vn, "nodad")
+			cls._ns(vm_ns, "ip", "-6", "addr", "add", f"{vm_v6}/128", "dev", vn)
+			cls._ns(vm_ns, "ip", "-6", "route", "replace", "default", "via", LL_HOST, "dev", vn)
+
+		# 6. The inet atlas scaffold + the broad per-VM forward accepts that
+		#    vm-network-up.py lays down (the rules the tunnel drop must beat).
+		cls._host("nft", "add table inet atlas")
+		cls._host("nft", "add chain inet atlas forward { type filter hook forward priority filter; policy accept; }")
+		for vh, vm_v6 in ((VH1, VM1_V6), (VH2, VM2_V6)):
+			cls._host("nft", f"add rule inet atlas forward ip6 daddr {vm_v6} oifname {vh} accept")
+			cls._host("nft", f"add rule inet atlas forward ip6 saddr {vm_v6} iifname {vh} accept")
+
+		# 7. Bring the host tunnel up with the SHIPPING argv builders, in apply_tunnel's
+		#    order: interface + key/port + the one peer + overlay address + up, then the
+		#    isolation rules — head-insert drop, head-insert accept (so the chain ends
+		#    [accept, drop, …per-VM…]), then the input chain + its host-drop.
+		cls._host(*link_add_argv(WG))
+		cls._host(*wg_set_interface_argv(WG, PORT, host_key_path))
+		cls._host(*wg_set_peer_argv(WG, client_pub, CLIENT_OVERLAY))
+		cls._host(*addr_add_argv(WG, HOST_OVERLAY_CIDR))
+		cls._host(*link_up_argv(WG))
+		cls._host("nft", *drop_rule_argv(WG))
+		cls._host("nft", *accept_rule_argv(WG, VM1_V6))
+		cls._host("nft", "add chain inet atlas input { type filter hook input priority filter; policy accept; }")
+		cls._host("nft", *host_drop_rule_argv(WG))
+
+		# 8. The hostile client: AllowedIPs ::/0, routing vm1, vm2 AND the host overlay
+		#    into the tunnel so every probe is actually attempted.
+		cls._ns(CLIENT_NS, "ip", "link", "add", WG_CLIENT, "type", "wireguard")
+		cls._ns(CLIENT_NS, "wg", "set", WG_CLIENT, "private-key", client_key_path)
+		cls._ns(CLIENT_NS, "wg", "set", WG_CLIENT, "peer", host_pub,
+			"endpoint", ENDPOINT, "allowed-ips", "::/0", "persistent-keepalive", "5")  # fmt: skip
+		cls._ns(CLIENT_NS, "ip", "-6", "addr", "add", f"{CLIENT_OVERLAY}/128", "dev", WG_CLIENT)
+		cls._ns(CLIENT_NS, "ip", "link", "set", WG_CLIENT, "up")
+		cls._ns(CLIENT_NS, "ip", "-6", "route", "add", VM_RANGE, "dev", WG_CLIENT)
+		cls._ns(CLIENT_NS, "ip", "-6", "route", "add", OVERLAY_RANGE, "dev", WG_CLIENT)
+
+		# 9. A host service bound to :: — the thing the input drop must hide.
+		server = (
+			"import socket\n"
+			"s=socket.socket(socket.AF_INET6,socket.SOCK_STREAM)\n"
+			"s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)\n"
+			f"s.bind(('::',{SERVICE_PORT})); s.listen(8)\n"
+			"while True:\n c,_=s.accept(); c.close()\n"
+		)
+		cls._service = subprocess.Popen(["ip", "netns", "exec", HOST_NS, "python3", "-c", server])
+
+		# 10. Warm the handshake: ping our own VM until it answers (or give up and let
+		#     test_1 report the failure with diagnostics).
+		for _ in range(20):
+			if cls._reach(VM1_V6) == 0:
+				break
+			time.sleep(0.5)
+		cls._dump()
+
+	@classmethod
+	def _genkey(cls, name):
+		priv = subprocess.run(["wg", "genkey"], capture_output=True, text=True, check=True).stdout.strip()
+		path = os.path.join(cls._keydir, f"{name}.key")
+		with open(path, "w") as handle:
+			handle.write(priv + "\n")
+		os.chmod(path, 0o600)
+		pub = subprocess.run(["wg", "pubkey"], input=priv + "\n", capture_output=True, text=True, check=True).stdout.strip()
+		return path, pub
+
+	@classmethod
+	def _reach(cls, addr):  # classmethod copy of _ping for use during warmup
+		return subprocess.run(
+			["ip", "netns", "exec", CLIENT_NS, "ping", "-6", "-c", "1", "-W", "1", addr], capture_output=True
+		).returncode
+
+	@classmethod
+	def _dump(cls):
+		"""Print the live host ruleset + wg state, so a pasted run shows what was
+		actually applied (handy when feeding output back)."""
+		print("\n----- host inet atlas ruleset (live) -----", file=sys.stderr)
+		print(cls._host("nft", "list", "table", "inet", "atlas", check=False).stdout, file=sys.stderr)
+		print("----- wg show (host) -----", file=sys.stderr)
+		print(cls._host("wg", "show", check=False).stdout, file=sys.stderr)
+
+	@classmethod
+	def _teardown(cls):
+		if cls._service is not None:
+			cls._service.terminate()
+			try:
+				cls._service.wait(timeout=3)
+			except subprocess.TimeoutExpired:
+				cls._service.kill()
+			cls._service = None
+		for ns in ALL_NS:
+			subprocess.run(["ip", "netns", "del", ns], capture_output=True)
+		# Defensive: reap any veth ends left in the root ns by a half-built setup.
+		for link in (TH, TC, VH1, VN1, VH2, VN2):
+			subprocess.run(["ip", "link", "del", link], capture_output=True)
+		if cls._keydir and os.path.isdir(cls._keydir):
+			shutil.rmtree(cls._keydir, ignore_errors=True)
+			cls._keydir = ""
+
+	# --- the isolation facts --------------------------------------------------
+	def test_1_reaches_own_vm(self):
+		"""The tunnel works: the client reaches the VM it was issued for."""
+		self.assertEqual(0, self._ping(VM1_V6), "client should reach its own VM over the tunnel")
+
+	def test_2_cannot_reach_other_vm(self):
+		"""The forward drop (head-inserted above vm2's own accept) blocks a second VM."""
+		self.assertNotEqual(0, self._ping(VM2_V6), "tunnel must NOT reach a second VM")
+
+	def test_3_cannot_reach_host_via_overlay_ping(self):
+		"""The input drop blocks a packet aimed at the host's own overlay address."""
+		self.assertNotEqual(0, self._ping(HOST_OVERLAY), "tunnel must NOT reach the host itself")
+
+	def test_4_cannot_reach_host_service(self):
+		"""A real host service bound to :: (sshd / the Frappe stack stand-in) is
+		unreachable over the tunnel."""
+		self.assertFalse(
+			self._tcp_connect(HOST_OVERLAY, SERVICE_PORT), "tunnel must NOT reach a host service bound to ::"
+		)
+
+	def test_5_input_drop_is_what_blocks_the_host(self):
+		"""Causation: pull the input drop and the host becomes reachable; restore it
+		(with the shipping builder) and it's blocked again. Proves the fix is load-bearing."""
+		self.assertNotEqual(0, self._ping(HOST_OVERLAY), "host should be blocked with the input drop in place")
+		listing = self._host("nft", "-a", "list", "chain", "inet", "atlas", "input").stdout
+		handles = list(_handles_for(listing, WG))
+		self.assertTrue(handles, "expected an input-chain drop for the tunnel interface")
+		for handle in handles:
+			self._host("nft", "delete", "rule", "inet", "atlas", "input", "handle", handle)
+		try:
+			self.assertEqual(
+				0, self._ping(HOST_OVERLAY), "WITHOUT the input drop the host IS reachable over the tunnel"
+			)
+		finally:
+			self._host("nft", *host_drop_rule_argv(WG))  # restore the fix
+		self.assertNotEqual(0, self._ping(HOST_OVERLAY), "re-applying the input drop blocks the host again")
+
+	def test_6_forward_drop_is_what_blocks_other_vm(self):
+		"""The transit half of the same story: pull the forward drop and vm2 leaks
+		through its own per-VM accept; restore it and vm2 is blocked again."""
+		self.assertNotEqual(0, self._ping(VM2_V6), "vm2 should be blocked with the forward drop in place")
+		listing = self._host("nft", "-a", "list", "chain", "inet", "atlas", "forward").stdout
+		drop_handles = [line.split()[-1] for line in listing.splitlines() if WG in line and "drop" in line]
+		self.assertTrue(drop_handles, "expected a forward-chain drop for the tunnel interface")
+		for handle in drop_handles:
+			self._host("nft", "delete", "rule", "inet", "atlas", "forward", "handle", handle)
+		try:
+			self.assertEqual(0, self._ping(VM2_V6), "WITHOUT the forward drop vm2 leaks via its own per-VM accept")
+		finally:
+			self._host("nft", *drop_rule_argv(WG))  # restore the head-inserted drop
+		self.assertNotEqual(0, self._ping(VM2_V6), "re-applying the forward drop blocks vm2 again")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/lib/atlas/wireguard.py
+++ b/scripts/lib/atlas/wireguard.py
@@ -1,0 +1,219 @@
+"""Host-side WireGuard tunnel plumbing for the VPN broker (spec/19-vpn-broker.md).
+
+Each tunnel terminates on the host with its **own** wg interface in the host root
+netns, listening on a per-tunnel UDP port on the server's public address. The
+interface routes a decrypted packet destined to the VM's `/128` into that VM's
+namespace over the host route `vm-network-up.py` already laid down — so reaching
+the VM needs no new routing. A point-to-point `/127` overlay on the interface
+gives the host and client ends private v6 addresses, and its connected route is
+the VM's return path to the client.
+
+**Isolation** — the one thing that makes "only your VM" true — is two rules in
+the existing `inet atlas forward` chain, keyed on the interface name (which is
+1:1 with the tunnel):
+
+    iifname <iface> ip6 daddr <vm-v6> accept
+    iifname <iface> drop
+
+WireGuard's cryptokey routing only governs what the host sends *back* to a peer;
+it does not restrict the *destination* of a decrypted inbound packet, so without
+the `drop` a client could address another VM and the host would route it. The
+`drop` closes that — anything from this interface that is not this VM is dropped.
+
+Everything here is pure string/argv construction except `apply_tunnel` /
+`remove_tunnel` / `apply_persisted_tunnels`, which touch the host. The rule and
+command *generation*, and the `TunnelConfig` (de)serialization, are unit-testable
+with bare `python3 -m unittest` (no host), like `reserved_ip_nat`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from atlas._run import run, run_ok
+from atlas.network_env import NetworkEnv
+
+TABLE = ("inet", "atlas")
+FORWARD = "forward"
+
+
+@dataclass(frozen=True)
+class TunnelConfig:
+	"""One tunnel's durable host state — everything `apply_tunnel` needs, and what
+	a `<tunnel>.env` sidecar under the VM's `tunnels/` directory persists so a cold
+	boot re-creates the tunnel exactly (the reserved-IP `network.env` pattern).
+
+	The private key lives in its own 0600 file (`private_key_path`), not inline, so
+	the metadata sidecar can stay 0644 and `wg set` reads the secret from a path."""
+
+	interface: str
+	listen_port: int
+	private_key_path: str
+	client_public_key: str
+	client_address: str  # bare overlay v6 the client carries; the peer's allowed-ip
+	host_address: str  # the host end's /127 overlay CIDR (its connected route is the return path)
+	virtual_machine_ipv6: str  # the VM's /128 (bare) — the one destination the tunnel may reach
+
+	@classmethod
+	def from_env(cls, env: NetworkEnv) -> "TunnelConfig":
+		"""Build from a parsed sidecar, failing loud (via require) on any missing key."""
+		return cls(
+			interface=env.require("INTERFACE"),
+			listen_port=env.require_int("LISTEN_PORT"),
+			private_key_path=env.require("PRIVATE_KEY_FILE"),
+			client_public_key=env.require("CLIENT_PUBLIC_KEY"),
+			client_address=env.require("CLIENT_ADDRESS"),
+			host_address=env.require("HOST_ADDRESS"),
+			virtual_machine_ipv6=env.require("VIRTUAL_MACHINE_IPV6"),
+		)
+
+	def to_env_text(self) -> str:
+		"""Render the KEY=value sidecar (the inverse of from_env). Bare values, one
+		per line, like provision's network.env."""
+		return (
+			"\n".join(
+				[
+					f"INTERFACE={self.interface}",
+					f"LISTEN_PORT={self.listen_port}",
+					f"PRIVATE_KEY_FILE={self.private_key_path}",
+					f"CLIENT_PUBLIC_KEY={self.client_public_key}",
+					f"CLIENT_ADDRESS={self.client_address}",
+					f"HOST_ADDRESS={self.host_address}",
+					f"VIRTUAL_MACHINE_IPV6={self.virtual_machine_ipv6}",
+				]
+			)
+			+ "\n"
+		)
+
+
+def link_add_argv(interface: str) -> list[str]:
+	"""Create the WireGuard interface in the current (host root) netns."""
+	return ["ip", "link", "add", interface, "type", "wireguard"]
+
+
+def link_up_argv(interface: str) -> list[str]:
+	return ["ip", "link", "set", interface, "up"]
+
+
+def link_del_argv(interface: str) -> list[str]:
+	"""Remove the interface — takes its addresses and connected routes with it."""
+	return ["ip", "link", "del", interface]
+
+
+def addr_add_argv(interface: str, host_cidr: str) -> list[str]:
+	"""Assign the host end's /127 overlay address. The kernel's connected route for
+	the /127 is the VM's return path to the client end (the upper address), so no
+	explicit per-client route is needed."""
+	return ["ip", "-6", "addr", "add", host_cidr, "dev", interface]
+
+
+def wg_set_interface_argv(interface: str, listen_port: int, private_key_path: str) -> list[str]:
+	"""Set the listen port and private key (read from a 0600 file, never inline)."""
+	return ["wg", "set", interface, "listen-port", str(listen_port), "private-key", private_key_path]
+
+
+def wg_set_peer_argv(interface: str, client_public_key: str, client_address: str) -> list[str]:
+	"""Add the one client peer, allowed-ips scoped to its overlay /128. Cryptokey
+	routing then accepts inbound only when its inner source is this address, and
+	sends return traffic only to this peer."""
+	return ["wg", "set", interface, "peer", client_public_key, "allowed-ips", f"{client_address}/128"]
+
+
+def accept_rule_argv(interface: str, virtual_machine_ipv6: str) -> list[str]:
+	"""forward: accept decrypted tunnel traffic destined to the VM. Appended before
+	the drop so the VM is reachable; everything else from the interface falls to
+	the drop."""
+	return [
+		"add", "rule", "inet", "atlas", FORWARD,
+		"iifname", interface, "ip6", "daddr", virtual_machine_ipv6, "accept",
+	]  # fmt: skip
+
+
+def drop_rule_argv(interface: str) -> list[str]:
+	"""forward: drop anything else arriving on this tunnel's interface — another
+	VM, the host, the internet. This is the isolation guarantee; without it a
+	client could address a VM that is not its own and the host would route it."""
+	return ["add", "rule", "inet", "atlas", FORWARD, "iifname", interface, "drop"]
+
+
+def apply_tunnel(config: TunnelConfig) -> None:
+	"""Idempotently bring the tunnel up: create the interface, set its key/port and
+	the one peer, assign the host overlay address, raise it, and install the two
+	isolation rules. Re-running (cold boot, reconcile, double apply) is a no-op —
+	the same self-healing contract as vm-network-up.py / reserved_ip_nat."""
+	if not run_ok("sudo", "ip", "link", "show", config.interface):
+		run("sudo", *link_add_argv(config.interface))
+	run("sudo", *wg_set_interface_argv(config.interface, config.listen_port, config.private_key_path))
+	run("sudo", *wg_set_peer_argv(config.interface, config.client_public_key, config.client_address))
+	addresses = run("sudo", "ip", "-6", "addr", "show", "dev", config.interface, check=False)
+	if config.host_address not in addresses:
+		run("sudo", *addr_add_argv(config.interface, config.host_address))
+	run("sudo", *link_up_argv(config.interface))
+
+	# The forward chain is created by the vm-network-up scaffold (which runs first,
+	# as ExecStartPre); guard defensively so a tunnel apply is self-sufficient.
+	if not run_ok("sudo", "nft", "list", "chain", *TABLE, FORWARD):
+		run(
+			"sudo",
+			"nft",
+			"add chain inet atlas forward { type filter hook forward priority filter; policy accept; }",
+		)
+	forward = run("sudo", "nft", "list", "chain", *TABLE, FORWARD)
+	# Add accept BEFORE drop so the pair lands in the right order on a clean chain.
+	if not _has_accept(forward, config.interface, config.virtual_machine_ipv6):
+		run("sudo", "nft", *accept_rule_argv(config.interface, config.virtual_machine_ipv6))
+	if not _has_drop(forward, config.interface):
+		run("sudo", "nft", *drop_rule_argv(config.interface))
+
+
+def remove_tunnel(interface: str) -> None:
+	"""Tear the tunnel down, best-effort and idempotent: delete the two forward
+	rules by handle (keyed on the interface name), then delete the interface (which
+	takes its addresses and connected route with it). A missing rule or interface is
+	not an error — a revoke may run after the VM is already gone, symmetric with
+	vm-network-down.py."""
+	listing = run("sudo", "nft", "-a", "list", "chain", *TABLE, FORWARD, check=False)
+	for handle in _handles_for(listing, interface):
+		run("sudo", "nft", "delete", "rule", "inet", "atlas", FORWARD, "handle", handle, check=False)
+	run("sudo", *link_del_argv(interface), check=False)
+
+
+def apply_persisted_tunnels(tunnels_directory: str) -> None:
+	"""Re-apply every persisted tunnel for a VM at cold boot. Called by
+	vm-network-up.py AFTER the netns/veth and the VM's `/128` host route exist, so
+	each tunnel comes up functional. No directory (a VM with no tunnels) is a no-op.
+
+	Fail-loud per tunnel (apply_tunnel raises): a tunnel that cannot be re-created
+	is a real fault the operator retries by re-running, like the rest of the unit's
+	ExecStartPre."""
+	if not os.path.isdir(tunnels_directory):
+		return
+	for entry in sorted(os.listdir(tunnels_directory)):
+		if not entry.endswith(".env"):
+			continue
+		path = os.path.join(tunnels_directory, entry)
+		# nosemgrep: frappe-security-file-traversal -- host script; reads a per-VM tunnel sidecar path, not untrusted web input
+		with open(path) as handle:
+			config = TunnelConfig.from_env(NetworkEnv.parse(handle.read()))
+		apply_tunnel(config)
+
+
+def _has_accept(listing: str, interface: str, virtual_machine_ipv6: str) -> bool:
+	return any(
+		interface in line and virtual_machine_ipv6 in line and "accept" in line
+		for line in listing.splitlines()
+	)
+
+
+def _has_drop(listing: str, interface: str) -> bool:
+	return any(interface in line and "drop" in line for line in listing.splitlines())
+
+
+def _handles_for(listing: str, interface: str):
+	"""Trailing handle number of every forward rule mentioning this interface.
+	`nft -a` prints `… # handle N`; the handle is the last token. Mirrors the
+	handle-scrape in vm-network-down.py / reserved_ip_nat."""
+	for line in listing.splitlines():
+		if interface in line and "handle" in line:
+			yield line.split()[-1]

--- a/scripts/lib/atlas/wireguard.py
+++ b/scripts/lib/atlas/wireguard.py
@@ -20,6 +20,14 @@ it does not restrict the *destination* of a decrypted inbound packet, so without
 the `drop` a client could address another VM and the host would route it. The
 `drop` closes that — anything from this interface that is not this VM is dropped.
 
+These two rules must sit at the **head** of the forward chain, above the broad
+per-VM forward-accept rules vm-network-up.py lays down (`ip6 daddr <vm> oifname
+<veth> accept`). Those rules do not constrain the input interface, so an appended
+tunnel `drop` is shadowed: a packet from this tunnel to *another* VM matches that
+VM's accept first (accept is terminal) and is forwarded — the exact leak the drop
+exists to stop. So we `insert` the pair (drop first, then accept, leaving
+[accept, drop, …per-VM…]) instead of appending it.
+
 Everything here is pure string/argv construction except `apply_tunnel` /
 `remove_tunnel` / `apply_persisted_tunnels`, which touch the host. The rule and
 command *generation*, and the `TunnelConfig` (de)serialization, are unit-testable
@@ -121,11 +129,11 @@ def wg_set_peer_argv(interface: str, client_public_key: str, client_address: str
 
 
 def accept_rule_argv(interface: str, virtual_machine_ipv6: str) -> list[str]:
-	"""forward: accept decrypted tunnel traffic destined to the VM. Appended before
-	the drop so the VM is reachable; everything else from the interface falls to
-	the drop."""
+	"""forward: accept decrypted tunnel traffic destined to the VM. Inserted at the
+	head AFTER the drop, so it ends up just above it ([accept, drop, …]); the VM is
+	reachable while everything else from the interface falls to the drop."""
 	return [
-		"add", "rule", "inet", "atlas", FORWARD,
+		"insert", "rule", "inet", "atlas", FORWARD,
 		"iifname", interface, "ip6", "daddr", virtual_machine_ipv6, "accept",
 	]  # fmt: skip
 
@@ -133,8 +141,9 @@ def accept_rule_argv(interface: str, virtual_machine_ipv6: str) -> list[str]:
 def drop_rule_argv(interface: str) -> list[str]:
 	"""forward: drop anything else arriving on this tunnel's interface — another
 	VM, the host, the internet. This is the isolation guarantee; without it a
-	client could address a VM that is not its own and the host would route it."""
-	return ["add", "rule", "inet", "atlas", FORWARD, "iifname", interface, "drop"]
+	client could address a VM that is not its own and the host would route it.
+	Inserted at the head (above the per-VM accepts that would otherwise shadow it)."""
+	return ["insert", "rule", "inet", "atlas", FORWARD, "iifname", interface, "drop"]
 
 
 def apply_tunnel(config: TunnelConfig) -> None:
@@ -160,11 +169,13 @@ def apply_tunnel(config: TunnelConfig) -> None:
 			"add chain inet atlas forward { type filter hook forward priority filter; policy accept; }",
 		)
 	forward = run("sudo", "nft", "list", "chain", *TABLE, FORWARD)
-	# Add accept BEFORE drop so the pair lands in the right order on a clean chain.
-	if not _has_accept(forward, config.interface, config.virtual_machine_ipv6):
-		run("sudo", "nft", *accept_rule_argv(config.interface, config.virtual_machine_ipv6))
+	# Insert at the head so the pair precedes the broad per-VM accepts. Each insert
+	# goes to the top, so insert drop FIRST and accept SECOND to leave the chain as
+	# [accept, drop, …per-VM…] — accept reachable, everything else dropped.
 	if not _has_drop(forward, config.interface):
 		run("sudo", "nft", *drop_rule_argv(config.interface))
+	if not _has_accept(forward, config.interface, config.virtual_machine_ipv6):
+		run("sudo", "nft", *accept_rule_argv(config.interface, config.virtual_machine_ipv6))
 
 
 def remove_tunnel(interface: str) -> None:

--- a/scripts/lib/atlas/wireguard.py
+++ b/scripts/lib/atlas/wireguard.py
@@ -8,9 +8,12 @@ the VM needs no new routing. A point-to-point `/127` overlay on the interface
 gives the host and client ends private v6 addresses, and its connected route is
 the VM's return path to the client.
 
-**Isolation** — the one thing that makes "only your VM" true — is two rules in
-the existing `inet atlas forward` chain, keyed on the interface name (which is
-1:1 with the tunnel):
+**Isolation** — the one thing that makes "only your VM" true — is interface-keyed
+nft rules (the interface name is 1:1 with the tunnel), split across two hooks
+because the kernel routes *transit* and *host-local* traffic on different paths.
+
+*Transit* — a decrypted packet the host would route onward — is the `forward`
+chain. Two rules in the existing `inet atlas forward`:
 
     iifname <iface> ip6 daddr <vm-v6> accept
     iifname <iface> drop
@@ -18,15 +21,28 @@ the existing `inet atlas forward` chain, keyed on the interface name (which is
 WireGuard's cryptokey routing only governs what the host sends *back* to a peer;
 it does not restrict the *destination* of a decrypted inbound packet, so without
 the `drop` a client could address another VM and the host would route it. The
-`drop` closes that — anything from this interface that is not this VM is dropped.
+`drop` closes that — anything from this interface bound for another VM or the
+internet is dropped. These two rules must sit at the **head** of the forward
+chain, above the broad per-VM forward-accept rules vm-network-up.py lays down
+(`ip6 daddr <vm> oifname <veth> accept`). Those rules do not constrain the input
+interface, so an appended tunnel `drop` is shadowed: a packet from this tunnel to
+*another* VM matches that VM's accept first (accept is terminal) and is forwarded
+— the exact leak the drop exists to stop. So we `insert` the pair (drop first,
+then accept, leaving [accept, drop, …per-VM…]) instead of appending it.
 
-These two rules must sit at the **head** of the forward chain, above the broad
-per-VM forward-accept rules vm-network-up.py lays down (`ip6 daddr <vm> oifname
-<veth> accept`). Those rules do not constrain the input interface, so an appended
-tunnel `drop` is shadowed: a packet from this tunnel to *another* VM matches that
-VM's accept first (accept is terminal) and is forwarded — the exact leak the drop
-exists to stop. So we `insert` the pair (drop first, then accept, leaving
-[accept, drop, …per-VM…]) instead of appending it.
+*Host-local* — a packet a client addresses to the **host itself** — never reaches
+the forward hook: local delivery is the `input` path. So the forward `drop` does
+NOT cover the host, and a client could craft `dst=<overlay host end>` (it shares
+the /127) or any host address with a service bound to `::` (sshd, the Frappe
+stack) and reach it. A third, symmetric rule in a dedicated `inet atlas input`
+chain (`policy accept`, so non-tunnel host ingress — including the tunnel's OWN
+outer UDP listener, which lands on the physical uplink, not `wg-…` — is untouched)
+closes that:
+
+    iifname <iface> drop
+
+Nothing legitimately terminates on the host over the tunnel (the host overlay end
+exists only to route the VM's return traffic), so a blanket input drop is safe.
 
 Everything here is pure string/argv construction except `apply_tunnel` /
 `remove_tunnel` / `apply_persisted_tunnels`, which touch the host. The rule and
@@ -44,6 +60,7 @@ from atlas.network_env import NetworkEnv
 
 TABLE = ("inet", "atlas")
 FORWARD = "forward"
+INPUT = "input"
 
 
 @dataclass(frozen=True)
@@ -139,18 +156,31 @@ def accept_rule_argv(interface: str, virtual_machine_ipv6: str) -> list[str]:
 
 
 def drop_rule_argv(interface: str) -> list[str]:
-	"""forward: drop anything else arriving on this tunnel's interface — another
-	VM, the host, the internet. This is the isolation guarantee; without it a
-	client could address a VM that is not its own and the host would route it.
-	Inserted at the head (above the per-VM accepts that would otherwise shadow it)."""
+	"""forward: drop anything else *forwarded* off this tunnel's interface — another
+	VM, the internet. This is the transit isolation guarantee; without it a client
+	could address a VM that is not its own and the host would route it. Inserted at
+	the head (above the per-VM accepts that would otherwise shadow it). The host
+	*itself* is a different path — see host_drop_rule_argv."""
 	return ["insert", "rule", "inet", "atlas", FORWARD, "iifname", interface, "drop"]
+
+
+def host_drop_rule_argv(interface: str) -> list[str]:
+	"""input: drop a decrypted packet this tunnel addresses to the HOST itself. The
+	forward chain only sees *transit*; a packet bound for a host-local service — the
+	overlay /127's host end (which the client shares), or any host address bound to
+	`::` (sshd, the Frappe stack) — is delivered locally on the input path, which
+	forward never sees, so without this a client could reach the host over the tunnel.
+	Appended, not inserted: the input chain holds only these per-tunnel drops, so
+	nothing shadows it."""
+	return ["add", "rule", "inet", "atlas", INPUT, "iifname", interface, "drop"]
 
 
 def apply_tunnel(config: TunnelConfig) -> None:
 	"""Idempotently bring the tunnel up: create the interface, set its key/port and
-	the one peer, assign the host overlay address, raise it, and install the two
-	isolation rules. Re-running (cold boot, reconcile, double apply) is a no-op —
-	the same self-healing contract as vm-network-up.py / reserved_ip_nat."""
+	the one peer, assign the host overlay address, raise it, and install the isolation
+	rules (the forward accept/drop pair plus the input host-drop). Re-running (cold
+	boot, reconcile, double apply) is a no-op — the same self-healing contract as
+	vm-network-up.py / reserved_ip_nat."""
 	if not run_ok("sudo", "ip", "link", "show", config.interface):
 		run("sudo", *link_add_argv(config.interface))
 	run("sudo", *wg_set_interface_argv(config.interface, config.listen_port, config.private_key_path))
@@ -177,16 +207,32 @@ def apply_tunnel(config: TunnelConfig) -> None:
 	if not _has_accept(forward, config.interface, config.virtual_machine_ipv6):
 		run("sudo", "nft", *accept_rule_argv(config.interface, config.virtual_machine_ipv6))
 
+	# Host-local isolation: the forward rules above govern only transit. A packet
+	# this tunnel addresses to the host itself is delivered locally on the input
+	# path, which forward never sees. A dedicated input chain (policy accept, so
+	# ordinary host ingress is untouched; created defensively like forward above)
+	# carries one drop for this interface — see host_drop_rule_argv.
+	if not run_ok("sudo", "nft", "list", "chain", *TABLE, INPUT):
+		run(
+			"sudo",
+			"nft",
+			"add chain inet atlas input { type filter hook input priority filter; policy accept; }",
+		)
+	host_input = run("sudo", "nft", "list", "chain", *TABLE, INPUT)
+	if not _has_drop(host_input, config.interface):
+		run("sudo", "nft", *host_drop_rule_argv(config.interface))
+
 
 def remove_tunnel(interface: str) -> None:
-	"""Tear the tunnel down, best-effort and idempotent: delete the two forward
-	rules by handle (keyed on the interface name), then delete the interface (which
-	takes its addresses and connected route with it). A missing rule or interface is
-	not an error — a revoke may run after the VM is already gone, symmetric with
-	vm-network-down.py."""
-	listing = run("sudo", "nft", "-a", "list", "chain", *TABLE, FORWARD, check=False)
-	for handle in _handles_for(listing, interface):
-		run("sudo", "nft", "delete", "rule", "inet", "atlas", FORWARD, "handle", handle, check=False)
+	"""Tear the tunnel down, best-effort and idempotent: delete this interface's rules
+	by handle in BOTH the forward chain (transit) and the input chain (host-local),
+	then delete the interface (which takes its addresses and connected route with it).
+	A missing rule, chain, or interface is not an error — a revoke may run after the VM
+	is already gone, symmetric with vm-network-down.py."""
+	for chain in (FORWARD, INPUT):
+		listing = run("sudo", "nft", "-a", "list", "chain", *TABLE, chain, check=False)
+		for handle in _handles_for(listing, interface):
+			run("sudo", "nft", "delete", "rule", "inet", "atlas", chain, "handle", handle, check=False)
 	run("sudo", *link_del_argv(interface), check=False)
 
 

--- a/scripts/vm-network-down.py
+++ b/scripts/vm-network-down.py
@@ -15,6 +15,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from atlas._run import run
+from atlas.firewall import remove_firewall
 from atlas.network_env import default_route_device, read_network_env_optional
 from atlas.paths import VirtualMachinePaths
 from atlas.reserved_ip_nat import remove_reserved_ip_nat
@@ -100,6 +101,14 @@ def main() -> None:
 				handles.append(line.split()[-1])
 		for handle in handles:
 			run("sudo", "nft", "delete", "rule", "inet", "atlas", "forward", "handle", handle, check=False)
+
+		# The public-ingress firewall block lives in its own higher-priority chain
+		# (spec/20-firewall.md), in the host root netns — the namespace delete above
+		# does not touch it. Remove it too, so a future VM that reuses this IPv6 is not
+		# silently blocked by a stale drop. The firewall.env sidecar (in the VM dir) is
+		# swept by terminate's rm -rf; on a plain stop it persists and vm-network-up
+		# re-applies the block on the next start. Best-effort, idempotent.
+		remove_firewall(virtual_machine_ipv6)
 
 
 if __name__ == "__main__":

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -35,6 +35,7 @@ from atlas.reserved_ip_nat import (
 	apply_routed_reserved_ip_nat,
 	discover_reserved_ip_anchor,
 )
+from atlas.wireguard import apply_persisted_tunnels
 
 
 def main() -> None:
@@ -361,6 +362,12 @@ def main() -> None:
 			apply_reserved_ip_nat(anchor, ipv4_guest_address, host_veth)
 		else:
 			apply_routed_reserved_ip_nat(reserved_ipv4, ipv4_guest_address, host_veth)
+
+	# 9. Re-apply any persisted WireGuard tunnels (spec/19-vpn-broker.md). Each
+	#    terminates in this (host root) netns and routes to the VM's /128 via the
+	#    host veth, so it comes up functional only now that route exists. A VM with
+	#    no tunnels has no tunnels/ dir — a no-op.
+	apply_persisted_tunnels(VirtualMachinePaths(uuid).tunnels_directory)
 
 
 if __name__ == "__main__":

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -28,6 +28,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from atlas._run import run, run_ok
+from atlas.firewall import apply_persisted_firewall
 from atlas.network_env import default_route_device, read_network_env
 from atlas.paths import VirtualMachinePaths
 from atlas.reserved_ip_nat import (
@@ -35,7 +36,6 @@ from atlas.reserved_ip_nat import (
 	apply_routed_reserved_ip_nat,
 	discover_reserved_ip_anchor,
 )
-from atlas.firewall import apply_persisted_firewall
 from atlas.wireguard import apply_persisted_tunnels
 
 

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -35,6 +35,7 @@ from atlas.reserved_ip_nat import (
 	apply_routed_reserved_ip_nat,
 	discover_reserved_ip_anchor,
 )
+from atlas.firewall import apply_persisted_firewall
 from atlas.wireguard import apply_persisted_tunnels
 
 
@@ -368,6 +369,12 @@ def main() -> None:
 	#    host veth, so it comes up functional only now that route exists. A VM with
 	#    no tunnels has no tunnels/ dir — a no-op.
 	apply_persisted_tunnels(VirtualMachinePaths(uuid).tunnels_directory)
+
+	# 10. Re-apply this VM's public-ingress firewall (spec/20-firewall.md), if one is
+	#     attached. Done last, after the VM's /128 route exists, so the public_filter
+	#     drop and the broad forward accept are both in place. No firewall.env (no
+	#     firewall attached) is a no-op — the VM stays fully public.
+	apply_persisted_firewall(VirtualMachinePaths(uuid).firewall_env)
 
 
 if __name__ == "__main__":

--- a/scripts/vm-tunnel.py
+++ b/scripts/vm-tunnel.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Bring a WireGuard tunnel up or down on the host for one VM, with no reboot — the
+# live half of the VPN broker (spec/19-vpn-broker.md), the tunnel analog of
+# vm-reserved-ip.py.
+#
+# up:   mint the host keypair (idempotent — an existing key is reused, so a
+#       re-apply never rotates the key out from under a client that already holds
+#       the config), write the <tunnel>.env + <tunnel>.key sidecars under the VM's
+#       tunnels/ dir (durable; re-applied at cold boot by vm-network-up.py), apply
+#       the live wg interface + the nft isolation rules, and emit the host PUBLIC
+#       key (the private half never leaves the host).
+# down: remove the live wg interface + its nft rules and delete the sidecars.
+#
+# A Task (typed --flags), dispatched by VPN Tunnel.request()/revoke(). Imports the
+# per-task staged atlas package under /tmp/atlas/lib, like the other Task scripts.
+
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import install_directory, install_file, run, run_input
+from atlas._task import TaskInputs, TaskResult
+from atlas.network_env import read_network_env
+from atlas.paths import VirtualMachinePaths
+from atlas.wireguard import TunnelConfig, apply_tunnel, remove_tunnel
+
+
+@dataclass(frozen=True)
+class TunnelInputs(TaskInputs):
+	"""Bring a VM's WireGuard tunnel up or down on the host."""
+
+	command: typing.ClassVar[str] = "vm-tunnel"
+	tunnel_name: str  # the VPN Tunnel UUID — names the .env / .key sidecars
+	virtual_machine_name: str  # the VM UUID — locates the VM dir + network.env
+	interface: str  # wg-<id>, derived controller-side from tunnel_name
+	action: str = "up"  # "up" | "down"
+	# up-only parameters (ignored on down, which works from the interface name):
+	listen_port: int = 0
+	client_public_key: str = ""
+	client_address: str = ""  # the client's overlay /128 (bare address)
+	host_address: str = ""  # the host end's /127 overlay CIDR
+
+
+@dataclass(frozen=True)
+class TunnelResult(TaskResult):
+	server_public_key: str  # empty on down
+
+
+def main() -> None:
+	inputs = TunnelInputs.from_args()
+	if inputs.action not in ("up", "down"):
+		sys.exit(f"action must be up|down, got {inputs.action!r}")
+
+	paths = VirtualMachinePaths(inputs.virtual_machine_name)
+	key_path = paths.tunnel_key(inputs.tunnel_name)
+	env_path = paths.tunnel_env(inputs.tunnel_name)
+
+	if inputs.action == "down":
+		remove_tunnel(inputs.interface)
+		# Best-effort — a revoke may run after terminate already rm -rf'd the dir.
+		for path in (env_path, key_path):
+			run("sudo", "rm", "-f", path, check=False)
+		print(f"Tunnel {inputs.interface} down on {inputs.virtual_machine_name}.")
+		TunnelResult(server_public_key="").emit()
+		return
+
+	virtual_machine_ipv6 = read_network_env(paths.network_env).require("VIRTUAL_MACHINE_IPV6")
+	install_directory(paths.tunnels_directory, mode="0700")
+	public_key = _ensure_host_key(key_path)
+	config = TunnelConfig(
+		interface=inputs.interface,
+		listen_port=inputs.listen_port,
+		private_key_path=key_path,
+		client_public_key=inputs.client_public_key,
+		client_address=inputs.client_address,
+		host_address=inputs.host_address,
+		virtual_machine_ipv6=virtual_machine_ipv6,
+	)
+	# The .env sidecar (0644) carries the durable metadata; the .key (0600) holds
+	# the private key. vm-network-up.py re-applies both at cold boot.
+	install_file(config.to_env_text(), env_path, mode="0644")
+	apply_tunnel(config)
+	print(f"Tunnel {inputs.interface} up on {inputs.virtual_machine_name} (port {inputs.listen_port}).")
+	TunnelResult(server_public_key=public_key).emit()
+
+
+def _ensure_host_key(key_path: str) -> str:
+	"""Return the tunnel's host PUBLIC key, minting the private key on first use.
+	Idempotent: an existing key file is reused so a re-apply (boot reconcile, retry)
+	never rotates the key — the client's config stays valid. `wg pubkey` derives the
+	public half from the private; neither needs root."""
+	if os.path.isfile(key_path):
+		# nosemgrep: frappe-security-file-traversal -- host script; reads a per-tunnel key path derived from the tunnel name, not untrusted web input
+		with open(key_path) as handle:
+			private_key = handle.read().strip()
+	else:
+		private_key = run("wg", "genkey").strip()
+		install_file(private_key + "\n", key_path, mode="0600")
+	return run_input("wg", "pubkey", stdin=private_key + "\n").strip()
+
+
+if __name__ == "__main__":
+	main()

--- a/spec/19-vpn-broker.md
+++ b/spec/19-vpn-broker.md
@@ -149,23 +149,40 @@ Per-server, sequential, in the spirit of `allocate_ipv6` / `derive_ipv4_link`
 The **client generates its own keypair and sends only its public key.** The
 client's private key never touches Atlas.
 
-- `request_tunnel(virtual_machine, client_public_key)` mints the **host-side**
-  keypair in the controller (X25519 via `cryptography`, WireGuard base64 — see
-  [`atlas/atlas/wireguard.py`](../atlas/atlas/wireguard.py)). The host private key
-  is stored encrypted on the `VPN Tunnel` row (Frappe is the source of truth) and
-  pushed to the host; it is **never** placed in the guest.
+The **host generates its own keypair, on the host**, exactly as Atlas already
+treats a guest's SSH **host** keys — host-resident crypto identity, not mirrored
+into the Frappe DB. This is deliberate: `Task.variables` is a plaintext, audited,
+immutable field a VM's owner can read for their own VM (`permissions.py`), so
+routing a private key through a Task — the only channel `run_task` has — would
+leave a private key in an audit row and on the host process table. Generating on
+the host keeps the private key in **one** place: a `0600` file under the VM dir,
+which `wg set` reads by path (never the command line).
+
+- [`vm-tunnel.py`](../scripts/vm-tunnel.py)`--action up` mints the host keypair
+  the first time (idempotent — a re-apply reuses the existing `<tunnel>.key`, so
+  the client's config never goes stale) and returns the **public** key.
+- `request_tunnel(virtual_machine, client_public_key)` stores that returned
+  `server_public_key` on the `VPN Tunnel` row (the public identity) and validates
+  the client's submitted key with
+  [`atlas/atlas/wireguard.py`](../atlas/atlas/wireguard.py)`.is_valid_public_key`
+  before dispatching, so a malformed key fails in the controller, not on the host.
 - The response carries the host `server_public_key`, the `endpoint`
   (`<server-v4>:<port>`), `allowed_ips` (`<vm-v6>/128`), the assigned
   `client_address` (`<client-overlay-v6>/128`), and a copy-paste client config
   template + setup instructions ([Client setup](#client-setup)).
+
+Principle #2 (Frappe is the source of truth) holds the same way it does for SSH
+host keys: the row records the public identity; the private material is
+host-resident and re-issued (a new tunnel) if the host is lost.
 
 ## Durability
 
 A tunnel is durable host state, reconstructible from the Frappe row, exactly like
 the rest of a VM's host networking:
 
-- The host config is persisted under the VM directory
-  (`/var/lib/atlas/virtual-machines/<uuid>/tunnels/<tunnel>.conf`).
+- The host config is persisted under the VM directory: a `<tunnel>.env` metadata
+  sidecar (`0644`) and a `<tunnel>.key` private-key file (`0600`) under
+  `/var/lib/atlas/virtual-machines/<uuid>/tunnels/`.
 - [`vm-network-up.py`](../scripts/vm-network-up.py) re-applies every persisted
   tunnel **after** it brings up the netns/veth, so tunnels survive a cold boot;
   [`vm-network-down.py`](../scripts/vm-network-down.py) tears them down with the
@@ -188,8 +205,8 @@ One row per tunnel, modelled on [`Reserved IP`](./02-doctypes.md#reserved-ip):
 | `status` | `Pending` → `Active` → `Revoked` |
 | `transport` | `public-ipv4` today; the seam for `private-vpc` later (see below) |
 | `client_public_key` | the client's WireGuard public key (immutable) |
-| `server_public_key` | host-side public key (returned to the client) |
-| `server_private_key` | host-side private key (encrypted; pushed to the host) |
+| `server_public_key` | host-side public key, returned by the host `up` Task and stored here (the private half stays host-only) |
+| `slot_index` | the per-server slot (drives `listen_port` + overlay); immutable |
 | `listen_port` | the allocated UDP port |
 | `interface_name` | `wg-<id>` |
 | `client_address` | `<client-overlay-v6>/128` assigned to the client |
@@ -199,9 +216,10 @@ One row per tunnel, modelled on [`Reserved IP`](./02-doctypes.md#reserved-ip):
 Controller methods, audited as Tasks:
 
 - `request_tunnel(virtual_machine, client_public_key)` (module-level,
-  whitelisted): allocate the slot, mint host keys, insert the row, run
-  `vm-tunnel.py --action up`, return the client config. Owner-scoped, and
-  Central-callable as the service user (the [16-central.md](./16-central.md)
+  whitelisted): validate the client key, allocate the slot, insert the row, run
+  `vm-tunnel.py --action up` (which mints the host key and returns its public
+  half), store `server_public_key`, and return the client config. Owner-scoped,
+  and Central-callable as the service user (the [16-central.md](./16-central.md)
   pattern, like `provision.create_vm`).
 - `revoke()`: run `vm-tunnel.py --action down`, set `Revoked`. Skips the host
   Task for a Terminated VM whose networking is already gone (the

--- a/spec/19-vpn-broker.md
+++ b/spec/19-vpn-broker.md
@@ -25,9 +25,9 @@ is reachable from the v6 internet, but:
   v6-only VM.
 - **Public exposure is not private access.** Reaching a port over the tunnel is
   independent of whether that port is exposed to the public internet. The owner
-  gets every port their VM actually serves on its address — including ones a
-  future per-VM public firewall ([09-roadmap.md](./09-roadmap.md)) would keep off
-  the public internet — without opening them to the world.
+  gets every port their VM actually serves on its address — including ones the
+  per-VM public firewall ([20-firewall.md](./20-firewall.md)) keeps off the
+  public internet — without opening them to the world.
 - **Scoped to exactly one VM.** The tunnel is not a route into anything wider: it
   reaches the target VM's `/128` and the host **drops** anything else. The client
   cannot hop through it to another VM, to the host, or to the internet.
@@ -97,9 +97,19 @@ Three independent layers, defense in depth:
    **not** restrict the *destination* of a decrypted inbound packet. So without
    this rule a client could set `dst=<other-vm-v6>` and the host would route it.
    The `drop` closes that: anything from this interface that is not destined to
-   this VM — another VM, the host, the internet — is dropped. This mirrors
-   `reserved_ip_nat.py`'s forward accept and survives the future per-VM-firewall
-   policy flip ([09-roadmap.md](./09-roadmap.md)).
+   this VM — another VM, the host, the internet — is dropped.
+
+   **These two rules are `insert`ed at the *head* of the forward chain, not
+   appended.** `vm-network-up.py` lays down a broad per-VM accept for *every* VM
+   (`ip6 daddr <vm> oifname <veth> accept`) that does **not** constrain the input
+   interface. `accept` is terminal, so an *appended* tunnel `drop` is shadowed: a
+   tunnel packet addressed to *another* VM matches that VM's accept first and is
+   forwarded — the exact leak the drop exists to stop. Inserting the pair at the
+   head (drop first, then accept, leaving `[accept, drop, …per-VM…]`) makes the
+   tunnel's verdict win. This survives the per-VM public firewall
+   ([20-firewall.md](./20-firewall.md)), which lives in a *separate*
+   higher-priority chain and is itself scoped to the public uplink, so it never
+   touches tunnel ingress.
 3. **The network namespace.** Even granting a hostile inner packet, the host
    routes only `<vm-v6>/128` into a netns that contains exactly one VM; there is
    no path from one VM's netns to another.

--- a/spec/19-vpn-broker.md
+++ b/spec/19-vpn-broker.md
@@ -1,0 +1,266 @@
+# The VPN broker (WireGuard tunnels)
+
+Atlas brokers **WireGuard** tunnels: a VM's owner asks Atlas for a tunnel to
+their VM, and Atlas provisions one on demand and hands back a ready client
+config. Once the client brings the tunnel up it can reach **that one VM's public
+IPv6 — and nothing else** — over an encrypted L3 link, from any client, including
+an **IPv4-only** one.
+
+This is the private-ingress sibling of the public-facing layers: the reverse
+proxy ([12-proxy.md](./12-proxy.md)) and TCP proxy ([17-tcp-proxy.md](./17-tcp-proxy.md))
+expose *one service* to *the world*; the VPN broker gives *the owner* private,
+all-port reach to *their own VM*. It reuses the per-VM network namespace and the
+`inet atlas` nftables table from [06-networking.md](./06-networking.md) — read
+that first; this chapter states only where the tunnel differs and why.
+
+## Why a tunnel
+
+A VM's identity is its public IPv6 ([06-networking.md](./06-networking.md)). That
+is reachable from the v6 internet, but:
+
+- **A client may not have IPv6.** An IPv4-only laptop or CI runner cannot dial a
+  v6 address at all. The tunnel's **outer transport is the server's public IPv4**
+  (the droplet's own v4, which every host has), so any client can connect; the
+  **inner** traffic it carries is the VM's v6. A v4-only client thus reaches a
+  v6-only VM.
+- **Public exposure is not private access.** Reaching a port over the tunnel is
+  independent of whether that port is exposed to the public internet. The owner
+  gets every port their VM actually serves on its address — including ones a
+  future per-VM public firewall ([09-roadmap.md](./09-roadmap.md)) would keep off
+  the public internet — without opening them to the world.
+- **Scoped to exactly one VM.** The tunnel is not a route into anything wider: it
+  reaches the target VM's `/128` and the host **drops** anything else. The client
+  cannot hop through it to another VM, to the host, or to the internet.
+
+What the tunnel deliberately is **not**: a way to make the VM a peer in the
+owner's own WireGuard mesh (that would terminate inside the guest — see
+[Why host-terminated](#why-host-terminated-not-in-guest)), nor a private network
+*between* VMs (the standing no-overlay non-goal in
+[06-networking.md](./06-networking.md) holds — this is Atlas↔VM, not VM↔VM).
+
+## The shape
+
+**One WireGuard interface per tunnel, terminated on the host, in the host's root
+network namespace.** Atlas owns it end to end; the guest is never touched and
+holds no tunnel state.
+
+- **Outer endpoint:** `<server-public-v4>:<port>`. The interface listens on a
+  per-tunnel UDP port on the host's public IPv4. There is no host input firewall
+  (the `inet atlas` table is `forward` + `nat` only — see
+  [06-networking.md](./06-networking.md)), so the port is reachable with no extra
+  INPUT rule.
+- **Inner reach:** the VM's `/128`. The host root netns already holds a
+  `<vm-v6>/128 via <host-veth>` route into the VM's namespace
+  (`vm-network-up.py`), so a packet the interface decrypts with destination
+  `<vm-v6>` is routed straight into the right VM with no new routing.
+- **Overlay link:** a `/127` from a ULA supernet gives the host side and the
+  client side a private v6 address each, so the VM has a return address to reply
+  to (`<vm-v6>` → `<client-overlay-v6>` routes back into the interface).
+
+The interface name is `wg-<11 hex of the tunnel UUID>` — `wg-` (3) + 11 = 14,
+IFNAMSIZ-safe like `derive_tap`, and distinct from the `atlas-…` veth/tap names.
+
+### Data plane
+
+```
+client (any v4)  --UDP/IPv4-->  <server-v4>:<port>   [host root netns]
+                                       │  wg-<id> decrypts
+                                       │  inner: src=<client-overlay-v6> dst=<vm-v6>
+                                       ▼
+                          host route <vm-v6>/128 via <host-veth>
+                                       ▼
+                          VM netns ── tap ── guest eth0  (binds <vm-v6>)
+```
+
+- **client → VM:** the client encapsulates `src=<client-overlay-v6>,
+  dst=<vm-v6>` to `<server-v4>:<port>`. `wg-<id>` decrypts, WireGuard's
+  cryptokey routing checks the inner source is in the peer's `AllowedIPs`
+  (`<client-overlay-v6>/128` ✓), and the host routes `<vm-v6>` into the VM.
+- **VM → client:** the guest replies `src=<vm-v6>, dst=<client-overlay-v6>` out
+  `eth0` → host. The host routes `<client-overlay-v6>/128 dev wg-<id>`; the
+  interface encrypts to the one peer whose `AllowedIPs` covers it, back out over
+  v4.
+
+### Isolation — only your VM, no leaks
+
+Three independent layers, defense in depth:
+
+1. **The client's `AllowedIPs` is `<vm-v6>/128`.** A well-behaved client routes
+   only the VM through the tunnel.
+2. **The host nft rule pins the interface to the VM.** Because the interface is
+   1:1 with the tunnel, its name uniquely identifies it, so two rules in the
+   existing `inet atlas forward` chain are exact:
+   - `iifname "wg-<id>" ip6 daddr <vm-v6> accept`
+   - `iifname "wg-<id>" drop`
+
+   Cryptokey routing only governs what the host *sends back* to a peer; it does
+   **not** restrict the *destination* of a decrypted inbound packet. So without
+   this rule a client could set `dst=<other-vm-v6>` and the host would route it.
+   The `drop` closes that: anything from this interface that is not destined to
+   this VM — another VM, the host, the internet — is dropped. This mirrors
+   `reserved_ip_nat.py`'s forward accept and survives the future per-VM-firewall
+   policy flip ([09-roadmap.md](./09-roadmap.md)).
+3. **The network namespace.** Even granting a hostile inner packet, the host
+   routes only `<vm-v6>/128` into a netns that contains exactly one VM; there is
+   no path from one VM's netns to another.
+
+### Why host-terminated, not in-guest
+
+Terminating WireGuard *inside* the guest would make isolation structurally free
+(the tunnel exists only in that one guest), but Atlas rejects it for the same
+reason it rejected configuring a Reserved IP's anchor inside the guest
+([06-networking.md](./06-networking.md)): it breaks the provider-agnostic,
+Atlas-owns-nothing-in-the-guest contract. Concretely:
+
+- **The v4 endpoint forces host plumbing anyway.** A guest has no public v4 —
+  only the host does. In-guest termination would *still* need a host DNAT of
+  `<server-v4>:<port>` into the guest, **plus** per-tunnel config pushed into the
+  guest. That is strictly more than host-termination, not less.
+- **Lifecycle durability.** Rebuild / restore / clone rewrite the guest disk;
+  in-guest config would be lost or duplicated. Host-side config lives in host
+  state and survives a rebuild exactly like Reserved IP's `RESERVED_IPV4`. A
+  tunnel can even be provisioned or revoked while the VM is **Stopped**, coming
+  alive on the next boot.
+- **Atlas-enforced isolation and revocation.** Isolation is the netns + nft rule
+  Atlas owns, not something a tenant can misconfigure out of, and Atlas can
+  revoke without trusting the guest.
+
+The free-isolation advantage of the in-guest model is already matched by
+host-side netns + the one nft rule, so there is no net win to terminating in the
+guest. (If a future feature genuinely wants *the VM to join an external
+WireGuard mesh as a peer*, that is a different, guest-terminated feature — not
+this broker.)
+
+## Addressing and allocation
+
+Per-server, sequential, in the spirit of `allocate_ipv6` / `derive_ipv4_link`
+([06-networking.md](./06-networking.md)):
+
+- A **tunnel slot** is the lowest unused index among the server's non-`Revoked`
+  tunnels. The index yields both the **listen port** (`TUNNEL_PORT_BASE +
+  index`) and a **`/127` overlay link** carved from `ATLAS_TUNNEL_SUPERNET` (a
+  ULA prefix). The overlay is private and never appears on the public wire — like
+  the NAT44 egress `/30`, it only has to be unique per host.
+- The slot is released when the tunnel is `Revoked` (its index returns to the
+  pool), exactly as a Terminated VM releases its `/128`.
+
+## Keys and custody
+
+The **client generates its own keypair and sends only its public key.** The
+client's private key never touches Atlas.
+
+- `request_tunnel(virtual_machine, client_public_key)` mints the **host-side**
+  keypair in the controller (X25519 via `cryptography`, WireGuard base64 — see
+  [`atlas/atlas/wireguard.py`](../atlas/atlas/wireguard.py)). The host private key
+  is stored encrypted on the `VPN Tunnel` row (Frappe is the source of truth) and
+  pushed to the host; it is **never** placed in the guest.
+- The response carries the host `server_public_key`, the `endpoint`
+  (`<server-v4>:<port>`), `allowed_ips` (`<vm-v6>/128`), the assigned
+  `client_address` (`<client-overlay-v6>/128`), and a copy-paste client config
+  template + setup instructions ([Client setup](#client-setup)).
+
+## Durability
+
+A tunnel is durable host state, reconstructible from the Frappe row, exactly like
+the rest of a VM's host networking:
+
+- The host config is persisted under the VM directory
+  (`/var/lib/atlas/virtual-machines/<uuid>/tunnels/<tunnel>.conf`).
+- [`vm-network-up.py`](../scripts/vm-network-up.py) re-applies every persisted
+  tunnel **after** it brings up the netns/veth, so tunnels survive a cold boot;
+  [`vm-network-down.py`](../scripts/vm-network-down.py) tears them down with the
+  rest of the VM's networking.
+- A **live** add/remove (no reboot) is one Task,
+  [`vm-tunnel.py`](../scripts/vm-tunnel.py) (`--action up|down`), which both
+  writes/removes the persisted config **and** applies/removes the live `wg` + nft
+  state — the same attach-now-plus-persist-for-reboot pattern as
+  [`vm-reserved-ip.py`](../scripts/vm-reserved-ip.py).
+
+## The `VPN Tunnel` DocType
+
+One row per tunnel, modelled on [`Reserved IP`](./02-doctypes.md#reserved-ip):
+
+| Field | Notes |
+| --- | --- |
+| `virtual_machine` | the target VM; immutable after insert |
+| `server` | denormalized from the VM (task dispatch + slot allocation scope); immutable |
+| `tenant` | attribution, from the VM |
+| `status` | `Pending` → `Active` → `Revoked` |
+| `transport` | `public-ipv4` today; the seam for `private-vpc` later (see below) |
+| `client_public_key` | the client's WireGuard public key (immutable) |
+| `server_public_key` | host-side public key (returned to the client) |
+| `server_private_key` | host-side private key (encrypted; pushed to the host) |
+| `listen_port` | the allocated UDP port |
+| `interface_name` | `wg-<id>` |
+| `client_address` | `<client-overlay-v6>/128` assigned to the client |
+| `endpoint` (computed) | `<server-v4>:<listen_port>` |
+| `allowed_ips` (computed) | `<vm-v6>/128` |
+
+Controller methods, audited as Tasks:
+
+- `request_tunnel(virtual_machine, client_public_key)` (module-level,
+  whitelisted): allocate the slot, mint host keys, insert the row, run
+  `vm-tunnel.py --action up`, return the client config. Owner-scoped, and
+  Central-callable as the service user (the [16-central.md](./16-central.md)
+  pattern, like `provision.create_vm`).
+- `revoke()`: run `vm-tunnel.py --action down`, set `Revoked`. Skips the host
+  Task for a Terminated VM whose networking is already gone (the
+  [`Reserved IP.detach`](./02-doctypes.md#reserved-ip) rule). A VM `terminate()`
+  revokes the VM's tunnels, like it detaches its Reserved IP.
+
+## Client setup
+
+The client needs the `wireguard-tools` package and an IPv4 path to the server.
+Generate a keypair, request the tunnel with the public key, drop the returned
+values into a config, and bring it up:
+
+```sh
+# 1. Generate a keypair (private key stays on this machine).
+wg genkey | tee privatekey | wg pubkey > publickey
+
+# 2. Ask Atlas for a tunnel, passing the PUBLIC key. The response carries
+#    server_public_key, endpoint, allowed_ips and client_address.
+
+# 3. Write /etc/wireguard/atlas.conf:
+cat > /etc/wireguard/atlas.conf <<EOF
+[Interface]
+PrivateKey = <contents of privatekey>
+Address    = <client_address>          # e.g. fd00:…::2/128
+
+[Peer]
+PublicKey  = <server_public_key>
+Endpoint   = <endpoint>                 # <server-v4>:<port>
+AllowedIPs = <allowed_ips>              # <vm-v6>/128
+PersistentKeepalive = 25               # keep the UDP path open through NAT
+EOF
+
+# 4. Bring it up, then reach the VM at its public IPv6.
+wg-quick up atlas
+ssh root@<vm-v6>
+```
+
+`PersistentKeepalive` keeps the path open when the client is behind NAT (common
+for a v4 client). The same instructions are returned inline by `request_tunnel`.
+
+## The private-network seam (future)
+
+The note in the task that birthed this feature — *use the public address now,
+leave space for a private VPC later* — is one function:
+`tunnel_endpoint_address(server)` returns `Server.ipv4_address` today and a
+private VPC address once Atlas and its servers share a VPC. The `transport`
+field records which (`public-ipv4` now, room for `private-vpc`), so the swap is a
+new enum value plus that one function — no schema churn and no change to the
+inner/isolation model.
+
+## Not in this iteration
+
+- **Desk UI and the real-droplet e2e** land in a follow-up: an operator form +
+  buttons, and a `vpn_tunnel` use case that, on a live droplet, completes a
+  handshake, reaches the owned VM, **proves it cannot reach a second VM** (the
+  isolation host fact), then revokes.
+- **No multi-VM / mesh tunnel.** One tunnel reaches one VM (the no-overlay
+  non-goal).
+- **No v4 *into* the VM over the tunnel.** Inner reach is the VM's v6 `/128`; a
+  guest service must bind the VM's address or `::` (a loopback-only service is
+  not reachable, as for any client).
+- **No per-tunnel bandwidth or connection accounting.**

--- a/spec/19-vpn-broker.md
+++ b/spec/19-vpn-broker.md
@@ -282,10 +282,14 @@ inner/isolation model.
 
 ## Not in this iteration
 
-- **Desk UI and the real-droplet e2e** land in a follow-up: an operator form +
-  buttons, and a `vpn_tunnel` use case that, on a live droplet, completes a
-  handshake, reaches the owned VM, **proves it cannot reach a second VM** (the
-  isolation host fact), then revokes.
+- **The Desk UI is built** (`vpn_tunnel.js`): a `VPN Tunnel` form with state-gated
+  buttons — Pending → **Bring up** / **Revoke**; Active → **Show client config**
+  (a dialog with the copy-paste `.conf` and the client setup steps), **Re-apply**,
+  **Revoke**. The form links off the Virtual Machine dashboard ("Network access")
+  and the Atlas workspace. **The real-droplet e2e** still lands in a follow-up: a
+  `vpn_tunnel` use case that, on a live droplet, completes a handshake, reaches the
+  owned VM, **proves it cannot reach a second VM** (the isolation host fact), then
+  revokes.
 - **No multi-VM / mesh tunnel.** One tunnel reaches one VM (the no-overlay
   non-goal).
 - **No v4 *into* the VM over the tunnel.** Inner reach is the VM's v6 `/128`; a

--- a/spec/19-vpn-broker.md
+++ b/spec/19-vpn-broker.md
@@ -45,10 +45,10 @@ network namespace.** Atlas owns it end to end; the guest is never touched and
 holds no tunnel state.
 
 - **Outer endpoint:** `<server-public-v4>:<port>`. The interface listens on a
-  per-tunnel UDP port on the host's public IPv4. There is no host input firewall
-  (the `inet atlas` table is `forward` + `nat` only — see
-  [06-networking.md](./06-networking.md)), so the port is reachable with no extra
-  INPUT rule.
+  per-tunnel UDP port on the host's public IPv4. The `inet atlas` input chain is
+  `policy accept` and drops only *decrypted* tunnel ingress (see the Isolation
+  section); the outer UDP packet arrives on the physical uplink, not a `wg-…`
+  interface, so the port is reachable with no extra INPUT rule.
 - **Inner reach:** the VM's `/128`. The host root netns already holds a
   `<vm-v6>/128 via <host-veth>` route into the VM's namespace
   (`vm-network-up.py`), so a packet the interface decrypts with destination
@@ -87,17 +87,18 @@ Three independent layers, defense in depth:
 
 1. **The client's `AllowedIPs` is `<vm-v6>/128`.** A well-behaved client routes
    only the VM through the tunnel.
-2. **The host nft rule pins the interface to the VM.** Because the interface is
-   1:1 with the tunnel, its name uniquely identifies it, so two rules in the
-   existing `inet atlas forward` chain are exact:
+2. **Host nft rules pin the interface to the VM.** Because the interface is 1:1
+   with the tunnel, its name uniquely identifies it. *Transit* — a decrypted
+   packet the host would route onward — is governed by two exact rules in the
+   existing `inet atlas forward` chain:
    - `iifname "wg-<id>" ip6 daddr <vm-v6> accept`
    - `iifname "wg-<id>" drop`
 
    Cryptokey routing only governs what the host *sends back* to a peer; it does
    **not** restrict the *destination* of a decrypted inbound packet. So without
    this rule a client could set `dst=<other-vm-v6>` and the host would route it.
-   The `drop` closes that: anything from this interface that is not destined to
-   this VM — another VM, the host, the internet — is dropped.
+   The `drop` closes that: anything forwarded off this interface bound for another
+   VM or the internet is dropped.
 
    **These two rules are `insert`ed at the *head* of the forward chain, not
    appended.** `vm-network-up.py` lays down a broad per-VM accept for *every* VM
@@ -110,6 +111,20 @@ Three independent layers, defense in depth:
    ([20-firewall.md](./20-firewall.md)), which lives in a *separate*
    higher-priority chain and is itself scoped to the public uplink, so it never
    touches tunnel ingress.
+
+   The forward hook only sees *transit*. A packet a client addresses to the
+   **host itself** — the overlay `/127`'s host end (which the client shares), or
+   any host address with a service bound to `::` (sshd, the Frappe stack) — is
+   delivered **locally** on the `input` path, which `forward` never sees. So the
+   `drop` above does not cover the host; a third, symmetric rule in a dedicated
+   `inet atlas input` chain (`policy accept`, so ordinary host ingress — including
+   the tunnel's own *outer* UDP listener, which lands on the physical uplink, not
+   `wg-…` — is untouched) closes it:
+   - `iifname "wg-<id>" drop`
+
+   Nothing legitimately terminates on the host over the tunnel (the host overlay
+   end exists only to route the VM's return traffic), so a blanket input drop is
+   safe; it is appended, since the input chain holds only these per-tunnel drops.
 3. **The network namespace.** Even granting a hostile inner packet, the host
    routes only `<vm-v6>/128` into a netns that contains exactly one VM; there is
    no path from one VM's netns to another.
@@ -288,8 +303,8 @@ inner/isolation model.
   **Revoke**. The form links off the Virtual Machine dashboard ("Network access")
   and the Atlas workspace. **The real-droplet e2e** still lands in a follow-up: a
   `vpn_tunnel` use case that, on a live droplet, completes a handshake, reaches the
-  owned VM, **proves it cannot reach a second VM** (the isolation host fact), then
-  revokes.
+  owned VM, **proves it can reach neither a second VM nor the host itself** (the
+  isolation host facts — the forward and input drops), then revokes.
 - **No multi-VM / mesh tunnel.** One tunnel reaches one VM (the no-overlay
   non-goal).
 - **No v4 *into* the VM over the tunnel.** Inner reach is the VM's v6 `/128`; a

--- a/spec/20-firewall.md
+++ b/spec/20-firewall.md
@@ -1,0 +1,123 @@
+# The per-VM public firewall
+
+A VM's identity is its public IPv6 ([06-networking.md](./06-networking.md)), and
+by default that address is reachable from the **whole** v6 internet: the
+`inet atlas forward` chain is `policy accept` with a broad per-VM accept, so every
+port the guest serves is exposed. A **Firewall** restricts that public surface to
+a chosen set of ports — "only 443", say — while leaving two paths untouched:
+
+- **the VPN tunnel keeps full access** to the whole VM (every port), and
+- **the VM's own outbound connections** keep working (their replies are not new
+  public ingress).
+
+It is the public-ingress complement of the VPN broker
+([19-vpn-broker.md](./19-vpn-broker.md)): the broker gives the *owner* private,
+all-port reach over an encrypted link; the firewall governs what the rest of the
+*internet* may reach. Together they make "the owner reaches everything, the world
+reaches only what you publish" true. Read [06-networking.md](./06-networking.md)
+first — this chapter states only where the firewall differs.
+
+## Why, and why opt-in
+
+While VMs sit on public IPv6 with no inbound filter, "only your VM" is not
+actually enforceable by the tunnel alone: anyone can reach any VM's public
+address directly, tunnel or not. The firewall is what closes the public surface so
+the tunnel's isolation means something.
+
+It is **opt-in, per VM**: a VM with **no Firewall attached stays fully public**
+(the current behavior — nothing breaks on deploy, the `Port Mapping` proxy path
+and public SSH keep working). Attaching a Firewall flips *that one VM* to
+**deny-all-public-except-listed**. An empty rule list is meaningful: a firewall
+with no open ports denies *all* public ingress, leaving the VM reachable **only**
+over its VPN tunnel. One Firewall per VM — a VM's public surface is a single set
+of allowed ports.
+
+## The mechanism
+
+A **separate, higher-priority base chain** on the same `forward` hook, not the
+existing `forward` chain — so the firewall logic stays isolated and never fights
+the tunnel rules for ordering:
+
+```
+chain public_filter {
+    type filter hook forward priority filter - 5; policy accept;
+    iifname <uplink> ip6 daddr <vm> ct state established,related accept
+    iifname <uplink> ip6 daddr <vm> tcp dport <p> accept   # one per allowed rule
+    iifname <uplink> ip6 daddr <vm> drop                   # public, not allowed -> DROP
+}
+```
+
+`priority filter - 5` is lower than `forward`'s `filter` (0), so `public_filter`
+is evaluated **first**. Three properties make this exactly right:
+
+- **The VPN bypasses the firewall for free.** Every rule is scoped to
+  `iifname <uplink>` (the host's public NIC). Tunnel traffic arrives on a `wg-…`
+  interface, never the uplink, so it matches nothing here and falls through to
+  `forward`, where the tunnel's own accept/drop ([19-vpn-broker.md](./19-vpn-broker.md))
+  govern it. No special case is needed.
+- **`drop` is terminal; `accept` is not.** A `drop` in this earlier chain ends the
+  packet's life across all chains, so a disallowed public port is unreachable. An
+  `accept` only ends *this* chain — allowed traffic proceeds to `forward` and is
+  delivered exactly as before, so nothing else changes.
+- **`established,related` keeps the VM's outbound alive.** A reply to a connection
+  the VM opened arrives from the uplink destined to the VM but is not new ingress;
+  the first rule lets it through. This is the one real behavioral addition — it
+  turns conntrack on for the forward hook.
+
+Every rule is `daddr`-scoped to one VM, so per-VM blocks are independent and their
+order relative to each other does not matter. `apply_firewall` is idempotent: it
+deletes this VM's block by handle and re-appends it (established, then one accept
+per rule, then drop), the self-healing contract shared with `apply_tunnel` and
+`reserved_ip_nat.py`.
+
+## Durability and teardown
+
+Like the reserved-IP NAT and the tunnels, a firewall is **reconstructible from
+disk** with no Frappe DB:
+
+- `firewall-apply.py` writes a per-VM `firewall.env` sidecar (VM IPv6 + the
+  allowed `proto/port` list) under the VM directory, then applies the nft block.
+- `vm-network-up.py` re-applies it at cold boot (step 10), after the VM's `/128`
+  route exists — `apply_persisted_firewall`. No sidecar (no firewall attached) is
+  a no-op: the VM stays public.
+- `vm-network-down.py` **removes the block** on stop/terminate. This matters for
+  correctness: the block lives in the host root netns and survives the namespace
+  delete, so a future VM that **reuses the IPv6** must not inherit a stale `drop`.
+  The sidecar (in the VM dir) is swept by terminate's `rm -rf`; on a plain stop it
+  persists and the next start re-applies the block.
+
+## The doctype and the apply path
+
+- **Firewall** (one per VM): `virtual_machine` (immutable), denormalized `server`
+  / `tenant`, an `enabled` toggle, a read-only `status` (Active/Disabled), and a
+  child table of **Firewall Rule** (`protocol` tcp/udp, `port`). Owner-scoped
+  (Atlas User `if_owner`, System Manager full), like `VPN Tunnel`.
+- The controller keeps the host in step on save: `on_update` → `firewall-apply.py
+  --action apply` with the rules when `enabled`, else `--action clear` (the VM
+  reverts to public); `on_trash` clears. A **terminated** VM is skipped — its host
+  state is already gone (`vm-network-down` removed it) and its `network.env` no
+  longer exists, so no Task is dispatched.
+- The rules cross the Task boundary as a repeatable `--rule tcp/443` flag (the
+  typed-list input from [04-tasks.md](./04-tasks.md)); an empty list is the
+  deny-all-public firewall.
+
+## Interaction with the proxies
+
+The `Port Mapping` reverse/TCP proxy ([12-proxy.md](./12-proxy.md),
+[17-tcp-proxy.md](./17-tcp-proxy.md)) dials a VM's **public IPv6** on a target
+port. That arrives as public ingress, so a firewalled VM must **allow the proxied
+port** for the proxy to reach it. This is intentional: the firewall is the single
+place that decides the VM's public surface, and the proxy is just another public
+client of it.
+
+## Non-goals / follow-ups
+
+- **IPv4 / reserved-IP ingress filtering.** The first cut scopes to public IPv6
+  (every VM's universal public surface). A reserved-IP VM's inbound v4 (DNAT'd to
+  its private /30 — [06-networking.md](./06-networking.md)) is not yet filtered.
+- **Source scoping and port ranges.** Rules are `proto/port` for any source; CIDR
+  sources and port ranges are a later refinement.
+- **Inter-VM traffic** stays as today (the forward chain's per-VM accepts); the
+  firewall governs the *public uplink*, not VM↔VM.
+- **The SPA/Desk UI** lands with the rest of the user dashboard
+  ([11-user-ui.md](./11-user-ui.md)); core (doctype + host mechanism) is first.

--- a/spec/20-firewall.md
+++ b/spec/20-firewall.md
@@ -64,6 +64,18 @@ is evaluated **first**. Three properties make this exactly right:
   the first rule lets it through. This is the one real behavioral addition — it
   turns conntrack on for the forward hook.
 
+Because the chain is stateful, applying a deny blocks **new** connections but does
+not tear down flows already in the conntrack table — an open SSH session survives
+the rule that forbids *new* SSH, since its packets still match `established,related`
+(a new SYN is state `NEW`, hits the `drop`). This is deliberate, and it is what
+every stateful cloud firewall does (AWS security groups, GCP and Azure firewall
+rules, DigitalOcean Cloud Firewalls); only a *stateless* filter — AWS Network ACLs —
+re-evaluates every packet and would cut the live flow. Atlas keeps the stateful
+behavior so tightening a VM's rules never drops the operator's own live session.
+Forcibly severing an already-open flow is a host-side conntrack eviction
+(`conntrack -D --orig-dst <vm-v6> …`), not a firewall verb — intentionally not part
+of apply.
+
 Every rule is `daddr`-scoped to one VM, so per-VM blocks are independent and their
 order relative to each other does not matter. `apply_firewall` is idempotent: it
 deletes this VM's block by handle and re-appends it (established, then one accept

--- a/spec/20-firewall.md
+++ b/spec/20-firewall.md
@@ -100,7 +100,9 @@ disk** with no Frappe DB:
 
 ## The doctype and the apply path
 
-- **Firewall** (one per VM): `virtual_machine` (immutable), denormalized `server`
+- **Firewall** (one per VM — a DB `unique` index on `virtual_machine`, so the rule
+  holds even under concurrent inserts; the controller's `exists` check is just the
+  friendly message over it): `virtual_machine` (immutable), denormalized `server`
   / `tenant`, an `enabled` toggle, a read-only `status` (Active/Disabled), and a
   child table of **Firewall Rule** (`protocol` tcp/udp, `port`). Owner-scoped
   (Atlas User `if_owner`, System Manager full), like `VPN Tunnel`.

--- a/spec/20-firewall.md
+++ b/spec/20-firewall.md
@@ -119,5 +119,8 @@ client of it.
   sources and port ranges are a later refinement.
 - **Inter-VM traffic** stays as today (the forward chain's per-VM accepts); the
   firewall governs the *public uplink*, not VM↔VM.
-- **The SPA/Desk UI** lands with the rest of the user dashboard
-  ([11-user-ui.md](./11-user-ui.md)); core (doctype + host mechanism) is first.
+- **The Desk UI is built** (`firewall.js`): a `Firewall` form with the allowed-port
+  table and an **Apply to host** button (the explicit apply verb — a plain Save
+  never SSHes), linked off the Virtual Machine dashboard ("Network access") and the
+  Atlas workspace. **The SPA surface** still lands with the rest of the user
+  dashboard ([11-user-ui.md](./11-user-ui.md)).

--- a/spec/README.md
+++ b/spec/README.md
@@ -137,6 +137,7 @@ keep it the source of truth.
 17. [The TCP proxy](./17-tcp-proxy.md)
 18. [Self-service subdomain routing (bench-admin sites)](./18-bench-self-routing.md)
 19. [The VPN broker (WireGuard tunnels)](./19-vpn-broker.md)
+20. [The per-VM public firewall](./20-firewall.md)
 
 ## First run on a fresh site
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -136,6 +136,7 @@ keep it the source of truth.
 16. [Central — the global control plane](./16-central.md)
 17. [The TCP proxy](./17-tcp-proxy.md)
 18. [Self-service subdomain routing (bench-admin sites)](./18-bench-self-routing.md)
+19. [The VPN broker (WireGuard tunnels)](./19-vpn-broker.md)
 
 ## First run on a fresh site
 
@@ -220,6 +221,7 @@ operator-facing features add to this list; new tests follow it.
 | Manage a VM's disk and size    | `Virtual Machine` → **Snapshot / Rebuild / Resize**; `Virtual Machine Snapshot` → **Restore to VM / Clone to new VM / Delete** | [05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md) |
 | Promote a snapshot to an image | `Virtual Machine Snapshot` → **Promote to image** (or `Image Build` → **Promote to image**): same-server base image new VMs pick via the `image` field | [08-images.md](./08-images.md#two-origins-for-a-base-image-a-url-or-a-snapshot-promote) |
 | Attach a public IPv4 to a VM   | `Reserved IP` → **Attach / Detach** (the inbound-v4 primitive: DNAT in, SNAT out) | [06-networking.md](./06-networking.md#ipv4-ingress-reserved-ip) |
+| Broker a VPN tunnel to a VM    | (user/Central-driven) `request_tunnel` / `revoke` provisions a host-terminated WireGuard tunnel scoped to the owner's one VM | [19-vpn-broker.md](./19-vpn-broker.md) |
 | Issue a TLS cert for a region  | `Root Domain` → **Issue / Renew Certificate**; `TLS Certificate` → **Issue/Renew / Push to Proxies**; `Route53 Settings` / `Lets Encrypt Settings` → **Test Connection** | [13-tls.md](./13-tls.md) |
 | Route guest-created bench sites | (guest-driven, no operator action) the in-guest `atlas-route register`/`deregister`/`list` POSTs reserve/remove a `Subdomain` the controller arbitrates (uniqueness, brand denylist, per-VM cap, own-VM scoping by source `/128`); every call audited; `terminate()` is the only controller-side teardown | [18-bench-self-routing.md](./18-bench-self-routing.md) |
 | Run an ad-hoc task / reboot    | `Server` → **Run Task / Reboot**                        | [04-tasks.md](./04-tasks.md) |


### PR DESCRIPTION
## What this adds

Two complementary per-VM network-access features — and the Desk UI for both — that together make *"the owner reaches everything, the world reaches only what you publish"* true.

### VPN broker — WireGuard tunnels (`spec/19-vpn-broker.md`)
- `request_tunnel(virtual_machine, client_public_key, label)` provisions a per-tunnel, **host-terminated** WireGuard interface in the host root netns, scoped to one VM's `/128`.
- Outer endpoint = the server's **public IPv4** (so a v4-only client reaches a v6-only VM); inner reach = the VM's v6; overlay = a ULA `/127`.
- The **client sends only its public key**; the **host mints its own keypair** (kept in a `0600` file, never in Frappe/Task).
- **Isolation**: an `iifname → daddr accept / drop` pair **inserted at the head** of `inet atlas forward`, so the broad per-VM accept can't shadow the drop. A client reaches its VM and nothing else.
- Owner-scoped + Central-callable, mirroring `create_vm`.

### Per-VM public firewall (`spec/20-firewall.md`)
- Opt-in, one `Firewall` per VM (+ `Firewall Rule` children: proto/port). No firewall = the VM stays fully public.
- Mechanism: a **separate higher-priority base chain `public_filter`** (`hook forward priority filter - 5`) scoped to `iifname <uplink> ip6 daddr <vm>`: `established,related accept`, one `accept` per allowed port, then `drop`.
- **The VPN bypasses it for free** — tunnel ingress is on `wg-*`, never the uplink.
- Ingress-only and **stateful** (matches AWS SG / GCP / Azure NSG / DO Cloud Firewalls): a deny blocks new connections but doesn't sever established conntrack flows — documented as a deliberate decision.
- Durable: `firewall.env` sidecar, re-applied at cold boot, removed on stop/terminate so a reused IPv6 inherits no stale drop.

### Desk UI
- `VPN Tunnel` form: state-gated Bring up / Show client config (dialog with copy-paste `.conf` + client setup steps) / Re-apply / Revoke; new whitelisted `client_config()`.
- `Firewall` form: allowed-port table + explicit **Apply to host** (a plain Save never SSHes).
- Both linked off the Virtual Machine dashboard ("Network access") and the Atlas workspace.

### Data integrity
- `Firewall.virtual_machine` gains a DB `unique` index — the controller's `exists()` check was TOCTOU-racy. Verified it rejects a duplicate with `IntegrityError 1062`.
- Documented why VPN Tunnel slot allocation uses a `for_update` Server-row lock rather than a unique index (revoke keeps the row, so reuse would collide).

## Validation
- VPN core + firewall **live-validated on a real droplet**: tunnel handshake, owned-VM reach, second-VM drop (isolation); public ICMP/`:22` dropped to a 443-firewalled VM while `:443` passes; VPN reaches everything.
- Desk forms assemble server-side with no JS error; `client_config()` returns a valid `.conf`.
- Unit tests included for controllers, APIs, networking/wireguard helpers, and the host firewall/wireguard libs.

## Deferred (not in this PR)
- Real-droplet e2e use case for the tunnel (handshake + isolation host fact).
- IPv4 / reserved-IP ingress filtering; source-CIDR + port-range firewall rules.
- The user SPA surface (Desk UI ships here; the SPA lands with the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
