### PR TITLE
feat: Capacity gating - Serialise VM placement & gate resize against host capacity

### DIFF
--- a/atlas/atlas/api/provision.py
+++ b/atlas/atlas/api/provision.py
@@ -133,3 +133,31 @@ def capacity() -> dict:
 		"unmeasured": unmeasured,
 		"largest_vm": shape,
 	}
+
+
+@frappe.whitelist()
+def resize_capacity(vm: str) -> dict:
+	"""The largest shape `vm` can resize to on its current host — Central's pre-resize
+	check, the in-place twin of `capacity()`.
+
+	A resize reshapes the VM on the host it already occupies, so — unlike `capacity()`,
+	which sizes a NEW machine against the best host's free headroom — the ceiling is
+	THIS host's free room with the VM's own current footprint added back (a resize frees
+	it before re-reserving). The VM can therefore always keep its size or shrink; Central
+	offers only resize targets that will fit, so an oversized resize never fails on the
+	host.
+
+	Returns `{available, unmeasured, largest_vm}` in the same shape as `capacity()`:
+	`largest_vm` is `{vcpus, memory_megabytes, disk_gigabytes}`, null (and `available`
+	False) only when the VM or its host is unknown. `unmeasured` flags a host with an
+	unreported axis (sentinel numbers — treat the ceiling as "size unknown"). Advisory:
+	the resize path on the host is the authoritative gate. Runs with the Central token,
+	like `capacity()` / `create_vm`."""
+	from atlas.atlas.placement import resize_headroom
+
+	shape = resize_headroom(vm)
+	if shape is None:
+		return {"available": False, "unmeasured": False, "largest_vm": None}
+
+	unmeasured = shape.pop("unmeasured")
+	return {"available": True, "unmeasured": unmeasured, "largest_vm": shape}

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -643,6 +643,19 @@ class VirtualMachine(Document):
 				frappe.throw(
 					f"Data disk can only grow: {self.data_disk_gigabytes} GB → {new_data_disk} GB is a shrink"
 				)
+		# Authoritative capacity gate: reshape only into room the host actually has, under
+		# a per-host lock so a concurrent create/resize can't double-book it. This is the
+		# only capacity check on the resize path — without it an oversized grow over-commits
+		# the host and fails at boot instead of failing fast here.
+		from atlas.atlas.placement import ensure_resize_capacity
+
+		ensure_resize_capacity(
+			self,
+			new_cpu_cores=new_cpu_max,
+			new_memory_mb=new_memory,
+			new_disk_gb=new_disk + new_data_disk,
+		)
+
 		# Run the on-host resize first; run_task raises on failure, so we only
 		# persist the new values once the config and disk actually changed.
 		# Saving before the Task would let a failed resize-vm.py leave the doc

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -57,6 +57,19 @@ def _fits(axis: dict, need: float) -> bool:
 	return axis["effective"] is None or axis["used"] + need <= axis["effective"]
 
 
+def _lock_host(server: str) -> None:
+	"""Row-lock the host until the enclosing request commits, serialising placement onto it.
+
+	Capacity is *checked* (read the host's usage) and *consumed* (insert/resize the VM) as
+	two steps; without a lock between them, two concurrent callers both read the same free
+	room and both place on it (a check-then-act / TOCTOU race → an over-committed host that
+	fails at boot instead of a clean rejection). Every placement path — create
+	(`default_server`) and resize (`ensure_resize_capacity`) — takes this same `Server`-row
+	lock first, so the second caller blocks here, then re-reads usage and sees the first's
+	machine. Keyed by host, so placements onto *different* hosts still run in parallel."""
+	frappe.db.get_value("Server", server, "name", for_update=True)
+
+
 def default_server(
 	required_vcpus: float,
 	required_memory_mb: float,
@@ -77,26 +90,40 @@ def default_server(
 
 	Runs with ignore_permissions: this is system placement, not desk RBAC —
 	Central (the operator) triggers it without needing Server read access; the
-	system still has to choose one."""
+	system still has to choose one.
+
+	Concurrency-safe: candidates are scanned cheaply first, then the chosen host is
+	row-locked (`_lock_host`) and its usage re-read *under the lock* before we commit to
+	it — so two simultaneous creates can't both read the same free room and double-book a
+	host. The loser blocks on the lock, re-reads, sees the winner's VM, and moves on (or
+	raises). The lock is held to the request commit, which for a create is fast (the VM
+	insert enqueues provisioning; no slow host work runs inline)."""
 	from atlas.atlas.api.server_capacity import capacity_for_server
 
 	servers = frappe.get_all(
 		"Server",
 		filters={"status": "Active"},
 		pluck="name",
-		order_by="creation asc",
+		order_by="creation asc",  # consistent lock order → no deadlock between placers
 		ignore_permissions=True,
 	)
 	if not servers:
 		frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
-	for server in servers:
-		capacity = capacity_for_server(server)
-		if (
+
+	def fits(capacity: dict) -> bool:
+		return (
 			_fits(capacity["cpu"], required_vcpus)
 			and _fits(capacity["memory"], required_memory_mb)
 			and _fits(capacity["disk"], required_disk_gb)
-		):
+		)
+
+	for server in servers:
+		if not fits(capacity_for_server(server)):
+			continue  # cheap unlocked skip; the winner is re-checked under the lock below
+		_lock_host(server)
+		if fits(capacity_for_server(server)):  # authoritative re-read while holding the lock
 			return server
+		# A concurrent create won this host between the skip-check and the lock — try the next.
 	frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
 
 
@@ -219,6 +246,54 @@ def resize_headroom(vm: str) -> dict | None:
 		"disk_gigabytes": int(disk),
 		"unmeasured": not measured,
 	}
+
+
+def _resize_fits(axis: dict, own: float, need: float) -> bool:
+	"""Does a resized `need` fit on this axis, given the VM's own `own` footprint is freed
+	first? The write-side predicate of `resize_headroom`'s ceiling (`effective - used +
+	own`): an uncatalogued axis (`effective is None`) is unlimited → always fits, and the
+	VM can always keep its current size or shrink (`need <= own <= ceiling`)."""
+	ceiling, _ = _axis_ceiling(axis, own, float("inf"))
+	return need <= ceiling
+
+
+def ensure_resize_capacity(
+	virtual_machine,
+	*,
+	new_cpu_cores: float,
+	new_memory_mb: float,
+	new_disk_gb: float,
+) -> None:
+	"""Authoritative capacity gate for an in-place resize — the write-side twin of
+	`resize_headroom`, and the only capacity check on the resize path.
+
+	Locks the VM's host and checks the new shape fits with the VM's OWN current footprint
+	freed (a resize releases it before re-reserving), so a downsize or a same-size no-op
+	always passes and a grow is capped to the host's real free room. Without this, resize
+	has no gate at all: an oversized grow over-commits the host and fails at boot instead
+	of failing fast here. The lock is the same `Server`-row lock create takes, so a resize
+	and a create can't both consume the same free room. Raises NoCapacityError otherwise.
+
+	No-op when the VM has no host yet (nothing placed to resize), mirroring
+	`resize_headroom` returning None."""
+	from atlas.atlas.api.server_capacity import capacity_for_server
+
+	if not virtual_machine.server:
+		return
+	_lock_host(virtual_machine.server)
+	c = capacity_for_server(virtual_machine.server)
+	own_cpu = float(virtual_machine.cpu_max_cores or virtual_machine.vcpus or 0)
+	own_mem = float(virtual_machine.memory_megabytes or 0)
+	own_disk = float((virtual_machine.disk_gigabytes or 0) + (virtual_machine.data_disk_gigabytes or 0))
+	if not (
+		_resize_fits(c["cpu"], own_cpu, float(new_cpu_cores or 0))
+		and _resize_fits(c["memory"], own_mem, float(new_memory_mb or 0))
+		and _resize_fits(c["disk"], own_disk, float(new_disk_gb or 0))
+	):
+		frappe.throw(
+			_("Not enough capacity on this host to resize to that size — contact your operator."),
+			NoCapacityError,
+		)
 
 
 def apply_user_defaults(virtual_machine) -> None:

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -169,6 +169,58 @@ def largest_vm() -> dict | None:
 	return best[1]
 
 
+def _axis_ceiling(axis: dict, own: float, sentinel: float) -> tuple[float, bool]:
+	"""The most of one axis a VM already on this host can occupy after a resize, and
+	whether the axis is measured.
+
+	A resize reshapes the VM in place, freeing its OWN current usage before re-reserving
+	the new size — so the ceiling is the host's free room with that footprint added back:
+	`effective - (used - own)`, i.e. `effective - used + own` (clamped at 0). Uncatalogued
+	axis (`effective is None`) → the sentinel, flagged unmeasured."""
+	if axis["effective"] is None:
+		return sentinel, False
+	return max(0.0, axis["effective"] - axis["used"] + own), True
+
+
+def resize_headroom(vm: str) -> dict | None:
+	"""The largest shape `vm` can resize to on the host it already occupies, or None when
+	the VM (or its host) is unknown.
+
+	Unlike `largest_vm` — the best *other* host's free headroom for a NEW machine — a
+	resize stays on the VM's current host, so the ceiling is THAT host's free room with
+	the VM's own footprint added back (`_axis_ceiling`). This guarantees the VM can always
+	keep its size or shrink, and grow into whatever else the host has spare — so Central
+	can offer only resize targets that will actually fit, instead of letting an oversized
+	resize fail on the host. Returns `{vcpus, memory_megabytes, disk_gigabytes,
+	unmeasured}`, matching `largest_vm`'s shape; an unreported axis contributes a sentinel
+	and marks the shape `unmeasured`."""
+	from atlas.atlas.api.server_capacity import capacity_for_server
+
+	row = frappe.db.get_value(
+		"Virtual Machine",
+		vm,
+		["server", "vcpus", "cpu_max_cores", "memory_megabytes", "disk_gigabytes", "data_disk_gigabytes"],
+		as_dict=True,
+	)
+	if not row or not row.server:
+		return None
+
+	c = capacity_for_server(row.server)
+	own_cpu = float(row.cpu_max_cores or row.vcpus or 0)
+	own_mem = float(row.memory_megabytes or 0)
+	own_disk = float((row.disk_gigabytes or 0) + (row.data_disk_gigabytes or 0))
+	cpu, m_cpu = _axis_ceiling(c["cpu"], own_cpu, _UNMEASURED_VCPUS)
+	mem, m_mem = _axis_ceiling(c["memory"], own_mem, _UNMEASURED_MEMORY_MB)
+	disk, m_disk = _axis_ceiling(c["disk"], own_disk, _UNMEASURED_DISK_GB)
+	measured = m_cpu and m_mem and m_disk
+	return {
+		"vcpus": int(cpu),
+		"memory_megabytes": int(mem),
+		"disk_gigabytes": int(disk),
+		"unmeasured": not measured,
+	}
+
+
 def apply_user_defaults(virtual_machine) -> None:
 	"""Fill `server` and `image` on a VM that a user created without them.
 

--- a/atlas/tests/test_provision_resize_capacity.py
+++ b/atlas/tests/test_provision_resize_capacity.py
@@ -1,0 +1,88 @@
+"""`provision.resize_capacity` — Central's pre-resize capacity read.
+
+Unlike `capacity()` (the best host's free headroom for a NEW machine), a resize
+reshapes a VM in place on the host it already occupies. So the ceiling is THAT
+host's free room with the VM's own footprint added back — the VM can always keep
+its size or shrink, and grow into whatever else the host has spare. These tests pin
+that contract and the add-back arithmetic.
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.api import provision
+from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
+
+
+def _clean_virtual_machines() -> None:
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestProvisionResizeCapacity(IntegrationTestCase):
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		self.provider = make_provider("resize-capacity-provider")
+		for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
+			frappe.db.set_value("Server", name, "status", "Draining")
+		self.image = make_image("resize-capacity-image")
+
+	def _active_server(self, **totals):
+		server = make_server(
+			self.provider,
+			"resize-capacity-server",
+			size="DigitalOcean/s-4vcpu-8gb",
+			ipv6_address="2001:db8:9::1",
+			ipv6_prefix="2001:db8:9::/64",
+			ipv6_virtual_machine_range="2001:db8:9::/124",
+			status="Active",
+		)
+		server.db_set("vcpus_total", 0)
+		server.db_set("memory_megabytes_total", 0)
+		server.db_set("pool_disk_gigabytes_total", 0)
+		for field, value in totals.items():
+			server.db_set(field, value)
+		return server
+
+	def test_contract_shape(self) -> None:
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertEqual(set(result), {"available", "unmeasured", "largest_vm"})
+		self.assertEqual(set(result["largest_vm"]), {"vcpus", "memory_megabytes", "disk_gigabytes"})
+
+	def test_lone_vm_can_grow_to_the_whole_host(self) -> None:
+		# The only VM on the host: its ceiling is the host's full totals (its own footprint
+		# freed and re-reserved), so it can grow to fill the box.
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertTrue(result["available"])
+		self.assertFalse(result["unmeasured"])
+		self.assertEqual(result["largest_vm"], {"vcpus": 4, "memory_megabytes": 8192, "disk_gigabytes": 160})
+
+	def test_shares_host_with_a_neighbour(self) -> None:
+		# Host 4 / 8192 / 160; VM-A (resizing) 1 / 2048 / 40, neighbour VM-B 1 / 1024 / 20.
+		# VM-A's ceiling adds back only its OWN footprint: cpu 4-2+1=3, mem 8192-3072+2048=7168,
+		# disk 160-60+40=140 — the neighbour's reservation still stands.
+		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm_a = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=1024, disk_gigabytes=20)
+		result = provision.resize_capacity(vm_a.name)
+		self.assertEqual(result["largest_vm"], {"vcpus": 3, "memory_megabytes": 7168, "disk_gigabytes": 140})
+
+	def test_unmeasured_host_returns_sentinels(self) -> None:
+		# No agent totals and an uncatalogued size → every axis uncatalogued → unlimited.
+		server = self._active_server()
+		server.db_set("size", "Scaleway/EM-B130E-NVME")  # not in the CPU slug dict
+		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		result = provision.resize_capacity(vm.name)
+		self.assertTrue(result["available"])
+		self.assertTrue(result["unmeasured"])
+		self.assertGreaterEqual(result["largest_vm"]["vcpus"], 1024)
+
+	def test_unknown_vm_is_unavailable(self) -> None:
+		result = provision.resize_capacity("no-such-vm")
+		self.assertFalse(result["available"])
+		self.assertIsNone(result["largest_vm"])

--- a/atlas/tests/test_resize_capacity_gate.py
+++ b/atlas/tests/test_resize_capacity_gate.py
@@ -1,0 +1,104 @@
+"""`VirtualMachine.resize()` capacity gate (`placement.ensure_resize_capacity`).
+
+resize() reshapes a VM in place on its current host and — before this — had NO
+capacity check, so an oversized grow silently over-committed the host and failed at
+boot. The gate now caps a grow to the host's real free room (the VM's own footprint
+freed, so downsizes / no-ops always pass) and fails fast with NoCapacityError instead.
+run_task is mocked throughout — these pin the gate, not the on-host reshape.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_module
+from atlas.tests._mocks import fake_task
+from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
+
+
+def _clean_virtual_machines() -> None:
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestResizeCapacityGate(IntegrationTestCase):
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		self.provider = make_provider("resize-gate-provider")
+		for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
+			frappe.db.set_value("Server", name, "status", "Draining")
+		self.image = make_image("resize-gate-image")
+
+	def _host(self, **totals):
+		server = make_server(
+			self.provider,
+			"resize-gate-server",
+			size="DigitalOcean/s-4vcpu-8gb",
+			ipv6_address="2001:db8:a::1",
+			ipv6_prefix="2001:db8:a::/64",
+			ipv6_virtual_machine_range="2001:db8:a::/124",
+			status="Active",
+		)
+		server.db_set("vcpus_total", 0)
+		server.db_set("memory_megabytes_total", 0)
+		server.db_set("pool_disk_gigabytes_total", 0)
+		for field, value in totals.items():
+			server.db_set(field, value)
+		return server
+
+	def _stopped_vm(self, server, **shape):
+		vm = make_virtual_machine(server, self.image, **shape)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		return vm
+
+	def test_grow_beyond_host_is_rejected_before_host_work(self) -> None:
+		host = self._host(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = self._stopped_vm(host, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		with patch.object(vm_module, "run_task") as run:
+			with self.assertRaises(frappe.ValidationError) as raised:
+				vm.resize(memory_megabytes=16384)  # host only has 8192
+		self.assertIn("capacity", str(raised.exception).lower())
+		run.assert_not_called()  # the gate throws before any on-host reshape
+
+	def test_lone_vm_can_grow_into_the_whole_host(self) -> None:
+		host = self._host(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = self._stopped_vm(host, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		with patch.object(vm_module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=8192)  # its own 2048 freed + 6144 spare
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 8192)
+
+	def test_downsize_always_passes(self) -> None:
+		host = self._host(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = self._stopped_vm(host, vcpus=2, cpu_max_cores=2, memory_megabytes=4096, disk_gigabytes=40)
+		with patch.object(vm_module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=2048)
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 2048)
+
+	def test_neighbour_reservation_caps_the_grow(self) -> None:
+		# Host 8192; neighbour holds 4096, this VM holds 2048 → it can grow to 8192-4096 =
+		# 4096 (its own footprint freed), not beyond — the neighbour's claim still stands.
+		host = self._host(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
+		vm = self._stopped_vm(host, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		make_virtual_machine(host, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=4096, disk_gigabytes=20)
+		with patch.object(vm_module, "run_task") as run:
+			with self.assertRaises(frappe.ValidationError):
+				vm.resize(memory_megabytes=6000)
+		run.assert_not_called()
+		with patch.object(vm_module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=4096)  # exactly fills the host
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 4096)
+
+	def test_uncatalogued_host_allows_any_grow(self) -> None:
+		# No agent totals → memory axis uncatalogued → unlimited (operator vouched by Active).
+		host = self._host()
+		vm = self._stopped_vm(host, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		with patch.object(vm_module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=65536)
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 65536)


### PR DESCRIPTION
Problem

Capacity was checked (read a host's free room) and consumed (insert/resize the VM) as two separate steps with no lock between them — a classic check-then-act (TOCTOU) race. Two users A and B could both load the plan menu, both see "2 vCPU / 4 GB fits" on a host with exactly that free, both submit, and:

- Create: each request reads its own snapshot (REPEATABLE READ), neither sees the other's VM, both inserts commit → the host is over-committed. RAM is a hard fit, so the failure surfaces later, at boot (OOM / VM won't start) instead of as a clean rejection.
- Resize: worse — VirtualMachine.resize() had no capacity check at all. It validated status/disk-shrink and went straight to the on-host reshape, so any oversized grow over-committed the host.

"Who wins?" was non-deterministic, and the loser often thought they'd succeeded, then died at boot.

Fix

A single primitive — a per-Server FOR UPDATE row lock (placement._lock_host) — that every placement path takes before reading usage and committing. The second caller blocks on it, then re-reads usage and sees the winner's machine. Keyed by host, so placements onto different hosts still run in parallel.

1. default_server (create) — optimistic scan + locked re-check
scan candidates unlocked (cheap skip)
→ lock the chosen host
→ re-read its usage UNDER the lock
→ still fits? place; else try the next host
A create is a single transaction with no inline host work (provisioning is enqueued after_commit), so the lock is held to the request commit. This fully serializes create-vs-create: the loser blocks, re-reads, and gets a clean NoCapacityError. Candidates are locked in creation asc order → no deadlock.

2. resize() — the missing authoritative gate
New placement.ensure_resize_capacity(vm, …) runs before any host work, under the same per-host lock. It caps the new shape to the host's real free room with the VM's own footprint added back (effective − used + own — the write-side twin of resize_headroom), so:
- a downsize or no-op always passes (need ≤ own ≤ ceiling),
- an oversized grow fails fast with NoCapacityError instead of at boot,
- an uncatalogued axis (operator-vouched, no reported total) stays unlimited.

Known limitation (deliberately scoped) — please review

resize()'s on-host step (run_task → _execute_into) commits mid-method (durability of the Task row). A transaction-scoped FOR UPDATE is released by that commit, so the lock does not span the full resize apply. Net effect:

- ✅ create-vs-create — fully serialized (single transaction).
- ✅ create-vs-resize and sequential resizes — the resize gate re-reads under the lock and rejects correctly.
- ⚠️ two simultaneous resizes on the same host — narrowed (both are gated) but not 100% serialized, because neither has persisted its new size before run_task's commit releases the lock.