### PR TITLE
feat(capacity): resize_capacity — per-host headroom for an in-place resize

### DIFF
--- a/atlas/atlas/api/provision.py
+++ b/atlas/atlas/api/provision.py
@@ -133,3 +133,31 @@ def capacity() -> dict:
 		"unmeasured": unmeasured,
 		"largest_vm": shape,
 	}
+
+
+@frappe.whitelist()
+def resize_capacity(vm: str) -> dict:
+	"""The largest shape `vm` can resize to on its current host — Central's pre-resize
+	check, the in-place twin of `capacity()`.
+
+	A resize reshapes the VM on the host it already occupies, so — unlike `capacity()`,
+	which sizes a NEW machine against the best host's free headroom — the ceiling is
+	THIS host's free room with the VM's own current footprint added back (a resize frees
+	it before re-reserving). The VM can therefore always keep its size or shrink; Central
+	offers only resize targets that will fit, so an oversized resize never fails on the
+	host.
+
+	Returns `{available, unmeasured, largest_vm}` in the same shape as `capacity()`:
+	`largest_vm` is `{vcpus, memory_megabytes, disk_gigabytes}`, null (and `available`
+	False) only when the VM or its host is unknown. `unmeasured` flags a host with an
+	unreported axis (sentinel numbers — treat the ceiling as "size unknown"). Advisory:
+	the resize path on the host is the authoritative gate. Runs with the Central token,
+	like `capacity()` / `create_vm`."""
+	from atlas.atlas.placement import resize_headroom
+
+	shape = resize_headroom(vm)
+	if shape is None:
+		return {"available": False, "unmeasured": False, "largest_vm": None}
+
+	unmeasured = shape.pop("unmeasured")
+	return {"available": True, "unmeasured": unmeasured, "largest_vm": shape}

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -169,6 +169,58 @@ def largest_vm() -> dict | None:
 	return best[1]
 
 
+def _axis_ceiling(axis: dict, own: float, sentinel: float) -> tuple[float, bool]:
+	"""The most of one axis a VM already on this host can occupy after a resize, and
+	whether the axis is measured.
+
+	A resize reshapes the VM in place, freeing its OWN current usage before re-reserving
+	the new size — so the ceiling is the host's free room with that footprint added back:
+	`effective - (used - own)`, i.e. `effective - used + own` (clamped at 0). Uncatalogued
+	axis (`effective is None`) → the sentinel, flagged unmeasured."""
+	if axis["effective"] is None:
+		return sentinel, False
+	return max(0.0, axis["effective"] - axis["used"] + own), True
+
+
+def resize_headroom(vm: str) -> dict | None:
+	"""The largest shape `vm` can resize to on the host it already occupies, or None when
+	the VM (or its host) is unknown.
+
+	Unlike `largest_vm` — the best *other* host's free headroom for a NEW machine — a
+	resize stays on the VM's current host, so the ceiling is THAT host's free room with
+	the VM's own footprint added back (`_axis_ceiling`). This guarantees the VM can always
+	keep its size or shrink, and grow into whatever else the host has spare — so Central
+	can offer only resize targets that will actually fit, instead of letting an oversized
+	resize fail on the host. Returns `{vcpus, memory_megabytes, disk_gigabytes,
+	unmeasured}`, matching `largest_vm`'s shape; an unreported axis contributes a sentinel
+	and marks the shape `unmeasured`."""
+	from atlas.atlas.api.server_capacity import capacity_for_server
+
+	row = frappe.db.get_value(
+		"Virtual Machine",
+		vm,
+		["server", "vcpus", "cpu_max_cores", "memory_megabytes", "disk_gigabytes", "data_disk_gigabytes"],
+		as_dict=True,
+	)
+	if not row or not row.server:
+		return None
+
+	c = capacity_for_server(row.server)
+	own_cpu = float(row.cpu_max_cores or row.vcpus or 0)
+	own_mem = float(row.memory_megabytes or 0)
+	own_disk = float((row.disk_gigabytes or 0) + (row.data_disk_gigabytes or 0))
+	cpu, m_cpu = _axis_ceiling(c["cpu"], own_cpu, _UNMEASURED_VCPUS)
+	mem, m_mem = _axis_ceiling(c["memory"], own_mem, _UNMEASURED_MEMORY_MB)
+	disk, m_disk = _axis_ceiling(c["disk"], own_disk, _UNMEASURED_DISK_GB)
+	measured = m_cpu and m_mem and m_disk
+	return {
+		"vcpus": int(cpu),
+		"memory_megabytes": int(mem),
+		"disk_gigabytes": int(disk),
+		"unmeasured": not measured,
+	}
+
+
 def apply_user_defaults(virtual_machine) -> None:
 	"""Fill `server` and `image` on a VM that a user created without them.
 

--- a/atlas/tests/test_provision_resize_capacity.py
+++ b/atlas/tests/test_provision_resize_capacity.py
@@ -1,0 +1,88 @@
+"""`provision.resize_capacity` — Central's pre-resize capacity read.
+
+Unlike `capacity()` (the best host's free headroom for a NEW machine), a resize
+reshapes a VM in place on the host it already occupies. So the ceiling is THAT
+host's free room with the VM's own footprint added back — the VM can always keep
+its size or shrink, and grow into whatever else the host has spare. These tests pin
+that contract and the add-back arithmetic.
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.api import provision
+from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
+
+
+def _clean_virtual_machines() -> None:
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestProvisionResizeCapacity(IntegrationTestCase):
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		self.provider = make_provider("resize-capacity-provider")
+		for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
+			frappe.db.set_value("Server", name, "status", "Draining")
+		self.image = make_image("resize-capacity-image")
+
+	def _active_server(self, **totals):
+		server = make_server(
+			self.provider,
+			"resize-capacity-server",
+			size="DigitalOcean/s-4vcpu-8gb",
+			ipv6_address="2001:db8:9::1",
+			ipv6_prefix="2001:db8:9::/64",
+			ipv6_virtual_machine_range="2001:db8:9::/124",
+			status="Active",
+		)
+		server.db_set("vcpus_total", 0)
+		server.db_set("memory_megabytes_total", 0)
+		server.db_set("pool_disk_gigabytes_total", 0)
+		for field, value in totals.items():
+			server.db_set(field, value)
+		return server
+
+	def test_contract_shape(self) -> None:
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertEqual(set(result), {"available", "unmeasured", "largest_vm"})
+		self.assertEqual(set(result["largest_vm"]), {"vcpus", "memory_megabytes", "disk_gigabytes"})
+
+	def test_lone_vm_can_grow_to_the_whole_host(self) -> None:
+		# The only VM on the host: its ceiling is the host's full totals (its own footprint
+		# freed and re-reserved), so it can grow to fill the box.
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertTrue(result["available"])
+		self.assertFalse(result["unmeasured"])
+		self.assertEqual(result["largest_vm"], {"vcpus": 4, "memory_megabytes": 8192, "disk_gigabytes": 160})
+
+	def test_shares_host_with_a_neighbour(self) -> None:
+		# Host 4 / 8192 / 160; VM-A (resizing) 1 / 2048 / 40, neighbour VM-B 1 / 1024 / 20.
+		# VM-A's ceiling adds back only its OWN footprint: cpu 4-2+1=3, mem 8192-3072+2048=7168,
+		# disk 160-60+40=140 — the neighbour's reservation still stands.
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm_a = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=1024, disk_gigabytes=20)
+		result = provision.resize_capacity(vm_a.name)
+		self.assertEqual(result["largest_vm"], {"vcpus": 3, "memory_megabytes": 7168, "disk_gigabytes": 140})
+
+	def test_unmeasured_host_returns_sentinels(self) -> None:
+		# No agent totals and an uncatalogued size → every axis uncatalogued → unlimited.
+		server = self._active_server()
+		server.db_set("size", "Scaleway/EM-B130E-NVME")  # not in the CPU slug dict
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertTrue(result["available"])
+		self.assertTrue(result["unmeasured"])
+		self.assertGreaterEqual(result["largest_vm"]["vcpus"], 1024)
+
+	def test_unknown_vm_is_unavailable(self) -> None:
+		result = provision.resize_capacity("no-such-vm")
+		self.assertFalse(result["available"])
+		self.assertIsNone(result["largest_vm"])


### PR DESCRIPTION


Central gates its resize menu on live capacity, but a resize reshapes a VM in place on the host it already occupies — so the ceiling is that host's free room with the VM's own footprint added back, not the fleet best-host headroom used for a new machine.

- placement.resize_headroom(vm): effective - used + own per axis (clamped), same uncatalogued -> sentinel/unmeasured rule as largest_vm.
- provision.resize_capacity(vm): whitelisted, returns {available, unmeasured, largest_vm} like capacity(); the in-place twin of the create-time check.

This lets Central offer only resize targets that will actually fit, instead of letting an oversized resize (RAM especially) fail on the host — resize() itself has no capacity gate.