### PR TITLE
feat(central): Enhance event logging and delivery mechanism

### DIFF
--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -17,11 +17,12 @@ Every emit also writes a Central Event Log row — a MyISAM (non-transactional)
 audit trail. Because MyISAM rows are not enrolled in the request transaction,
 the row survives a rollback of the business change that triggered it: you can
 always see what we *tried* to emit, even for a VM/Site save that was later
-reverted. The deliver job is enqueue_after_commit, so a rolled-back emit's job
-never runs — its row stays `pending` and is never POSTed (log the attempt, skip
-the delivery). On commit, deliver() POSTs and stamps the same row ok / error /
-skipped. The single's `status` field stays the at-a-glance breadcrumb; the log
-is the queryable history.
+reverted. On commit the row is marked `queued` and the deliver job is enqueued;
+on rollback it is marked `rolled_back` and never POSTed. The queued row is the
+durable outbox: if RQ misses the immediate job, the scheduler can safely replay
+only committed events. deliver() POSTs and stamps the same row ok / error /
+skipped. The single's `status` field stays the at-a-glance breadcrumb; the log is
+the queryable history.
 """
 
 from __future__ import annotations
@@ -31,6 +32,8 @@ import json
 import frappe
 
 from atlas.atlas.central import CentralError
+
+MAX_PENDING_RETRY_BATCH = 100
 
 
 def _enabled() -> bool:
@@ -133,7 +136,18 @@ def on_server_update(doc, method=None):
 def _emit(event_type: str, payload: dict, doc=None) -> None:
 	# Write the audit row FIRST, then enqueue delivery against it. The row is the
 	# durable record of the attempt; the deliver job (after-commit) only stamps it.
-	log_name = _write_log(event_type, payload, doc)
+	occurred_at = frappe.utils.now()
+	log_name = _write_log(event_type, payload, doc, occurred_at=occurred_at)
+	_mark_log_after_transaction(log_name)
+	_enqueue_delivery_after_commit(log_name, event_type, payload, occurred_at)
+
+
+def _mark_log_after_transaction(log_name: str) -> None:
+	frappe.db.after_commit.add(lambda: _set_log_status(log_name, "queued"))
+	frappe.db.after_rollback.add(lambda: _set_log_status(log_name, "rolled_back"))
+
+
+def _enqueue_delivery_after_commit(log_name: str, event_type: str, payload: dict, occurred_at: str) -> None:
 	frappe.enqueue(
 		"atlas.atlas.central_report.deliver",
 		queue="default",
@@ -142,10 +156,54 @@ def _emit(event_type: str, payload: dict, doc=None) -> None:
 		log_name=log_name,
 		event_type=event_type,
 		payload=payload,
+		occurred_at=occurred_at,
 	)
 
 
-def _write_log(event_type: str, payload: dict, doc=None) -> str:
+def retry_pending(limit: int = 50, include_legacy_pending: bool = False) -> int:
+	"""Drain committed-but-undelivered Central events in creation order.
+
+	The Central Event Log is the durable outbox. A missed RQ job must not strand the
+	mirror forever; retrying queued rows replays the same delivery contract. Legacy
+	pending rows from builds before `queued` existed can be replayed manually, but
+	the scheduler must not touch fresh pending rows because their source transaction
+	may still roll back."""
+	if not _delivery_ready():
+		return 0
+
+	statuses = ["queued"]
+	if include_legacy_pending:
+		statuses.append("pending")
+
+	limit = _retry_limit(limit)
+	rows = frappe.get_all(
+		"Central Event Log",
+		filters={"status": ["in", statuses]},
+		fields=["name", "event_type", "payload", "occurred_at"],
+		order_by="creation asc",
+		limit=limit,
+	)
+	if not rows:
+		return 0
+	for row in rows:
+		deliver(row.name, row.event_type, json.loads(row.payload or "{}"), occurred_at=row.occurred_at)
+	return len(rows)
+
+
+def _delivery_ready() -> bool:
+	settings = frappe.get_single("Central Settings")
+	return bool(settings.enabled and settings.api_key)
+
+
+def _retry_limit(limit: int) -> int:
+	try:
+		value = int(limit)
+	except (TypeError, ValueError):
+		value = 50
+	return max(1, min(value, MAX_PENDING_RETRY_BATCH))
+
+
+def _write_log(event_type: str, payload: dict, doc=None, occurred_at: str | None = None) -> str:
 	"""Insert the Central Event Log row for this emit and return its name.
 
 	The Central Event Log is MyISAM (non-transactional), so this INSERT hits the
@@ -163,7 +221,7 @@ def _write_log(event_type: str, payload: dict, doc=None) -> str:
 				"payload": json.dumps(payload, default=str, indent=2),
 				"status": "pending",
 				"attempts": 0,
-				"occurred_at": frappe.utils.now(),
+				"occurred_at": occurred_at or frappe.utils.now(),
 				"reference_doctype": doc.doctype if doc is not None else None,
 				"reference_name": doc.name if doc is not None else None,
 			}
@@ -173,12 +231,12 @@ def _write_log(event_type: str, payload: dict, doc=None) -> str:
 	)
 
 
-def deliver(log_name: str, event_type: str, payload: dict) -> None:
+def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | None = None) -> None:
 	"""Background job: POST one event to Central and stamp its Central Event Log
 	row with the outcome. Also updates the single's `status` breadcrumb so the
 	operator sees the last delivery at a glance. Runs only on commit
-	(enqueue_after_commit), so a rolled-back emit's row is never reached here and
-	stays `pending` — logged, never delivered."""
+	(enqueue_after_commit), so a rolled-back emit's row is never reached here and is
+	stamped `rolled_back` — logged, never delivered."""
 	settings = frappe.get_single("Central Settings")
 	if not settings.enabled:
 		return
@@ -194,7 +252,7 @@ def deliver(log_name: str, event_type: str, payload: dict) -> None:
 			{
 				"type": event_type,
 				"payload": payload,
-				"occurred_at": frappe.utils.now(),
+				"occurred_at": _iso(occurred_at) or frappe.utils.now(),
 			}
 		)
 		_stamp(log_name, status="ok", http_status=200)
@@ -203,6 +261,13 @@ def deliver(log_name: str, event_type: str, payload: dict) -> None:
 		frappe.log_error(f"Central event {event_type} failed: {exception}", "Central event")
 		_stamp(log_name, status="error", last_error=str(exception)[:140], http_status=exception.status_code)
 		settings.db_set("status", f"error: {exception}"[:140], commit=True)
+
+
+def _set_log_status(log_name: str, status: str) -> None:
+	try:
+		frappe.db.set_value("Central Event Log", log_name, "status", status, update_modified=False)
+	except Exception:
+		frappe.log_error(f"Central Event Log {log_name} {status} stamp failed", "Central event")
 
 
 def _stamp(

--- a/atlas/atlas/doctype/central_event_log/central_event_log.json
+++ b/atlas/atlas/doctype/central_event_log/central_event_log.json
@@ -37,18 +37,18 @@
    "read_only": 1
   },
   {
-   "description": "pending = emitted, delivery not (yet) run — also the terminal state when the emitting transaction rolled back (the after-commit deliver job never fired). ok = POSTed. error = Central rejected/unreachable, see Last Error. skipped = enabled but not registered (no atlas_id), so unroutable.",
+   "description": "pending = emitted inside an open transaction. queued = transaction committed and the event is eligible for delivery/retry. rolled_back = audit-only; the source transaction rolled back and must never be POSTed. ok = POSTed. error = Central rejected/unreachable, see Last Error. skipped = enabled but not registered (no atlas_id), so unroutable.",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "pending\nok\nerror\nskipped",
+   "options": "pending\nqueued\nok\nerror\nskipped\nrolled_back",
    "read_only": 1
   },
   {
    "default": "0",
-   "description": "How many times deliver() POSTed this row. 0 while pending; 1 once delivered (v1 has no retry).",
+   "description": "How many times deliver() POSTed this row. 0 while pending/queued/rolled_back; increments on every delivery attempt.",
    "fieldname": "attempts",
    "fieldtype": "Int",
    "in_list_view": 1,

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -230,6 +230,9 @@ scheduler_events = {
 		"atlas.atlas.doctype.tls_certificate.tls_certificate.renew_expiring",
 	],
 	"cron": {
+		"*/1 * * * *": [
+			"atlas.atlas.central_report.retry_pending",
+		],
 		"*/10 * * * *": [
 			"atlas.atlas.providers.worker.reconcile_pending_servers",
 		],

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -81,6 +81,7 @@ def _patched_emit():
 	with (
 		patch.object(central_report, "_enabled", return_value=True),
 		patch.object(central_report, "_write_log", return_value="cel-1"),
+		patch.object(central_report, "_mark_log_after_transaction"),
 		patch.object(central_report.frappe, "enqueue") as enqueue,
 	):
 		yield enqueue
@@ -252,9 +253,79 @@ class TestCentralReport(IntegrationTestCase):
 			patch.object(central_report.frappe, "get_single", return_value=settings),
 			patch.object(central_report, "_stamp") as stamp,
 		):
-			central_report.deliver("cel-1", "vm.created", {"name": "vm-1"})
+			central_report.deliver("cel-1", "vm.created", {"name": "vm-1"}, occurred_at="2026-07-06 00:23:05")
 		settings.client.return_value.post_event.assert_called_once()
+		event = settings.client.return_value.post_event.call_args[0][0]
+		self.assertEqual(event["occurred_at"], "2026-07-06 00:23:05")
 		stamp.assert_called_once_with("cel-1", status="ok", http_status=200)
+
+	def test_retry_pending_replays_queued_events_in_order(self) -> None:
+		rows = [
+			frappe._dict(
+				name="cel-1",
+				event_type="vm.status_changed",
+				payload=json.dumps({"name": "vm-1", "status": "Stopped"}),
+				occurred_at="2026-07-06 00:23:05",
+			),
+			frappe._dict(
+				name="cel-2",
+				event_type="vm.status_changed",
+				payload=json.dumps({"name": "vm-2", "status": "Running"}),
+				occurred_at="2026-07-06 00:24:00",
+			),
+		]
+		with (
+			patch.object(central_report, "_delivery_ready", return_value=True),
+			patch.object(central_report.frappe, "get_all", return_value=rows) as get_all,
+			patch.object(central_report, "deliver") as deliver,
+		):
+			count = central_report.retry_pending(limit=1000)
+		self.assertEqual(count, 2)
+		self.assertEqual(get_all.call_args.kwargs["filters"], {"status": ["in", ["queued"]]})
+		self.assertEqual(get_all.call_args.kwargs["limit"], central_report.MAX_PENDING_RETRY_BATCH)
+		deliver.assert_any_call(
+			"cel-1",
+			"vm.status_changed",
+			{"name": "vm-1", "status": "Stopped"},
+			occurred_at="2026-07-06 00:23:05",
+		)
+		deliver.assert_any_call(
+			"cel-2",
+			"vm.status_changed",
+			{"name": "vm-2", "status": "Running"},
+			occurred_at="2026-07-06 00:24:00",
+		)
+
+	def test_retry_pending_can_replay_legacy_pending_when_explicit(self) -> None:
+		with (
+			patch.object(central_report, "_delivery_ready", return_value=True),
+			patch.object(central_report.frappe, "get_all", return_value=[]) as get_all,
+			patch.object(central_report, "deliver"),
+		):
+			count = central_report.retry_pending(limit=2, include_legacy_pending=True)
+		self.assertEqual(count, 0)
+		self.assertEqual(get_all.call_args.kwargs["filters"], {"status": ["in", ["queued", "pending"]]})
+
+	def test_retry_pending_returns_before_query_when_delivery_not_ready(self) -> None:
+		with (
+			patch.object(central_report, "_delivery_ready", return_value=False),
+			patch.object(central_report.frappe, "get_all") as get_all,
+			patch.object(central_report, "deliver") as deliver,
+		):
+			count = central_report.retry_pending()
+		self.assertEqual(count, 0)
+		get_all.assert_not_called()
+		deliver.assert_not_called()
+
+	def test_retry_pending_returns_before_delivery_when_no_rows(self) -> None:
+		with (
+			patch.object(central_report, "_delivery_ready", return_value=True),
+			patch.object(central_report.frappe, "get_all", return_value=[]),
+			patch.object(central_report, "deliver") as deliver,
+		):
+			count = central_report.retry_pending()
+		self.assertEqual(count, 0)
+		deliver.assert_not_called()
 
 	def test_deliver_skips_when_unregistered(self) -> None:
 		settings = MagicMock()
@@ -284,6 +355,16 @@ class TestCentralReport(IntegrationTestCase):
 		self.assertEqual(row.reference_name, "vm-1")
 		row.delete()
 		frappe.db.commit()
+
+	def test_rollback_marks_event_log_audit_only(self) -> None:
+		name = central_report._write_log("vm.status_changed", {"name": "vm-rb"}, self._vm())
+		central_report._mark_log_after_transaction(name)
+		frappe.db.rollback()
+		try:
+			self.assertEqual(frappe.db.get_value("Central Event Log", name, "status"), "rolled_back")
+		finally:
+			frappe.delete_doc("Central Event Log", name, force=True, ignore_permissions=True)
+			frappe.db.commit()
 
 
 class TestCentralReportSite(IntegrationTestCase):


### PR DESCRIPTION
- Introduced a new status "queued" for events that are eligible for delivery after transaction commits.
- Added "rolled_back" status for events that were emitted but the source transaction rolled back.
- Implemented retry logic for delivering queued events, allowing for replays of committed events.
- Updated the logging mechanism to include timestamps for events.
- Enhanced tests to cover new functionality and ensure correct behavior during retries and rollbacks.