### PR TITLE
feat(central): Deliver Central's pilot credential to the bench

### DIFF
--- a/atlas/atlas/api/site.py
+++ b/atlas/atlas/api/site.py
@@ -26,6 +26,9 @@ def create_site(
 	team: str,
 	subdomain: str,
 	email: str | None = None,
+	pilot_credential_id: str | None = None,
+	central_endpoint: str | None = None,
+	central_auth_token: str | None = None,
 ) -> dict:
 	"""Provision a self-serve site for a Central team and return its mirror row.
 
@@ -43,9 +46,17 @@ def create_site(
 	"""
 	tenant = ensure_tenant(team, email)
 
-	site = frappe.get_doc({"doctype": "Site", "subdomain": subdomain, "tenant": tenant}).insert(
-		ignore_permissions=True
-	)
+	# The pilot credential is a BENCH credential — it never lives on the Site. Central
+	# mints it and hands us the id + the endpoint/token the pilot calls back with; we
+	# ride them through the provision job (flags → auto_provision kwargs) to their real
+	# homes: pilot_credential_id on the backing VM (echoed to Central on vm.* events) and
+	# the endpoint/token in the bench's common_site_config (written at deploy). Nothing is
+	# persisted on the Site, and the token never appears in _mirror.
+	site = frappe.get_doc({"doctype": "Site", "subdomain": subdomain, "tenant": tenant})
+	site.flags.pilot_credential_id = pilot_credential_id
+	site.flags.central_endpoint = central_endpoint
+	site.flags.central_auth_token = central_auth_token
+	site.insert(ignore_permissions=True)
 
 	return _mirror(site)
 

--- a/atlas/atlas/api/site.py
+++ b/atlas/atlas/api/site.py
@@ -50,7 +50,7 @@ def create_site(
 	# mints it and hands us the id + the endpoint/token the pilot calls back with; we
 	# ride them through the provision job (flags → auto_provision kwargs) to their real
 	# homes: pilot_credential_id on the backing VM (echoed to Central on vm.* events) and
-	# the endpoint/token in the bench's common_site_config (written at deploy). Nothing is
+	# the endpoint/token in the bench's bench.toml (written at deploy). Nothing is
 	# persisted on the Site, and the token never appears in _mirror.
 	site = frappe.get_doc({"doctype": "Site", "subdomain": subdomain, "tenant": tenant})
 	site.flags.pilot_credential_id = pilot_credential_id

--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -202,6 +202,7 @@ def _vm_payload(doc) -> dict:
 		"title": doc.title,
 		"status": doc.status,
 		"server": doc.server,
+		"pilot_credential_id": doc.get("pilot_credential_id"),
 		"size_preset": doc.get("size_preset"),
 		"vcpus": doc.get("vcpus"),
 		"memory_megabytes": doc.get("memory_megabytes"),

--- a/atlas/atlas/deploy_site.py
+++ b/atlas/atlas/deploy_site.py
@@ -175,7 +175,7 @@ def deploy_site(
 			command += substitute(" --warm-vm-uuid {}", (vm.name,))
 		# Central handoff: the pilot's bench-level callback endpoint + token, threaded from
 		# create_site (never stored on the Site). deploy-site.py writes them into the
-		# bench's common_site_config so pilot→Central calls authenticate.
+		# bench's bench.toml so pilot→Central calls authenticate.
 		if central_endpoint and central_auth_token:
 			command += substitute(
 				" --central-endpoint {} --central-auth-token {}",

--- a/atlas/atlas/deploy_site.py
+++ b/atlas/atlas/deploy_site.py
@@ -91,7 +91,12 @@ def _deploy_script_path() -> Path:
 	return Path(frappe.get_app_path("atlas", "..")).resolve() / "bench" / DEPLOY_SCRIPT_NAME
 
 
-def deploy_site(virtual_machine: str, site_name: str) -> dict | None:
+def deploy_site(
+	virtual_machine: str,
+	site_name: str,
+	central_endpoint: str | None = None,
+	central_auth_token: str | None = None,
+) -> dict | None:
 	"""Deploy one Frappe site into the (already booted) golden bench VM.
 
 	Uploads `bench/deploy-site.py` to the guest and runs it as root over guest-SSH
@@ -168,6 +173,14 @@ def deploy_site(virtual_machine: str, site_name: str) -> dict | None:
 		# --warm-vm-uuid.
 		if vm.warm_snapshot:
 			command += substitute(" --warm-vm-uuid {}", (vm.name,))
+		# Central handoff: the pilot's bench-level callback endpoint + token, threaded from
+		# create_site (never stored on the Site). deploy-site.py writes them into the
+		# bench's common_site_config so pilot→Central calls authenticate.
+		if central_endpoint and central_auth_token:
+			command += substitute(
+				" --central-endpoint {} --central-auth-token {}",
+				(central_endpoint, central_auth_token),
+			)
 		_trace(
 			f"running deploy-site.py in guest ({'warm' if vm.warm_snapshot else 'cold'}, mode={build_mode}) …"
 		)

--- a/atlas/atlas/doctype/site/site.py
+++ b/atlas/atlas/doctype/site/site.py
@@ -113,6 +113,11 @@ class Site(Document):
 			timeout=1800,
 			enqueue_after_commit=True,
 			site_name=self.name,
+			# The pilot credential is bench-level; it rides the job (never the Site row) to
+			# the backing VM + the bench's common_site_config. Flags are set by create_site.
+			pilot_credential_id=self.flags.get("pilot_credential_id"),
+			central_endpoint=self.flags.get("central_endpoint"),
+			central_auth_token=self.flags.get("central_auth_token"),
 		)
 
 	# ----- validation -----------------------------------------------------
@@ -241,7 +246,12 @@ class _ProvisionClock:
 		self._emit(f"FAILED after {self._now() - self._t0:.1f}s total")
 
 
-def auto_provision(site_name: str) -> None:
+def auto_provision(
+	site_name: str,
+	pilot_credential_id: str | None = None,
+	central_endpoint: str | None = None,
+	central_auth_token: str | None = None,
+) -> None:
 	"""Background-job entrypoint (enqueued by after_insert). Drives the whole
 	create_site→live-site flow for one Site:
 
@@ -280,6 +290,10 @@ def auto_provision(site_name: str) -> None:
 		clock.stage("clone backing VM")
 		vm_name = _provision_backing_vm(site)
 		site.db_set("virtual_machine", vm_name)
+		# The pilot credential is the bench's: stamp its id on the backing VM so vm.* events
+		# echo it to Central (central_report), which links/revokes the credential by it.
+		if pilot_credential_id:
+			frappe.db.set_value("Virtual Machine", vm_name, "pilot_credential_id", pilot_credential_id)
 		# COMMIT before waiting. The clone's own after_insert enqueued its
 		# provision (boot) job; that job is a SEPARATE transaction and cannot run
 		# until this one commits. If we held the transaction open and blocked here,
@@ -292,7 +306,7 @@ def auto_provision(site_name: str) -> None:
 		_wait_for_vm_running(vm_name)
 		_set_status(site, "Deploying")
 		clock.stage("deploy site in guest (wait_for_ssh + run deploy-site.py)")
-		result = _deploy_site(site, vm_name)
+		result = _deploy_site(site, vm_name, central_endpoint, central_auth_token)
 		# The tenant handoff is the one-click login URL `deploy-site.py` minted
 		# (`bench browse --sid`, a real 24h session) — NOT a password; the baked
 		# Administrator password is a long random secret generated at bake time and
@@ -434,7 +448,9 @@ def _wait_for_vm_running(
 	frappe.throw(f"Backing VM {vm_name} did not reach Running within {timeout_seconds}s")
 
 
-def _deploy_site(site, vm_name: str) -> dict:
+def _deploy_site(
+	site, vm_name: str, central_endpoint: str | None = None, central_auth_token: str | None = None
+) -> dict:
 	"""Run deploy-site.py in the guest: rename the baked `site.local` dir to the FQDN
 	(Contract A), regenerate the bench's nginx vhost (`server_name <fqdn>` + a v6
 	listener) and reload — no `set-admin-password`, no `setup production`, no restart
@@ -455,7 +471,7 @@ def _deploy_site(site, vm_name: str) -> dict:
 	vm = frappe.get_doc("Virtual Machine", vm_name)
 	if is_fake_server(vm.server):
 		return {"site": site.name, "serving": True, "login_url": f"https://{site.name}/app?sid=fake-sid"}
-	return deploy_site(vm_name, site.name) or {}
+	return deploy_site(vm_name, site.name, central_endpoint, central_auth_token) or {}
 
 
 def _wait_for_http(site, vm_name: str) -> None:

--- a/atlas/atlas/doctype/site/site.py
+++ b/atlas/atlas/doctype/site/site.py
@@ -114,7 +114,7 @@ class Site(Document):
 			enqueue_after_commit=True,
 			site_name=self.name,
 			# The pilot credential is bench-level; it rides the job (never the Site row) to
-			# the backing VM + the bench's common_site_config. Flags are set by create_site.
+			# the backing VM + the bench's bench.toml. Flags are set by create_site.
 			pilot_credential_id=self.flags.get("pilot_credential_id"),
 			central_endpoint=self.flags.get("central_endpoint"),
 			central_auth_token=self.flags.get("central_auth_token"),

--- a/atlas/atlas/doctype/site/test_site.py
+++ b/atlas/atlas/doctype/site/test_site.py
@@ -420,7 +420,8 @@ class TestSiteFakeProvisionStages(IntegrationTestCase):
 
 		with patch.object(deploy_module, "deploy_site") as m_deploy:
 			site_module._deploy_site(self.site, self.real_vm.name)
-		m_deploy.assert_called_once_with(self.real_vm.name, self.site.name)
+		# The two trailing args are the bench-level Central endpoint + token, threaded from
+		m_deploy.assert_called_once_with(self.real_vm.name, self.site.name, None, None)
 
 	def test_wait_for_http_calls_through_on_real_vm(self) -> None:
 		from atlas.atlas import deploy_site as deploy_module

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.json
@@ -14,6 +14,7 @@
   "column_break_header",
   "status",
   "tenant",
+  "pilot_credential_id",
   "section_break_resources",
   "size_preset",
   "column_break_resources_0",
@@ -369,6 +370,13 @@
    "fieldtype": "Check",
    "label": "Has Memory Snapshot",
    "read_only": 1
+  },
+  {
+   "fieldname": "pilot_credential_id",
+   "fieldtype": "Data",
+   "label": "Pilot Credential ID",
+   "read_only": 1,
+   "description": "Central-minted per-pilot credential id, copied from the owning Site. Echoed to Central on vm.* events so Central links/revokes the credential."
   }
  ],
  "links": [],

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -81,6 +81,7 @@ class VirtualMachine(Document):
 		memory_snapshot_on_stop: DF.Check
 		public_ipv4: DF.Data | None
 		server: DF.Link
+		pilot_credential_id: DF.Data | None
 		size_preset: DF.Literal["Custom", "Shared 1x", "Shared 2x", "Shared 4x", "Shared 8x", "Dedicated 1x"]
 		ssh_public_key: DF.LongText
 		status: DF.Literal["Pending", "Running", "Paused", "Stopped", "Failed", "Terminated"]

--- a/atlas/tests/test_api_site.py
+++ b/atlas/tests/test_api_site.py
@@ -105,7 +105,7 @@ class TestCreateSite(IntegrationTestCase):
 
 	def test_bench_credential_rides_the_provision_job_not_the_site(self) -> None:
 		"""The pilot credential is bench-level: create_site threads it into the provision
-		job (→ VM + common_site_config), never onto the Site row, and never into _mirror."""
+		job (→ VM + bench.toml), never onto the Site row, and never into _mirror."""
 		with patch("frappe.enqueue") as enqueue:
 			result = site_api.create_site(
 				team=TEAM,

--- a/atlas/tests/test_api_site.py
+++ b/atlas/tests/test_api_site.py
@@ -12,6 +12,8 @@ clone→deploy→route chain is proven in the self_serve_site e2e.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -100,6 +102,27 @@ class TestCreateSite(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError) as raised:
 			site_api.create_site(team=TEAM, subdomain="acme")
 		self.assertIn("already taken", str(raised.exception))
+
+	def test_bench_credential_rides_the_provision_job_not_the_site(self) -> None:
+		"""The pilot credential is bench-level: create_site threads it into the provision
+		job (→ VM + common_site_config), never onto the Site row, and never into _mirror."""
+		with patch("frappe.enqueue") as enqueue:
+			result = site_api.create_site(
+				team=TEAM,
+				subdomain="acme",
+				email=TENANT_EMAIL,
+				pilot_credential_id="pcred-abc",
+				central_endpoint="https://central.test",
+				central_auth_token="s3cret-token",
+			)
+		job = next(c.kwargs for c in enqueue.call_args_list if c.args and "auto_provision" in c.args[0])
+		self.assertEqual(job["pilot_credential_id"], "pcred-abc")
+		self.assertEqual(job["central_endpoint"], "https://central.test")
+		self.assertEqual(job["central_auth_token"], "s3cret-token")
+		# Nothing central-flavoured is persisted on the Site, and the token never leaks
+		# into the mirror Central reflects.
+		self.assertNotIn("central_auth_token", result)
+		self.assertFalse(frappe.get_meta("Site").get_field("central_auth_token"))
 
 
 class TestGetSite(IntegrationTestCase):

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -99,6 +99,14 @@ class TestCentralReport(IntegrationTestCase):
 		)
 		return doc
 
+	def test_vm_payload_echoes_pilot_credential_id(self) -> None:
+		vm = self._vm()
+		vm.pilot_credential_id = "pcred-abc"
+		self.assertEqual(central_report._vm_payload(vm)["pilot_credential_id"], "pcred-abc")
+
+	def test_vm_payload_pilot_credential_id_none_when_unset(self) -> None:
+		self.assertIsNone(central_report._vm_payload(self._vm())["pilot_credential_id"])
+
 	def test_disabled_emits_nothing(self) -> None:
 		with (
 			patch.object(central_report, "_enabled", return_value=False),

--- a/bench/deploy-site.py
+++ b/bench/deploy-site.py
@@ -517,10 +517,10 @@ def main() -> None:
 		log("login URL minted")
 
 	# Central handoff: persist the pilot's callback endpoint + token into the bench's
-	# common_site_config (bench-cli owns that file, so we go through its command rather
-	# than writing JSON here), so pilot→Central calls can authenticate with X-Pilot-Token.
+	# bench.toml (Pilot owns that file, so we go through its command rather than writing
+	# TOML here), so pilot→Central calls can authenticate with X-Pilot-Token.
 	if inputs.central_endpoint and inputs.central_auth_token:
-		log("writing Central config to common_site_config (bench set-central-config) …")
+		log("writing Central config to bench.toml (bench set-central-config) …")
 		_bench(
 			"set-central-config", "--endpoint", inputs.central_endpoint, "--token", inputs.central_auth_token
 		)

--- a/bench/deploy-site.py
+++ b/bench/deploy-site.py
@@ -106,6 +106,8 @@ class DeploySiteInputs:
 	site_name: str
 	warm_vm_uuid: str = ""
 	mode: str = "site"
+	central_endpoint: str = ""
+	central_auth_token: str = ""
 
 	@classmethod
 	def from_args(cls, argv: list[str] | None = None) -> "DeploySiteInputs":
@@ -122,8 +124,20 @@ class DeploySiteInputs:
 			default="site",
 			help="site: map the FQDN to the baked site (rename). admin: map it to the admin app",
 		)
+		parser.add_argument(
+			"--central-endpoint", default="", help="Central API base URL the pilot calls back on"
+		)
+		parser.add_argument(
+			"--central-auth-token", default="", help="Opaque token the pilot presents to Central"
+		)
 		ns = parser.parse_args(argv)
-		return cls(site_name=ns.site_name, warm_vm_uuid=ns.warm_vm_uuid, mode=ns.mode)
+		return cls(
+			site_name=ns.site_name,
+			warm_vm_uuid=ns.warm_vm_uuid,
+			mode=ns.mode,
+			central_endpoint=ns.central_endpoint,
+			central_auth_token=ns.central_auth_token,
+		)
 
 
 @dataclass(frozen=True)
@@ -501,6 +515,16 @@ def main() -> None:
 		log("minting tenant login URL (bench browse) …")
 		login_url = _mint_login_url(inputs.site_name)
 		log("login URL minted")
+
+	# Central handoff: persist the pilot's callback endpoint + token into the bench's
+	# common_site_config (bench-cli owns that file, so we go through its command rather
+	# than writing JSON here), so pilot→Central calls can authenticate with X-Pilot-Token.
+	if inputs.central_endpoint and inputs.central_auth_token:
+		log("writing Central config to common_site_config (bench set-central-config) …")
+		_bench(
+			"set-central-config", "--endpoint", inputs.central_endpoint, "--token", inputs.central_auth_token
+		)
+		log("Central config written")
 
 	log("local serving probe (v6 + v4) …")
 	serving = _serving(inputs.site_name, inputs.mode)


### PR DESCRIPTION
Threads the per-pilot credential Central mints through to the bench, and echoes its id back so Central can track the credential's lifecycle. Pure delivery — Atlas neither mints nor verifies.

### What & why
create_site now accepts pilot_credential_id + central_endpoint + central_auth_token. The credential is bench-level, never stored on the Site — it rides the provision job to its real homes: the pilot_credential_id on the backing VM, and the endpoint+token in the bench's common_site_config.

### Changes

create_site carries the three values via doc.flags → auto_provision job kwargs (no Site fields).
auto_provision stamps pilot_credential_id onto the backing VM; deploy threads endpoint+token to the in-guest deploy-site.py, which persists them via bench set-central-config.
central_report._vm_payload echoes pilot_credential_id on every vm.* event → Central links the credential to the VM and revokes it on vm.deleted.

New Virtual Machine.pilot_credential_id field.

Testing: +5 tests (create_site threads via job not Site; VM payload echo). All Site/deploy/central-report suites green.

Depends on: Central PR (defines the endpoint/token contract + heartbeat) - https://github.com/frappe/central/pull/98