### PR TITLE
feat(placement): load-aware host selection (part 1) for the proportional size ladder

### DIFF
--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -69,6 +69,43 @@ def host_memory_reserve_megabytes() -> int:
 	return int(value) if value is not None else 1024
 
 
+# The per-VM columns every capacity sum charges against a host, on all three axes.
+_VM_COST_FIELDS = (
+	"vcpus",
+	"cpu_max_cores",
+	"memory_megabytes",
+	"disk_gigabytes",
+	"data_disk_gigabytes",
+)
+
+
+def _incoming_migration_vms(server: str) -> list:
+	"""Cost rows for the VMs migrating INTO `server` but not yet cut over.
+
+	A non-terminal `Virtual Machine Migration` with `target_server == server` means
+	the target is already hydrating that VM's disk and will boot it; its `vm.server`
+	still names the source until Repointing, so `capacity_for_server`'s resident query
+	misses it. Return the same `_VM_COST_FIELDS` shape so it sums alongside the
+	resident VMs. Skips any whose `server` is already this host (defensive against a
+	just-repointed row) so a VM is never counted twice on the same host."""
+	from atlas.atlas.doctype.virtual_machine_migration.virtual_machine_migration import (
+		TERMINAL_STATUSES,
+	)
+
+	names = frappe.get_all(
+		"Virtual Machine Migration",
+		filters={"target_server": server, "status": ["not in", TERMINAL_STATUSES]},
+		pluck="virtual_machine",
+	)
+	if not names:
+		return []
+	return frappe.get_all(
+		"Virtual Machine",
+		filters={"name": ["in", names], "server": ["!=", server], "status": ["!=", "Terminated"]},
+		fields=list(_VM_COST_FIELDS),
+	)
+
+
 def _axis(total: float | None, effective: float | None, used: float) -> dict:
 	"""A per-resource capacity block.
 
@@ -131,17 +168,21 @@ def capacity_for_server(server: str) -> dict:
 	memory_total = int(s["memory_megabytes_total"]) if s.get("memory_megabytes_total") else None
 	disk_total = int(s["pool_disk_gigabytes_total"]) if s.get("pool_disk_gigabytes_total") else None
 
-	vms = frappe.get_all(
+	resident = frappe.get_all(
 		"Virtual Machine",
 		filters={"server": server, "status": ["!=", "Terminated"]},
-		fields=[
-			"vcpus",
-			"cpu_max_cores",
-			"memory_megabytes",
-			"disk_gigabytes",
-			"data_disk_gigabytes",
-		],
+		fields=list(_VM_COST_FIELDS),
 	)
+	# A VM migrating INTO this host is already spending its budget here: the target
+	# hydrates the disk and boots the guest before cutover repoints `vm.server`
+	# (spec/24). Until then `vm.server` still names the source, so the resident query
+	# misses it — count it against the target too, or placement would double-book a
+	# host that is receiving migrations (including the consolidation moves placement
+	# itself starts, spec/25). The source keeps counting it (it still runs there until
+	# cutover): a migrating VM is deliberately charged to BOTH hosts for its brief
+	# life, the safe direction for a capacity gate.
+	incoming = _incoming_migration_vms(server)
+	vms = resident + incoming
 	factor = overprovision_factor()
 	# Memory: hard fit, but never packable to the full physical total — the host OS
 	# + per-VM VMM overhead live in the same RAM, so effective = total − reserve
@@ -175,7 +216,11 @@ def capacity_for_server(server: str) -> dict:
 		"share_units": share["share_units"] if share else None,
 		"stranded": share["stranded"] if share else None,
 		"pool_data_percent": s.get("pool_data_percent"),  # advisory alert signal
-		"virtual_machine_count": len(vms),
+		"virtual_machine_count": len(resident),
+		# VMs migrating in but not yet cut over — counted in `used` above, surfaced
+		# separately so the operator can see why a host reads fuller than its resident
+		# VM list.
+		"incoming_migration_count": len(incoming),
 	}
 
 

--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -23,7 +23,11 @@ slug→vCPU dict, so vCPU accounting keeps working on hosts catalogued the old w
 before the agent reports.
 """
 
+import math
+
 import frappe
+
+from atlas.atlas.sizes import SHARE_UNIT
 
 # vCPUs per DigitalOcean size slug. Legacy fallback for the CPU axis when the
 # agent hasn't stamped `vcpus_total`. Hand-maintained; a missing slug (and no
@@ -51,6 +55,18 @@ def overprovision_factor() -> float:
 	and disk are hard fits."""
 	value = frappe.db.get_single_value("Atlas Settings", "overprovision_factor")
 	return float(value) if value else 1.0
+
+
+def host_memory_reserve_megabytes() -> int:
+	"""MB carved off every host's memory budget before placement/resize accounting.
+
+	`Atlas Settings.host_memory_reserve_megabytes`, default 1024 when unset. Guest
+	RAM must never pack to 100% of MemTotal: the host OS, per-VM Firecracker/jailer
+	overhead, and thin-pool metadata live in the same RAM, so packing to MemTotal
+	OOMs the host. Subtracted from the memory axis's effective budget only (the raw
+	`total` stays physical); CPU and disk are unaffected. An explicit 0 disables it."""
+	value = frappe.db.get_single_value("Atlas Settings", "host_memory_reserve_megabytes")
+	return int(value) if value is not None else 1024
 
 
 def _axis(total: float | None, effective: float | None, used: float) -> dict:
@@ -127,26 +143,71 @@ def capacity_for_server(server: str) -> dict:
 		],
 	)
 	factor = overprovision_factor()
+	# Memory: hard fit, but never packable to the full physical total — the host OS
+	# + per-VM VMM overhead live in the same RAM, so effective = total − reserve
+	# (clamped ≥ 0). The raw total stays physical for display.
+	memory_reserve = host_memory_reserve_megabytes()
+	memory_effective = max(0, memory_total - memory_reserve) if memory_total is not None else None
+	cpu_axis = _axis(
+		total=vcpus_total,
+		effective=(vcpus_total * factor) if vcpus_total is not None else None,
+		used=sum(float(v.cpu_max_cores or v.vcpus or 0) for v in vms),
+	)
+	memory_axis = _axis(
+		total=memory_total,
+		effective=memory_effective,  # total − host_memory_reserve, no oversubscription
+		used=sum(int(v.memory_megabytes or 0) for v in vms),
+	)
+	disk_axis = _axis(
+		total=disk_total,
+		effective=disk_total,  # no oversubscription
+		used=sum(int(v.disk_gigabytes or 0) + int(v.data_disk_gigabytes or 0) for v in vms),
+	)
+	share = _share_units(cpu_axis, memory_axis, disk_axis)
 	return {
 		"server": server,
 		"size": size,
-		"cpu": _axis(
-			total=vcpus_total,
-			effective=(vcpus_total * factor) if vcpus_total is not None else None,
-			used=sum(float(v.cpu_max_cores or v.vcpus or 0) for v in vms),
-		),
-		"memory": _axis(
-			total=memory_total,
-			effective=memory_total,  # no oversubscription
-			used=sum(int(v.memory_megabytes or 0) for v in vms),
-		),
-		"disk": _axis(
-			total=disk_total,
-			effective=disk_total,  # no oversubscription
-			used=sum(int(v.disk_gigabytes or 0) + int(v.data_disk_gigabytes or 0) for v in vms),
-		),
+		"cpu": cpu_axis,
+		"memory": memory_axis,
+		"disk": disk_axis,
+		# Share-unit view of this host (None when no axis is measured) — how many
+		# Shared-1x slots fit, how many are used, and what each axis strands.
+		"share_units": share["share_units"] if share else None,
+		"stranded": share["stranded"] if share else None,
 		"pool_data_percent": s.get("pool_data_percent"),  # advisory alert signal
 		"virtual_machine_count": len(vms),
+	}
+
+
+def _share_units(cpu_axis: dict, memory_axis: dict, disk_axis: dict) -> dict | None:
+	"""The share-unit view of a host: sellable Shared-1x slots and per-axis stranding.
+
+	One share unit is `sizes.SHARE_UNIT` (a Shared 1x). Because every preset is an
+	exact whole-number multiple of it (spec/24), a host holds
+	`floor(min over measured axes of effective/unit)` units, and any mix of preset
+	VMs whose unit-sum ≤ that fits — packing is one-dimensional. `used` is the max
+	over measured axes of `ceil(used/unit)` (the binding axis, rounded up so a
+	partly-used unit is spent). `stranded` per measured axis is
+	`effective − units_total × unit_cost`: the resources the *bottleneck* axis makes
+	unsellable at full subscription — the shape-mismatch waste an operator compares
+	host shapes by. Reporting only, never a placement input. Returns None when no
+	axis is measured (nothing to count against)."""
+	priced = {
+		"cpu": (cpu_axis, SHARE_UNIT["cpu_max_cores"]),
+		"memory": (memory_axis, SHARE_UNIT["memory_megabytes"]),
+		"disk": (disk_axis, SHARE_UNIT["disk_gigabytes"]),
+	}
+	measured = {
+		key: (axis, unit) for key, (axis, unit) in priced.items() if axis["effective"] is not None
+	}
+	if not measured:
+		return None
+	total = min(int(axis["effective"] // unit) for axis, unit in measured.values())
+	used = max((math.ceil(axis["used"] / unit) for axis, unit in measured.values()), default=0)
+	stranded = {key: axis["effective"] - total * unit for key, (axis, unit) in measured.items()}
+	return {
+		"share_units": {"total": total, "used": used, "free": total - used},
+		"stranded": stranded,
 	}
 
 
@@ -186,11 +247,38 @@ def cluster_capacity() -> dict:
 		order_by="creation asc",
 	)
 	servers = [capacity_for_server(name) for name in names]
+	fleet_share = _sum_share_units(servers)
 	return {
 		"server_count": len(servers),
 		"cpu": _sum_axis(servers, "cpu"),
 		"memory": _sum_axis(servers, "memory"),
 		"disk": _sum_axis(servers, "disk"),
+		# Fleet share-unit roll-up (None when no server is measured): summed sellable
+		# slots and stranded resources across measured hosts — the shape-comparison
+		# line the operator reads to decide what host shapes to buy next.
+		"share_units": fleet_share["share_units"] if fleet_share else None,
+		"stranded": fleet_share["stranded"] if fleet_share else None,
 		"virtual_machine_count": sum(s["virtual_machine_count"] for s in servers),
 		"servers": servers,
+	}
+
+
+def _sum_share_units(servers: list[dict]) -> dict | None:
+	"""Fleet roll-up of per-server share units + stranded resources.
+
+	Sums only servers with a measured `share_units` block; an uncatalogued host is
+	unlimited and uncountable, so it is left out (the totals are a floor, like
+	`_sum_axis`). Returns None when no server is measured."""
+	measured = [s for s in servers if s.get("share_units")]
+	if not measured:
+		return None
+	total = sum(s["share_units"]["total"] for s in measured)
+	used = sum(s["share_units"]["used"] for s in measured)
+	stranded: dict[str, float] = {}
+	for s in measured:
+		for axis_key, value in s["stranded"].items():
+			stranded[axis_key] = stranded.get(axis_key, 0) + value
+	return {
+		"share_units": {"total": total, "used": used, "free": total - used},
+		"stranded": stranded,
 	}

--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -178,7 +178,7 @@ def capacity_for_server(server: str) -> dict:
 	# (spec/24). Until then `vm.server` still names the source, so the resident query
 	# misses it — count it against the target too, or placement would double-book a
 	# host that is receiving migrations (including the consolidation moves placement
-	# itself starts, spec/25). The source keeps counting it (it still runs there until
+	# itself starts, spec/28). The source keeps counting it (it still runs there until
 	# cutover): a migrating VM is deliberately charged to BOTH hosts for its brief
 	# life, the safe direction for a capacity gate.
 	incoming = _incoming_migration_vms(server)

--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -183,7 +183,7 @@ def _share_units(cpu_axis: dict, memory_axis: dict, disk_axis: dict) -> dict | N
 	"""The share-unit view of a host: sellable Shared-1x slots and per-axis stranding.
 
 	One share unit is `sizes.SHARE_UNIT` (a Shared 1x). Because every preset is an
-	exact whole-number multiple of it (spec/24), a host holds
+	exact whole-number multiple of it (spec/28), a host holds
 	`floor(min over measured axes of effective/unit)` units, and any mix of preset
 	VMs whose unit-sum ≤ that fits — packing is one-dimensional. `used` is the max
 	over measured axes of `ceil(used/unit)` (the binding axis, rounded up so a

--- a/atlas/atlas/doctype/atlas_settings/atlas_settings.json
+++ b/atlas/atlas/doctype/atlas_settings/atlas_settings.json
@@ -141,7 +141,7 @@
    "fieldtype": "Check",
    "label": "Consolidate on No-Capacity",
    "default": "1",
-   "description": "When placing a NEW VM finds no host with room, migrate a few small VMs off one host onto others to free a contiguous slot (defragmentation-on-arrival, spec/25 case 3). The migrations run in the background; the create is told to retry (ConsolidationInProgressError) and lands once room appears. Off = fail loud with NoCapacityError instead. Only ever moves small VMs that are safe to move (no attached public IPv4, no in-flight migration, same provider as the target)."
+   "description": "When placing a NEW VM finds no host with room, migrate a few small VMs off one host onto others to free a contiguous slot (defragmentation-on-arrival, spec/28 case 3). The migrations run in the background; the create is told to retry (ConsolidationInProgressError) and lands once room appears. Off = fail loud with NoCapacityError instead. Only ever moves small VMs that are safe to move (no attached public IPv4, no in-flight migration, same provider as the target)."
   },
   {
    "fieldname": "max_consolidation_migrations",

--- a/atlas/atlas/doctype/atlas_settings/atlas_settings.json
+++ b/atlas/atlas/doctype/atlas_settings/atlas_settings.json
@@ -21,6 +21,8 @@
   "overprovision_factor",
   "placement_headroom_percent",
   "host_memory_reserve_megabytes",
+  "placement_consolidation_enabled",
+  "max_consolidation_migrations",
   "section_break_tcp_proxy",
   "tcp_port_pool",
   "section_break_ssh",
@@ -133,6 +135,21 @@
    "default": "1024",
    "non_negative": 1,
    "description": "Subtracted from each host's memory budget before placement and resize accounting (effective = total − reserve, clamped ≥ 0). Guest RAM must never pack to 100% of MemTotal — the host OS, per-VM Firecracker/jailer overhead, and thin-pool metadata live there too, and packing to MemTotal OOMs the host."
+  },
+  {
+   "fieldname": "placement_consolidation_enabled",
+   "fieldtype": "Check",
+   "label": "Consolidate on No-Capacity",
+   "default": "1",
+   "description": "When placing a NEW VM finds no host with room, migrate a few small VMs off one host onto others to free a contiguous slot (defragmentation-on-arrival, spec/25 case 3). The migrations run in the background; the create is told to retry (ConsolidationInProgressError) and lands once room appears. Off = fail loud with NoCapacityError instead. Only ever moves small VMs that are safe to move (no attached public IPv4, no in-flight migration, same provider as the target)."
+  },
+  {
+   "fieldname": "max_consolidation_migrations",
+   "fieldtype": "Int",
+   "label": "Max Consolidation Migrations",
+   "default": "3",
+   "non_negative": 1,
+   "description": "The most VMs a single consolidation pass may move to free room for one arrival — the \"a few\" in \"migrate a few small VMs\". A plan that would need more moves than this on every host is rejected and the arrival fails with NoCapacityError. Keeps defragmentation bounded so a full fleet can't trigger a migration storm."
   },
   {
    "fieldname": "section_break_tcp_proxy",

--- a/atlas/atlas/doctype/atlas_settings/atlas_settings.json
+++ b/atlas/atlas/doctype/atlas_settings/atlas_settings.json
@@ -17,7 +17,10 @@
   "default_user_image",
   "default_bench_snapshot",
   "section_break_capacity",
+  "placement_strategy",
   "overprovision_factor",
+  "placement_headroom_percent",
+  "host_memory_reserve_megabytes",
   "section_break_tcp_proxy",
   "tcp_port_pool",
   "section_break_ssh",
@@ -100,12 +103,36 @@
    "label": "Capacity"
   },
   {
+   "fieldname": "placement_strategy",
+   "fieldtype": "Select",
+   "label": "Placement Strategy",
+   "options": "Spread\nBest Fit\nTetris\nFirst Fit\nHybrid",
+   "default": "Spread",
+   "description": "How the controller picks a host for a new VM among those that fit. Spread (default): the emptiest by relative fill — best blast radius + burst/resize headroom, fewest forced resize-migrations. Best Fit: the fullest — keeps hosts drainable and best Dedicated acceptance, but many resize-migrations. Tetris: best shape match (dot-product alignment) — least stranding on mixed hosts. First Fit: creation order — cheapest, most fragmenting. Hybrid: Dedicated-class VMs Best Fit, the rest Spread — a middle ground that improves Dedicated acceptance over Spread at a small migration cost (it does NOT reduce migrations). On the proportional size ladder with uniform hosts Spread/Tetris coincide; compare them offline with atlas.atlas.packing_sim."
+  },
+  {
    "fieldname": "overprovision_factor",
    "fieldtype": "Float",
    "label": "Overprovision Factor",
    "default": "1",
    "non_negative": 1,
    "description": "Fleet-wide vCPU oversubscription multiplier. A host's effective vCPU budget is its physical total times this factor; placement (and the capacity display) check against that budget. 1 = no oversubscription. Servers whose size has no known vCPU total are unaffected — they are always treated as having room."
+  },
+  {
+   "fieldname": "placement_headroom_percent",
+   "fieldtype": "Percent",
+   "label": "Placement Headroom Percent",
+   "default": "0",
+   "non_negative": 1,
+   "description": "Fleet-wide arrival fill ceiling: the fraction of each measured axis that placing a NEW VM must leave free, so a later in-place resize has room to grow without a migration. 0 = pack to 100%. A per-server value > 0 overrides this for that host; resize itself ignores the reserve and spends it (that is what it is for)."
+  },
+  {
+   "fieldname": "host_memory_reserve_megabytes",
+   "fieldtype": "Int",
+   "label": "Host Memory Reserve (MB)",
+   "default": "1024",
+   "non_negative": 1,
+   "description": "Subtracted from each host's memory budget before placement and resize accounting (effective = total − reserve, clamped ≥ 0). Guest RAM must never pack to 100% of MemTotal — the host OS, per-VM Firecracker/jailer overhead, and thin-pool metadata live there too, and packing to MemTotal OOMs the host."
   },
   {
    "fieldname": "section_break_tcp_proxy",

--- a/atlas/atlas/doctype/server/server.js
+++ b/atlas/atlas/doctype/server/server.js
@@ -4,8 +4,59 @@ frappe.ui.form.on("Server", {
 			return;
 		}
 		add_buttons(frm);
+		render_capacity(frm);
 	},
 });
+
+// Per-host capacity headline: axis fills plus the share-unit + stranded line the
+// operator compares host shapes by (spec/24). Reads the same capacity_for_server
+// helper placement uses; skips silently on an unmeasured/erroring host.
+function render_capacity(frm) {
+	frappe
+		.call({
+			method: "atlas.atlas.api.server_capacity.capacity_for_server",
+			args: { server: frm.doc.name },
+		})
+		.then(({ message: capacity }) => {
+			if (capacity) {
+				frm.dashboard.set_headline(capacity_headline(capacity));
+			}
+		});
+}
+
+function capacity_headline(capacity) {
+	const fill = (axis) =>
+		axis.effective ? `${Math.round((100 * axis.used) / axis.effective)}%` : "—";
+	let text = `Capacity — CPU ${fill(capacity.cpu)} · RAM ${fill(capacity.memory)} · disk ${fill(
+		capacity.disk
+	)}`;
+	const units = capacity.share_units;
+	if (units) {
+		text += ` · ${units.free} / ${units.total} share units free`;
+		const stranded = format_stranded(capacity.stranded);
+		if (stranded) {
+			text += ` · stranded: ${stranded}`;
+		}
+	}
+	return `<span>${frappe.utils.escape_html(text)}</span>`;
+}
+
+function format_stranded(stranded) {
+	if (!stranded) {
+		return "";
+	}
+	const bits = [];
+	if (stranded.cpu > 0.01) {
+		bits.push(`${stranded.cpu.toFixed(1)} cores`);
+	}
+	if (stranded.memory > 0) {
+		bits.push(`${Math.round(stranded.memory)} MB`);
+	}
+	if (stranded.disk > 0) {
+		bits.push(`${Math.round(stranded.disk)} GB disk`);
+	}
+	return bits.join(", ");
+}
 
 function add_buttons(frm) {
 	const status = frm.doc.status;
@@ -26,6 +77,7 @@ function add_buttons(frm) {
 		frappe.atlas.add_action(frm, "Sync Image", () => open_sync_image_dialog(frm));
 		frappe.atlas.add_action(frm, "Bake Image", () => open_bake_image_dialog(frm));
 		frappe.atlas.add_action(frm, "Sync Scripts", () => sync_scripts(frm));
+		frappe.atlas.add_action(frm, "Refresh Capacity", () => refresh_capacity(frm));
 		frappe.atlas.add_action(frm, "Allocate Reserved IP", () =>
 			confirm_allocate_reserved_ip(frm)
 		);
@@ -109,6 +161,29 @@ function sync_scripts(frm) {
 		frappe.show_alert(
 			{
 				message: __("Synced {0} script file(s) to {1}.", [count, frm.doc.title]),
+				indicator: "green",
+			},
+			6
+		);
+	});
+}
+
+function refresh_capacity(frm) {
+	// Re-measure the host's capacity facts (CPU/RAM/pool size + fullness) and stamp
+	// them, without a full re-bootstrap. Read-only on the host, no vendor side
+	// effects, so no confirm. Reloads the doc so the Capacity section updates.
+	frm.call(
+		"refresh_capacity_facts",
+		{},
+		{
+			freeze: true,
+			freeze_message: __("Measuring host capacity…"),
+		}
+	).then(() => {
+		frm.reload_doc();
+		frappe.show_alert(
+			{
+				message: __("Capacity facts refreshed for {0}.", [frm.doc.title]),
 				indicator: "green",
 			},
 			6

--- a/atlas/atlas/doctype/server/server.json
+++ b/atlas/atlas/doctype/server/server.json
@@ -39,6 +39,7 @@
   "pool_disk_gigabytes_total",
   "pool_data_percent",
   "capacity_reported_at",
+  "placement_headroom_percent",
   "section_break_metadata",
   "provider_metadata"
  ],
@@ -246,6 +247,13 @@
    "fieldtype": "Datetime",
    "label": "Capacity Reported At",
    "read_only": 1
+  },
+  {
+   "description": "Per-host arrival fill ceiling. > 0 overrides Atlas Settings.placement_headroom_percent for this host; 0/unset inherits the fleet default. (Frappe writes 0 for an untouched Percent field, so \"explicitly 0 while the fleet default is > 0\" is not expressible per-host — an accepted trade-off.) The reserve applies to placing NEW VMs only; resize spends it.",
+   "fieldname": "placement_headroom_percent",
+   "fieldtype": "Percent",
+   "label": "Placement Headroom Percent",
+   "non_negative": 1
   },
   {
    "collapsible": 1,

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -403,6 +403,16 @@ class Server(Document):
 		self.jailer_version = parsed["jailer_version"]
 		self.kernel_version = parsed["kernel_version"]
 		self.architecture = parsed["architecture"]
+		# The host's capacity totals ride the same BootstrapResult line (see
+		# atlas.hostfacts). `.get()` because a Fake host's synthesized bootstrap
+		# result omits them — its capacity comes from `fake_host_totals` in
+		# `capacity_for_server`, so the row's totals stay unset and it reads as a
+		# measured Fake host regardless. A real bootstrap always carries all three.
+		self._stamp_capacity_facts(
+			parsed.get("vcpus_total"),
+			parsed.get("memory_megabytes_total"),
+			parsed.get("pool_disk_gigabytes_total"),
+		)
 		# Reaching here means the bootstrap Task succeeded — and run_task raises on
 		# any failure, so bootstrap-server.py's deep sanity gate (which runs
 		# `atlas --help` to prove the console script dispatches) passed. Persist
@@ -410,6 +420,46 @@ class Server(Document):
 		# trip: a legacy/unbootstrapped host has cli_ready=0 and the operator sees
 		# the re-bootstrap signal. Fail-fast moved from per-Task to once-at-bootstrap.
 		self.cli_ready = 1
+
+	def _stamp_capacity_facts(
+		self,
+		vcpus_total: int | None,
+		memory_megabytes_total: int | None,
+		pool_disk_gigabytes_total: int | None,
+		pool_data_percent: float | None = None,
+	) -> None:
+		"""Persist the host's measured capacity totals and the stamp time. Shared by
+		bootstrap (three totals; pool fullness starts ~0, so it is left out) and
+		Refresh Capacity (all four). `capacity_reported_at` records when the host was
+		last measured, so a host silent past a staleness threshold can be treated as
+		uncatalogued later rather than trusting stale totals (a future guard)."""
+		self.vcpus_total = vcpus_total
+		self.memory_megabytes_total = memory_megabytes_total
+		self.pool_disk_gigabytes_total = pool_disk_gigabytes_total
+		if pool_data_percent is not None:
+			self.pool_data_percent = pool_data_percent
+		self.capacity_reported_at = frappe.utils.now_datetime()
+
+	@frappe.whitelist()
+	def refresh_capacity_facts(self) -> str:
+		"""Re-measure the host's capacity facts and stamp them — the Refresh Capacity
+		button. For an already-Active host whose shape changed (a resized droplet, a
+		grown pool) or that was bootstrapped before the totals were reported. Runs the
+		read-only `server-facts` Task and persists the four numbers; returns the Task
+		name. Bootstrap already stamps the three totals, so this is the no-re-bootstrap
+		refresh — and the one path that also captures live `pool_data_percent`."""
+		if self.status != "Active":
+			frappe.throw(f"Refresh capacity on an Active host (status is {self.status})")
+		task = run_task(server=self.name, script="server-facts", variables={}, timeout_seconds=120)
+		parsed = parse_result(task.stdout)
+		self._stamp_capacity_facts(
+			parsed["vcpus_total"],
+			parsed["memory_megabytes_total"],
+			parsed["pool_disk_gigabytes_total"],
+			parsed["pool_data_percent"],
+		)
+		self.save(ignore_permissions=True)
+		return task.name
 
 
 def reinstall_atlas_venv_package(connection, server_name: str) -> None:

--- a/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
@@ -3,8 +3,31 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from atlas.atlas.placement import NoResizeCapacityError
 from atlas.tests._mocks import fake_task
 from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
+
+
+def _resize_server(**totals) -> str:
+	"""A distinct Active server catalogued with the given capacity totals — the
+	resize-gate tests need a MEASURED host so the gate has an effective budget to
+	check against (the shared vm-test-server is memory/disk-uncatalogued on purpose).
+	Also clears the memory floor so `effective` equals the stamped total exactly."""
+	frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
+	provider = make_provider("vm-resize-provider")
+	server = make_server(
+		provider,
+		"vm-resize-server",
+		ipv4_address="10.0.0.77",
+		ipv6_address="2001:db8:5::1",
+		ipv6_prefix="2001:db8:5::/64",
+		ipv6_virtual_machine_range="2001:db8:5::/120",
+		status="Active",
+	)
+	stamped = {"vcpus_total": 0, "memory_megabytes_total": 0, "pool_disk_gigabytes_total": 0, **totals}
+	for field, value in stamped.items():
+		server.db_set(field, value)
+	return server.name
 
 
 def _ensure_test_server() -> str:
@@ -319,12 +342,16 @@ class TestVirtualMachine(IntegrationTestCase):
 
 		with patch.object(module.frappe, "enqueue") as enqueue:
 			vm = _new_vm()
-		enqueue.assert_called_once()
-		_, kwargs = enqueue.call_args
-		self.assertEqual(
-			kwargs["virtual_machine_name"],
-			vm.name,
-		)
+		# The insert also enqueues central_report.deliver events (vm.created,
+		# vm.status_changed); single out the auto_provision enqueue and assert it
+		# targets this VM, rather than assuming it is the only enqueue.
+		auto_provision_calls = [
+			call
+			for call in enqueue.call_args_list
+			if call.args and call.args[0].endswith(".auto_provision")
+		]
+		self.assertEqual(len(auto_provision_calls), 1)
+		self.assertEqual(auto_provision_calls[0].kwargs["virtual_machine_name"], vm.name)
 
 	def test_auto_provision_is_noop_when_not_pending(self) -> None:
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
@@ -815,6 +842,67 @@ class TestVirtualMachine(IntegrationTestCase):
 				vm.resize(data_disk_gigabytes=4)
 		self.assertIn("no data disk", str(raised.exception))
 		mocked.assert_not_called()
+
+	# --- resize capacity gate (spec/24) ------------------------------------
+
+	def test_resize_within_capacity_passes(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		server = _resize_server(memory_megabytes_total=4096)
+		vm = make_virtual_machine(server, _ensure_test_image(), memory_megabytes=512, disk_gigabytes=4)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task", return_value=fake_task(name="task-resize")) as mocked:
+			vm.resize(memory_megabytes=1024)
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 1024)
+		mocked.assert_called_once()
+
+	def test_resize_over_capacity_raises(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		# Host holds exactly 1024 MB and the VM already fills it; doubling the RAM
+		# doesn't fit → NoResizeCapacityError, and the on-host resize never runs.
+		server = _resize_server(memory_megabytes_total=1024)
+		vm = make_virtual_machine(server, _ensure_test_image(), memory_megabytes=1024, disk_gigabytes=4)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task") as mocked:
+			with self.assertRaises(NoResizeCapacityError):
+				vm.resize(memory_megabytes=2048)
+		mocked.assert_not_called()
+
+	def test_resize_charges_only_positive_deltas(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		# CPU is measured and already full (1 core on a 1-core host), but growing RAM
+		# only charges the RAM delta — the unchanged CPU axis must not block it.
+		server = _resize_server(vcpus_total=1, memory_megabytes_total=4096)
+		vm = make_virtual_machine(
+			server, _ensure_test_image(), vcpus=1, cpu_max_cores=1, memory_megabytes=512, disk_gigabytes=4
+		)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=1024)
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 1024, "a full CPU axis doesn't block a RAM-only grow")
+
+	def test_resize_spends_the_placement_reserve(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		# A 50% arrival reserve would refuse PLACING a new VM past 512 MB, but resize
+		# checks the FULL effective budget (1024) — so it spends into the reserve.
+		server = _resize_server(memory_megabytes_total=1024)
+		frappe.db.set_single_value("Atlas Settings", "placement_headroom_percent", 50)
+		self.addCleanup(frappe.db.set_single_value, "Atlas Settings", "placement_headroom_percent", 0)
+		vm = make_virtual_machine(server, _ensure_test_image(), memory_megabytes=512, disk_gigabytes=4)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task", return_value=fake_task(name="task-resize")):
+			vm.resize(memory_megabytes=1024)
+		vm.reload()
+		self.assertEqual(vm.memory_megabytes, 1024, "resize spends the headroom placement reserved")
 
 	def test_snapshot_persists_data_disk_fields(self) -> None:
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as module

--- a/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
@@ -843,7 +843,7 @@ class TestVirtualMachine(IntegrationTestCase):
 		self.assertIn("no data disk", str(raised.exception))
 		mocked.assert_not_called()
 
-	# --- resize capacity gate (spec/24) ------------------------------------
+	# --- resize capacity gate (spec/28) ------------------------------------
 
 	def test_resize_within_capacity_passes(self) -> None:
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as module

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -834,7 +834,7 @@ class VirtualMachine(Document):
 				frappe.throw(
 					f"Data disk can only grow: {self.data_disk_gigabytes} GB → {new_data_disk} GB is a shrink"
 				)
-		# Capacity gate (spec/24): a resize must not silently oversubscribe the host.
+		# Capacity gate (spec/28): a resize must not silently oversubscribe the host.
 		# Charge only the positive per-axis deltas against the host's FULL effective
 		# budget — the arrival headroom reserve is the resize's to spend. Raises
 		# NoResizeCapacityError (a NoCapacityError subclass) when the delta doesn't

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -19,7 +19,7 @@ from atlas.atlas.networking import (
 	derive_veth_pair,
 	resource_limit_args,
 )
-from atlas.atlas.placement import apply_user_defaults
+from atlas.atlas.placement import apply_user_defaults, check_resize_capacity
 from atlas.atlas.ssh import run_task
 from atlas.atlas.task_results import parse_result
 
@@ -834,6 +834,19 @@ class VirtualMachine(Document):
 				frappe.throw(
 					f"Data disk can only grow: {self.data_disk_gigabytes} GB → {new_data_disk} GB is a shrink"
 				)
+		# Capacity gate (spec/24): a resize must not silently oversubscribe the host.
+		# Charge only the positive per-axis deltas against the host's FULL effective
+		# budget — the arrival headroom reserve is the resize's to spend. Raises
+		# NoResizeCapacityError (a NoCapacityError subclass) when the delta doesn't
+		# fit; that is the trigger for a future migrate-to-grow (case 2). CPU cost is
+		# the bandwidth share (cpu_max_cores or vcpus), matching capacity accounting.
+		check_resize_capacity(
+			self.server,
+			delta_cpu=new_cpu_max - float(self.cpu_max_cores or self.vcpus or 0),
+			delta_memory_mb=new_memory - (self.memory_megabytes or 0),
+			delta_disk_gb=(new_disk + new_data_disk)
+			- (self.disk_gigabytes + (self.data_disk_gigabytes or 0)),
+		)
 		# Run the on-host resize first; run_task raises on failure, so we only
 		# persist the new values once the config and disk actually changed.
 		# Saving before the Task would let a failed resize-vm.py leave the doc

--- a/atlas/atlas/packing.py
+++ b/atlas/atlas/packing.py
@@ -1,0 +1,116 @@
+"""Pure placement/packing math — strategy scoring, no Frappe.
+
+Shared by the live scorer (`atlas/atlas/placement.py`) and the offline simulator
+(`atlas/atlas/packing_sim.py`) so the policy they reason about can't drift.
+Everything here is plain numbers, never Server rows: a per-axis budget of `None`
+means that axis is uncatalogued → unlimited (the operator vouched for the host by
+Activating it).
+
+The three packed axes are `cpu` (`cpu_max_cores` — the guaranteed share, which is
+the packing dimension), `memory` (MB) and `disk` (GB). See `spec/24-placement.md`
+for why the proportional size ladder makes packing one-dimensional, and why on
+*homogeneous* hosts every strategy yields identical utilisation — the strategies
+diverge only on heterogeneous fleets and on drainability/defragmentation, which the
+simulator quantifies.
+"""
+
+from __future__ import annotations
+
+AXES = ("cpu", "memory", "disk")
+
+# Placement strategies. Each names the score that orders the FEASIBLE hosts
+# (min-rank wins); they share one feasibility gate and all rank measured hosts
+# ahead of unmeasured ones, breaking final ties by creation order.
+SPREAD = "Spread"  # worst-fit: emptiest by relative fill — blast radius + burst/resize headroom
+BEST_FIT = "Best Fit"  # most-allocated: fullest feasible host — keeps hosts drainable, holes for Dedicated
+TETRIS = "Tetris"  # dot-product alignment: match demand shape to host headroom — least stranding
+FIRST_FIT = "First Fit"  # creation order — the pre-scorer behaviour; cheapest, most fragmenting
+HYBRID = "Hybrid"  # dedicated-class VMs Best Fit (don't fragment the big holes), the rest Spread
+STRATEGIES = (SPREAD, BEST_FIT, TETRIS, FIRST_FIT, HYBRID)
+DEFAULT_STRATEGY = SPREAD
+
+# A VM is "dedicated-class" when it guarantees a whole core or more (cpu_max_cores ≥
+# 1). The Hybrid strategy best-fits these so the scarce large holes stay contiguous,
+# while spreading the sub-core shared tiers to keep in-place resize headroom on every
+# host. The threshold is on the CPU (guarantee) axis because that is the packing
+# dimension and it cleanly separates Dedicated (1.0) from the shared tiers (≤ 0.5).
+DEDICATED_CPU_THRESHOLD = 1.0
+
+
+def _resolve(strategy: str, needs: dict) -> str:
+	"""Map the operator's strategy to the one this particular VM is scored under.
+
+	Only `HYBRID` is VM-dependent: a dedicated-class VM (a whole guaranteed core or
+	more) is placed Best Fit, everything else Spread. Every other strategy is the same
+	for all VMs and passes through unchanged."""
+	if strategy == HYBRID:
+		return BEST_FIT if needs["cpu"] >= DEDICATED_CPU_THRESHOLD else SPREAD
+	return strategy
+
+
+def _evaluate(
+	budgets: dict, used: dict, needs: dict, reserve: float
+) -> tuple[bool, int, float, float]:
+	"""Feasibility + shape metrics for placing `needs` on one host.
+
+	`budgets`/`used`/`needs` are dicts over `AXES` (a budget of `None` = that axis is
+	unmeasured → unlimited). Returns `(fits, unmeasured_count, fill, alignment)`:
+
+	- `fits` — every MEASURED axis has room within its reserved budget
+	  `budget × (1 − reserve)`.
+	- `fill` — the max post-placement fill across measured axes (the bottleneck),
+	  relative to the reserved budget; lower = emptier host afterward.
+	- `alignment` — the dot product of normalised demand and normalised free
+	  headroom over measured axes: how well the VM's shape matches where the host has
+	  room (the Tetris/most-aligned heuristic); higher = better shape match."""
+	fits = True
+	unmeasured = 0
+	fill = 0.0
+	alignment = 0.0
+	for axis in AXES:
+		budget = budgets[axis]
+		if budget is None:
+			unmeasured += 1
+			continue
+		allowed = budget * (1.0 - reserve)
+		projected = used[axis] + needs[axis]
+		if projected > allowed:
+			fits = False
+		if allowed > 0:
+			fill = max(fill, projected / allowed)
+		if budget > 0:
+			free = max(0.0, budget - used[axis])
+			alignment += (needs[axis] / budget) * (free / budget)
+	return fits, unmeasured, fill, alignment
+
+
+def rank_key(
+	strategy: str,
+	budgets: dict,
+	used: dict,
+	needs: dict,
+	reserve: float,
+	tie_breaker,
+) -> tuple | None:
+	"""The sort key for placing `needs` on one host under `strategy`, or `None` if it
+	does not fit.
+
+	Lower wins. The key is `(unmeasured_axis_count, score, tie_breaker)`: measured
+	hosts first (a real fill beats an unknown one), then the strategy's score, then
+	`tie_breaker` (the host's creation index) for determinism. On a proportional
+	catalog with homogeneous hosts every strategy's score ties, so the tie-breaker
+	decides and utilisation is identical — the strategies only diverge on
+	heterogeneous fleets (spec/24)."""
+	fits, unmeasured, fill, alignment = _evaluate(budgets, used, needs, reserve)
+	if not fits:
+		return None
+	strategy = _resolve(strategy, needs)
+	if strategy == BEST_FIT:
+		score = -fill  # fullest feasible host
+	elif strategy == TETRIS:
+		score = -alignment  # best shape match
+	elif strategy == FIRST_FIT:
+		score = 0.0  # pure creation order
+	else:
+		score = fill  # SPREAD (default): emptiest feasible host
+	return (unmeasured, score, tie_breaker)

--- a/atlas/atlas/packing.py
+++ b/atlas/atlas/packing.py
@@ -7,7 +7,7 @@ means that axis is uncatalogued → unlimited (the operator vouched for the host
 Activating it).
 
 The three packed axes are `cpu` (`cpu_max_cores` — the guaranteed share, which is
-the packing dimension), `memory` (MB) and `disk` (GB). See `spec/24-placement.md`
+the packing dimension), `memory` (MB) and `disk` (GB). See `spec/28-placement.md`
 for why the proportional size ladder makes packing one-dimensional, and why on
 *homogeneous* hosts every strategy yields identical utilisation — the strategies
 diverge only on heterogeneous fleets and on drainability/defragmentation, which the
@@ -100,7 +100,7 @@ def rank_key(
 	`tie_breaker` (the host's creation index) for determinism. On a proportional
 	catalog with homogeneous hosts every strategy's score ties, so the tie-breaker
 	decides and utilisation is identical — the strategies only diverge on
-	heterogeneous fleets (spec/24)."""
+	heterogeneous fleets (spec/28)."""
 	fits, unmeasured, fill, alignment = _evaluate(budgets, used, needs, reserve)
 	if not fits:
 		return None

--- a/atlas/atlas/packing_metrics.py
+++ b/atlas/atlas/packing_metrics.py
@@ -1,0 +1,84 @@
+"""Pure fleet-packing metrics — no Frappe, no simulator state.
+
+Computed from a snapshot of per-host budgets + usage (the same per-axis numbers
+`capacity_for_server` produces, and what `packing_sim` tracks). These are the
+numbers `spec/24-placement.md` says to watch: committed utilisation, the
+cell-compaction ratio, stranded capacity / axis imbalance, and sellable share-unit
+slots. The simulator uses them to score a run; they also work standalone against any
+list of objects exposing `.budget` (dict over `AXES`), `.used` (dict) and
+`.vm_count` — e.g. a thin adapter over `capacity_for_server`.
+"""
+
+from __future__ import annotations
+
+import math
+
+from atlas.atlas.packing import AXES
+from atlas.atlas.sizes import SHARE_UNIT
+
+# The share unit's cost keyed by the packing-axis names (SHARE_UNIT is keyed by the
+# VM resource fields). One source of truth: sizes.SHARE_UNIT (a Shared 1x).
+UNIT_COST = {
+	"cpu": SHARE_UNIT["cpu_max_cores"],
+	"memory": SHARE_UNIT["memory_megabytes"],
+	"disk": SHARE_UNIT["disk_gigabytes"],
+}
+
+
+def committed_utilization(hosts) -> dict:
+	"""Per-axis committed/usable across the fleet: `sum(used) / sum(budget)`.
+
+	The oversubscription factor can push the CPU axis above 1.0; memory and disk are
+	hard fits and stay ≤ 1.0. A dict over `AXES`."""
+	out = {}
+	for axis in AXES:
+		budget = sum(h.budget[axis] for h in hosts)
+		used = sum(h.used[axis] for h in hosts)
+		out[axis] = (used / budget) if budget else 0.0
+	return out
+
+
+def share_units(host) -> dict:
+	"""Sellable Shared-1x slots on one host: `{total, used, free}` (see spec/24)."""
+	total = min(int(host.budget[axis] // UNIT_COST[axis]) for axis in AXES)
+	used = max((math.ceil(host.used[axis] / UNIT_COST[axis]) for axis in AXES), default=0)
+	return {"total": total, "used": used, "free": total - used}
+
+
+def stranded(host) -> dict:
+	"""Per-axis capacity the bottleneck axis makes unsellable at full subscription:
+	`budget − share_units.total × unit_cost`."""
+	total = share_units(host)["total"]
+	return {axis: host.budget[axis] - total * UNIT_COST[axis] for axis in AXES}
+
+
+def imbalance(host) -> float:
+	"""`max_axis(fill) − min_axis(fill)` — how lopsided a host's usage is. High
+	imbalance means one axis is nearly full while another sits idle (stranding)."""
+	fills = [(host.used[axis] / host.budget[axis]) if host.budget[axis] else 0.0 for axis in AXES]
+	return max(fills) - min(fills)
+
+
+def compaction_ratio(hosts) -> float:
+	"""`lower_bound_host_count / hosts_in_use` (spec/24 §6).
+
+	The lower bound is the fewest hosts (largest-first) whose cumulative budget covers
+	the committed totals, taken as the max over axes — the theoretical floor a perfect
+	repack could reach. `~1.0` = already tight; `< 1.0` = consolidation is possible
+	(that many hosts could be drained). Returns 1.0 for an empty fleet."""
+	in_use = sum(1 for h in hosts if h.vm_count)
+	if not in_use:
+		return 1.0
+	committed = {axis: sum(h.used[axis] for h in hosts) for axis in AXES}
+	lower_bound = 0
+	for axis in AXES:
+		budgets = sorted((h.budget[axis] for h in hosts), reverse=True)
+		accumulated = 0.0
+		count = 0
+		for budget in budgets:
+			if accumulated >= committed[axis]:
+				break
+			accumulated += budget
+			count += 1
+		lower_bound = max(lower_bound, count)
+	return lower_bound / in_use

--- a/atlas/atlas/packing_metrics.py
+++ b/atlas/atlas/packing_metrics.py
@@ -2,7 +2,7 @@
 
 Computed from a snapshot of per-host budgets + usage (the same per-axis numbers
 `capacity_for_server` produces, and what `packing_sim` tracks). These are the
-numbers `spec/24-placement.md` says to watch: committed utilisation, the
+numbers `spec/28-placement.md` says to watch: committed utilisation, the
 cell-compaction ratio, stranded capacity / axis imbalance, and sellable share-unit
 slots. The simulator uses them to score a run; they also work standalone against any
 list of objects exposing `.budget` (dict over `AXES`), `.used` (dict) and
@@ -39,7 +39,7 @@ def committed_utilization(hosts) -> dict:
 
 
 def share_units(host) -> dict:
-	"""Sellable Shared-1x slots on one host: `{total, used, free}` (see spec/24)."""
+	"""Sellable Shared-1x slots on one host: `{total, used, free}` (see spec/28)."""
 	total = min(int(host.budget[axis] // UNIT_COST[axis]) for axis in AXES)
 	used = max((math.ceil(host.used[axis] / UNIT_COST[axis]) for axis in AXES), default=0)
 	return {"total": total, "used": used, "free": total - used}
@@ -60,7 +60,7 @@ def imbalance(host) -> float:
 
 
 def compaction_ratio(hosts) -> float:
-	"""`lower_bound_host_count / hosts_in_use` (spec/24 §6).
+	"""`lower_bound_host_count / hosts_in_use` (spec/28 §6).
 
 	The lower bound is the fewest hosts (largest-first) whose cumulative budget covers
 	the committed totals, taken as the max over axes — the theoretical floor a perfect

--- a/atlas/atlas/packing_sim.py
+++ b/atlas/atlas/packing_sim.py
@@ -1,0 +1,453 @@
+"""Offline packing simulator — compare placement strategies before changing production.
+
+Event-driven: Poisson arrivals by plan mix, per-plan exponential lifetimes (the VM
+*drops* those departures model), and an exponential upgrade hazard (the *resizes*).
+Each arrival is placed with the SAME scorer production uses
+(`atlas.atlas.packing.rank_key`), so a strategy that wins here is the one to set on
+`Atlas Settings.placement_strategy`.
+
+It simulates the two events not yet wired into the app — VM drops and in-place
+resizes / forced migrations — because they are cheap to model and are exactly what
+distinguishes the strategies (on the proportional ladder with uniform hosts every
+strategy ties; they diverge on heterogeneous fleets and on drainability, spec/24).
+The workload is generated ONCE and replayed under each strategy, so the comparison
+is fair (same arrivals, lifetimes, upgrades) and reproducible from the seed.
+
+Reported per strategy: acceptance, blocked-largest-plan rate (the fragmentation
+canary), in-place upgrade success rate, FORCED MIGRATIONS, mean committed
+utilisation, mean hosts in use, and the compaction ratio.
+
+Run:  python3 -m atlas.atlas.packing_sim --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import random
+import statistics
+from dataclasses import dataclass, field
+
+from atlas.atlas import packing, packing_metrics
+from atlas.atlas.sizes import SIZE_PRESETS
+
+_PLANS = list(SIZE_PRESETS)
+_LARGEST_PLAN = _PLANS[-1]
+
+# A realistic default cloud host shape as an EFFECTIVE per-axis budget:
+# (cpu_max_cores, memory_mb, disk_gb). 8 cores / 16 GB / 320 GB — RAM binds first
+# (2 GB per core), the shape spec/24 calls out as the common cloud case.
+DEFAULT_HOST_SHAPE = (8.0, 16384.0, 320.0)
+
+# Skewed toward the small shared tiers, one long tail of Dedicated — the churny mix
+# the fragmentation canary (blocked-largest) is most sensitive to.
+DEFAULT_PLAN_MIX = {
+	"Shared 1x": 4.0,
+	"Shared 2x": 3.0,
+	"Shared 4x": 2.0,
+	"Shared 8x": 1.0,
+	"Dedicated 1x": 1.0,
+}
+
+
+def plan_demand(plan: str) -> dict:
+	"""The per-axis demand vector for a size preset (the packing-axis view of it)."""
+	preset = SIZE_PRESETS[plan]
+	return {
+		"cpu": float(preset["cpu_max_cores"]),
+		"memory": float(preset["memory_megabytes"]),
+		"disk": float(preset["disk_gigabytes"]),
+	}
+
+
+def _next_plan(plan: str) -> str | None:
+	"""The next tier up the ladder, or None if already the largest."""
+	index = _PLANS.index(plan)
+	return _PLANS[index + 1] if index + 1 < len(_PLANS) else None
+
+
+@dataclass
+class SimConfig:
+	"""Every knob the operator can turn to reach their own conclusions."""
+
+	strategy: str = packing.SPREAD
+	seed: int = 0
+	duration: float = 10000.0  # sim-time units
+	arrival_rate: float = 1.0  # arrivals per unit time (Poisson λ)
+	host_count: int = 20
+	host_shapes: tuple = (DEFAULT_HOST_SHAPE,)  # cycled across the fleet (mixed = heterogeneous)
+	plan_mix: dict = field(default_factory=lambda: dict(DEFAULT_PLAN_MIX))
+	mean_lifetime: float = 500.0  # mean VM lifetime (exponential)
+	upgrade_hazard: float = 0.0  # per-unit-time rate a VM asks to grow one tier (0 = never)
+	reserve: float = 0.0  # arrival headroom fraction placement leaves free (resize spends it)
+
+
+@dataclass
+class _Request:
+	"""A pre-generated arrival, independent of any strategy so the workload replays
+	identically. `upgrade_offsets` are times after arrival at which it attempts to
+	grow one tier (only fired while the VM is alive)."""
+
+	arrival: float
+	plan: str
+	lifetime: float
+	upgrade_offsets: list
+
+
+class _Host:
+	def __init__(self, host_id: int, shape) -> None:
+		self.host_id = host_id
+		self.budget = {"cpu": shape[0], "memory": shape[1], "disk": shape[2]}
+		self.used = {axis: 0.0 for axis in packing.AXES}
+		self.vm_count = 0
+
+	def add(self, demand: dict) -> None:
+		for axis in packing.AXES:
+			self.used[axis] += demand[axis]
+		self.vm_count += 1
+
+	def remove(self, demand: dict) -> None:
+		for axis in packing.AXES:
+			self.used[axis] -= demand[axis]
+		self.vm_count -= 1
+
+	def in_place_fits(self, delta: dict) -> bool:
+		# A resize spends the reserve, so it checks the FULL budget.
+		return all(self.used[axis] + delta[axis] <= self.budget[axis] for axis in packing.AXES)
+
+
+class _VM:
+	__slots__ = ("plan", "demand", "host", "alive")
+
+	def __init__(self, plan: str, demand: dict, host: "_Host") -> None:
+		self.plan = plan
+		self.demand = demand
+		self.host = host
+		self.alive = True
+
+
+def generate_workload(config: SimConfig) -> list:
+	"""Sample the arrival stream once (seeded) so every strategy replays it.
+
+	Poisson arrivals (exponential gaps at rate `arrival_rate`), plan by `plan_mix`,
+	exponential lifetime, and a thinned exponential process of upgrade attempts at
+	`upgrade_hazard` over the VM's life."""
+	rng = random.Random(config.seed)
+	plans = list(config.plan_mix)
+	weights = [config.plan_mix[plan] for plan in plans]
+	requests = []
+	now = 0.0
+	while True:
+		now += rng.expovariate(config.arrival_rate)
+		if now >= config.duration:
+			break
+		plan = rng.choices(plans, weights=weights, k=1)[0]
+		lifetime = rng.expovariate(1.0 / config.mean_lifetime)
+		upgrade_offsets = []
+		if config.upgrade_hazard > 0:
+			offset = 0.0
+			while True:
+				offset += rng.expovariate(config.upgrade_hazard)
+				if offset >= lifetime:
+					break
+				upgrade_offsets.append(offset)
+		requests.append(_Request(now, plan, lifetime, upgrade_offsets))
+	return requests
+
+
+class _Stats:
+	def __init__(self) -> None:
+		self.accepted = 0
+		self.blocked = 0
+		self.attempts_by_plan = {plan: 0 for plan in _PLANS}
+		self.blocked_by_plan = {plan: 0 for plan in _PLANS}
+		self.in_place_upgrades = 0
+		self.forced_migrations = 0
+		self.blocked_resizes = 0
+		self.peak_hosts_in_use = 0
+		self._util = {axis: 0.0 for axis in packing.AXES}
+		self._hosts_in_use = 0.0
+		self._compaction = 0.0
+
+	def sample(self, hosts, dt: float) -> None:
+		if dt <= 0:
+			return
+		utilization = packing_metrics.committed_utilization(hosts)
+		for axis in packing.AXES:
+			self._util[axis] += utilization[axis] * dt
+		in_use = sum(1 for host in hosts if host.vm_count)
+		self._hosts_in_use += in_use * dt
+		self._compaction += packing_metrics.compaction_ratio(hosts) * dt
+		self.peak_hosts_in_use = max(self.peak_hosts_in_use, in_use)
+
+	def finalize(self, duration: float) -> dict:
+		attempted = self.accepted + self.blocked
+		upgrade_attempts = self.in_place_upgrades + self.forced_migrations + self.blocked_resizes
+		return {
+			"accepted": self.accepted,
+			"attempted": attempted,
+			"acceptance": self.accepted / attempted if attempted else 1.0,
+			"blocked": self.blocked,
+			"blocked_largest_rate": (
+				self.blocked_by_plan[_LARGEST_PLAN] / self.attempts_by_plan[_LARGEST_PLAN]
+				if self.attempts_by_plan[_LARGEST_PLAN]
+				else 0.0
+			),
+			"in_place_upgrade_rate": (
+				self.in_place_upgrades / upgrade_attempts if upgrade_attempts else 1.0
+			),
+			"forced_migrations": self.forced_migrations,
+			"blocked_resizes": self.blocked_resizes,
+			"mean_utilization": {axis: self._util[axis] / duration for axis in packing.AXES},
+			"mean_hosts_in_use": self._hosts_in_use / duration,
+			"peak_hosts_in_use": self.peak_hosts_in_use,
+			"mean_compaction": self._compaction / duration,
+		}
+
+
+class _Simulation:
+	def __init__(self, config: SimConfig, workload: list) -> None:
+		self.config = config
+		self.workload = workload
+		self.hosts = [
+			_Host(index, config.host_shapes[index % len(config.host_shapes)])
+			for index in range(config.host_count)
+		]
+		self.stats = _Stats()
+		self._events: list = []  # heap of (time, seq, kind, payload)
+		self._seq = 0
+		self._clock = 0.0
+
+	def _push(self, time: float, kind: str, payload) -> None:
+		heapq.heappush(self._events, (time, self._seq, kind, payload))
+		self._seq += 1
+
+	def _place(self, demand: dict, exclude: "_Host | None" = None) -> "_Host | None":
+		best = None
+		for index, host in enumerate(self.hosts):
+			if host is exclude:
+				continue
+			key = packing.rank_key(
+				self.config.strategy, host.budget, host.used, demand, self.config.reserve, index
+			)
+			if key is None:
+				continue
+			if best is None or key < best[0]:
+				best = (key, host)
+		return best[1] if best else None
+
+	def run(self) -> dict:
+		for request in self.workload:
+			self._push(request.arrival, "arrival", request)
+		while self._events:
+			time, _seq, kind, payload = heapq.heappop(self._events)
+			if time >= self.config.duration:
+				break
+			self.stats.sample(self.hosts, time - self._clock)
+			self._clock = time
+			if kind == "arrival":
+				self._on_arrival(payload)
+			elif kind == "depart":
+				self._on_depart(payload)
+			else:
+				self._on_upgrade(payload)
+		# Account the final steady-state segment up to the horizon. Events scheduled
+		# beyond it (drain-down departs/upgrades) are dropped: they don't affect the
+		# [0, duration) time-averaged metrics, and every arrival is < duration by
+		# construction, so acceptance/blocked are already complete.
+		self.stats.sample(self.hosts, self.config.duration - self._clock)
+		return self.stats.finalize(self.config.duration)
+
+	def _on_arrival(self, request: "_Request") -> None:
+		self.stats.attempts_by_plan[request.plan] += 1
+		demand = plan_demand(request.plan)
+		host = self._place(demand)
+		if host is None:
+			self.stats.blocked += 1
+			self.stats.blocked_by_plan[request.plan] += 1
+			return
+		host.add(demand)
+		self.stats.accepted += 1
+		vm = _VM(request.plan, demand, host)
+		self._push(request.arrival + request.lifetime, "depart", vm)
+		for offset in request.upgrade_offsets:
+			self._push(request.arrival + offset, "upgrade", vm)
+
+	def _on_depart(self, vm: "_VM") -> None:
+		if not vm.alive:
+			return
+		vm.host.remove(vm.demand)
+		vm.alive = False
+
+	def _on_upgrade(self, vm: "_VM") -> None:
+		if not vm.alive:
+			return
+		target = _next_plan(vm.plan)
+		if target is None:
+			return
+		new = plan_demand(target)
+		delta = {axis: new[axis] - vm.demand[axis] for axis in packing.AXES}
+		if vm.host.in_place_fits(delta):
+			for axis in packing.AXES:
+				vm.host.used[axis] += delta[axis]
+			vm.plan, vm.demand = target, new
+			self.stats.in_place_upgrades += 1
+			return
+		# No room to grow in place → the resize needs a migration (spec/24 case 2).
+		source = vm.host
+		source.remove(vm.demand)
+		target_host = self._place(new, exclude=source)
+		if target_host is not None:
+			target_host.add(new)
+			vm.host, vm.plan, vm.demand = target_host, target, new
+			self.stats.forced_migrations += 1
+		else:
+			source.add(vm.demand)  # roll back — the VM keeps its old size on its old host
+			self.stats.blocked_resizes += 1
+
+
+def run(config: SimConfig) -> dict:
+	"""Run one strategy over a fresh (seeded) workload; return the finalized stats."""
+	return _Simulation(config, generate_workload(config)).run()
+
+
+def compare(config: SimConfig, strategies=packing.STRATEGIES) -> dict:
+	"""Run every strategy over the SAME workload (fair, reproducible). `config.seed`
+	fixes the workload; the strategy field is overridden per run."""
+	workload = generate_workload(config)
+	results = {}
+	for strategy in strategies:
+		run_config = SimConfig(**{**config.__dict__, "strategy": strategy})
+		results[strategy] = _Simulation(run_config, workload).run()
+	return results
+
+
+_SCALAR_METRICS = (
+	"acceptance",
+	"blocked_largest_rate",
+	"in_place_upgrade_rate",
+	"forced_migrations",
+	"mean_hosts_in_use",
+	"mean_compaction",
+)
+
+
+def compare_seeds(config: SimConfig, seeds: int, strategies=packing.STRATEGIES) -> dict:
+	"""Run `compare` over `seeds` independent seeds and aggregate mean + sample stddev
+	per strategy for the scalar metrics — the statistical view that says whether a
+	strategy's edge is real or one lucky workload. Each seed's workload is still shared
+	across strategies (fair), and the whole sweep is reproducible from `config.seed`."""
+	runs = [
+		compare(SimConfig(**{**config.__dict__, "seed": config.seed + index}), strategies)
+		for index in range(seeds)
+	]
+	aggregate = {}
+	for strategy in strategies:
+		per_metric = {}
+		for metric in _SCALAR_METRICS:
+			values = [run[strategy][metric] for run in runs]
+			stddev = statistics.stdev(values) if len(values) > 1 else 0.0
+			per_metric[metric] = (statistics.fmean(values), stddev)
+		aggregate[strategy] = per_metric
+	return aggregate
+
+
+def _format_aggregate(aggregate: dict, seeds: int) -> str:
+	rows = [("strategy", "accept", "blk-lrg", "in-place", "migrations (mean±sd)", "hosts", "compaction")]
+	for strategy, metrics in aggregate.items():
+		migrations_mean, migrations_sd = metrics["forced_migrations"]
+		rows.append(
+			(
+				strategy,
+				f"{metrics['acceptance'][0]:.3f}",
+				f"{metrics['blocked_largest_rate'][0]:.3f}",
+				f"{metrics['in_place_upgrade_rate'][0]:.3f}",
+				f"{migrations_mean:.1f} ± {migrations_sd:.1f}",
+				f"{metrics['mean_hosts_in_use'][0]:.1f}",
+				f"{metrics['mean_compaction'][0]:.3f}",
+			)
+		)
+	widths = [max(len(row[col]) for row in rows) for col in range(len(rows[0]))]
+	table = "\n".join(
+		"  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows
+	)
+	return f"averaged over {seeds} seeds\n{table}"
+
+
+def _format_table(results: dict) -> str:
+	rows = [
+		("strategy", "accept", "blk-lrg", "in-place", "migrations", "util(mem)", "hosts", "compaction"),
+	]
+	for strategy, stats in results.items():
+		rows.append(
+			(
+				strategy,
+				f"{stats['acceptance']:.3f}",
+				f"{stats['blocked_largest_rate']:.3f}",
+				f"{stats['in_place_upgrade_rate']:.3f}",
+				str(stats["forced_migrations"]),
+				f"{stats['mean_utilization']['memory']:.3f}",
+				f"{stats['mean_hosts_in_use']:.1f}",
+				f"{stats['mean_compaction']:.3f}",
+			)
+		)
+	widths = [max(len(row[col]) for row in rows) for col in range(len(rows[0]))]
+	return "\n".join(
+		"  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows
+	)
+
+
+def _parse_shape(text: str) -> tuple:
+	cpu, memory, disk = (float(part) for part in text.split(","))
+	return (cpu, memory, disk)
+
+
+def _build_config(args: argparse.Namespace) -> SimConfig:
+	shapes = tuple(_parse_shape(shape) for shape in args.host_shape) if args.host_shape else (DEFAULT_HOST_SHAPE,)
+	return SimConfig(
+		seed=args.seed,
+		duration=args.duration,
+		arrival_rate=args.arrival_rate,
+		host_count=args.host_count,
+		host_shapes=shapes,
+		mean_lifetime=args.mean_lifetime,
+		upgrade_hazard=args.upgrade_hazard,
+		reserve=args.reserve / 100.0,
+	)
+
+
+def main(argv=None) -> None:
+	parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+	parser.add_argument("--seed", type=int, default=0)
+	parser.add_argument("--seeds", type=int, default=1, help="average over this many seeds (mean ± sd)")
+	parser.add_argument("--duration", type=float, default=10000.0, help="sim-time units")
+	parser.add_argument("--arrival-rate", type=float, default=1.0, help="Poisson arrivals per unit time")
+	parser.add_argument("--host-count", type=int, default=20)
+	parser.add_argument(
+		"--host-shape",
+		action="append",
+		default=[],
+		metavar="CPU,MEM_MB,DISK_GB",
+		help="host effective budget; repeat for a heterogeneous fleet (cycled)",
+	)
+	parser.add_argument("--mean-lifetime", type=float, default=500.0)
+	parser.add_argument("--upgrade-hazard", type=float, default=0.0, help="resize-up rate per VM per unit time")
+	parser.add_argument("--reserve", type=float, default=0.0, help="arrival headroom percent")
+	parser.add_argument(
+		"--strategy",
+		choices=packing.STRATEGIES,
+		help="run only this strategy (default: compare all)",
+	)
+	args = parser.parse_args(argv)
+	config = _build_config(args)
+	strategies = (args.strategy,) if args.strategy else packing.STRATEGIES
+	if args.seeds > 1:
+		print(_format_aggregate(compare_seeds(config, args.seeds, strategies), args.seeds))
+	elif args.strategy:
+		print(_format_table({args.strategy: run(SimConfig(**{**config.__dict__, "strategy": args.strategy}))}))
+	else:
+		print(_format_table(compare(config)))
+
+
+if __name__ == "__main__":
+	main()

--- a/atlas/atlas/packing_sim.py
+++ b/atlas/atlas/packing_sim.py
@@ -9,7 +9,7 @@ Each arrival is placed with the SAME scorer production uses
 It simulates the two events not yet wired into the app — VM drops and in-place
 resizes / forced migrations — because they are cheap to model and are exactly what
 distinguishes the strategies (on the proportional ladder with uniform hosts every
-strategy ties; they diverge on heterogeneous fleets and on drainability, spec/24).
+strategy ties; they diverge on heterogeneous fleets and on drainability, spec/28).
 The workload is generated ONCE and replayed under each strategy, so the comparison
 is fair (same arrivals, lifetimes, upgrades) and reproducible from the seed.
 
@@ -36,7 +36,7 @@ _LARGEST_PLAN = _PLANS[-1]
 
 # A realistic default cloud host shape as an EFFECTIVE per-axis budget:
 # (cpu_max_cores, memory_mb, disk_gb). 8 cores / 16 GB / 320 GB — RAM binds first
-# (2 GB per core), the shape spec/24 calls out as the common cloud case.
+# (2 GB per core), the shape spec/28 calls out as the common cloud case.
 DEFAULT_HOST_SHAPE = (8.0, 16384.0, 320.0)
 
 # Skewed toward the small shared tiers, one long tail of Dedicated — the churny mix
@@ -293,7 +293,7 @@ class _Simulation:
 			vm.plan, vm.demand = target, new
 			self.stats.in_place_upgrades += 1
 			return
-		# No room to grow in place → the resize needs a migration (spec/24 case 2).
+		# No room to grow in place → the resize needs a migration (spec/28 case 2).
 		source = vm.host
 		source.remove(vm.demand)
 		target_host = self._place(new, exclude=source)

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -4,7 +4,8 @@ A dashboard user (see spec/11-user-ui.md) never picks where their machine
 runs — they state name, size, and SSH key, and the controller fills `server`
 and `image` here. The operator still owns the fleet: which Servers are Active
 and which Image is the default are operator decisions. This is placement, not
-scheduling — first Active server with room, no balancing.
+scheduling — load-aware spread across Active servers (the emptiest by relative
+fill wins; see spec/24-placement.md), not queues or reactive rebalancing.
 
 Operators creating a VM in Desk supply `server`/`image` explicitly, so this
 never runs for them.
@@ -240,13 +241,76 @@ def default_server_for_image(
 	)
 
 
-def _fits(axis: dict, need: float) -> bool:
-	"""Does `need` more of this resource fit on this axis?
+class NoResizeCapacityError(NoCapacityError):
+	"""A resize cannot grow the VM in place — its host lacks room for the delta.
 
-	`effective is None` means the host is uncatalogued on this axis → unlimited
-	room (the operator vouched for it by marking it Active), so anything fits.
-	Otherwise the axis fits when used + need stays within the effective budget."""
-	return axis["effective"] is None or axis["used"] + need <= axis["effective"]
+	Subclasses `NoCapacityError` so Central's existing "region full → retry / queue /
+	alert the operator" handling still fires unchanged (same HTTP status, same
+	message shape). The distinct type carries the extra signal that the remedy is
+	specific: migrate this VM to a host that fits the new size (spec/24 case 2 —
+	future work), not just retry the same placement."""
+
+
+def check_resize_capacity(
+	server: str,
+	delta_cpu: float,
+	delta_memory_mb: float,
+	delta_disk_gb: float,
+) -> None:
+	"""Raise `NoResizeCapacityError` if growing a VM on `server` by these per-axis
+	deltas would exceed the host's FULL effective budget.
+
+	Called from `VirtualMachine.resize` before the on-host resize runs.
+	`capacity_for_server`'s `used` already counts this VM at its current size (it
+	sums every non-Terminated VM), so the check is `used + delta ≤ effective` per
+	axis, for the positive deltas only — a shrink needs no room, and an unmeasured
+	axis (`effective is None`) is unlimited. Deliberately checks `effective`, NOT the
+	placement budget: the arrival headroom reserve exists precisely so a resize can
+	consume it."""
+	from atlas.atlas.api.server_capacity import capacity_for_server
+
+	capacity = capacity_for_server(server)
+	deltas = {"cpu": delta_cpu, "memory": delta_memory_mb, "disk": delta_disk_gb}
+	for axis_key, delta in deltas.items():
+		if delta <= 0:
+			continue
+		axis = capacity[axis_key]
+		if axis["effective"] is not None and axis["used"] + delta > axis["effective"]:
+			frappe.throw(
+				_("No room to grow on this host — the VM must migrate to resize."),
+				NoResizeCapacityError,
+			)
+
+
+def _placement_reserve_fraction(server: str) -> float:
+	"""The arrival fill ceiling for placing a NEW VM on `server`, as a fraction in
+	[0, 1).
+
+	A per-server `placement_headroom_percent` > 0 wins; otherwise the fleet
+	`Atlas Settings.placement_headroom_percent`. Frappe writes 0 for an untouched
+	Percent field, so a per-server 0 means "inherit the fleet default", not
+	"explicitly no reserve" — an accepted trade-off documented on the field. The
+	reserve keeps free room on each host for a later in-place resize; resize itself
+	ignores it (spending it is exactly what the reserve is for — see step 4)."""
+	per_server = frappe.db.get_value("Server", server, "placement_headroom_percent")
+	if per_server and per_server > 0:
+		percent = per_server
+	else:
+		percent = frappe.db.get_single_value("Atlas Settings", "placement_headroom_percent") or 0
+	return float(percent) / 100.0
+
+
+def _strategy() -> str:
+	"""The fleet placement strategy from Atlas Settings (`packing.STRATEGIES`).
+
+	Falls back to `packing.DEFAULT_STRATEGY` when unset or unknown, so an operator can
+	switch the scorer (Spread / Best Fit / Tetris / First Fit) without touching code.
+	spec/24 and the offline simulator (`packing_sim.py`) explain the trade-off each
+	strategy makes; on the proportional ladder + homogeneous hosts they coincide."""
+	from atlas.atlas import packing
+
+	value = frappe.db.get_single_value("Atlas Settings", "placement_strategy")
+	return value if value in packing.STRATEGIES else packing.DEFAULT_STRATEGY
 
 
 def default_server(
@@ -255,27 +319,34 @@ def default_server(
 	required_disk_gb: float,
 	candidate_servers: set[str] | None = None,
 ) -> str:
-	"""The first Active server with room on all three axes: CPU, RAM, pool disk.
+	"""The Active server a new VM should land on, per the fleet placement strategy.
 
-	`required_vcpus` is a CPU *bandwidth* cost (cpu_max_cores units), matching how
-	`capacity_for_server` sums usage — a 1/16-vCPU machine needs 0.0625, not a
-	whole vCPU. `required_memory_mb` and `required_disk_gb` are the VM's memory
-	and reserved disk (root + data). Capacity is the same accounting the desk
-	capacity helper uses (atlas/api/server_capacity.py): each axis's *effective*
-	budget minus what its non-Terminated VMs already spend, and a VM is placed
-	only where it fits on *every* axis. An axis with no known total — the agent
-	hasn't reported it, or (for CPU) the size isn't catalogued — reports
-	`effective is None` and is unlimited on that axis: the operator vouches for
-	the host by marking it Active. Raises when nothing fits on all three.
+	`required_vcpus` is a CPU *bandwidth* cost (cpu_max_cores units) — a 1/16-vCPU
+	machine needs 0.0625, not a whole vCPU — matching how `capacity_for_server` sums
+	usage. `required_memory_mb` and `required_disk_gb` are the VM's memory and
+	reserved disk (root + data). For each Active host, capacity is the same
+	three-axis accounting the desk helper uses (atlas/api/server_capacity.py): each
+	axis's *effective* budget minus what its non-Terminated VMs already spend. An
+	axis with no known total reports `effective is None` and is unlimited there — the
+	operator vouches for the host by marking it Active.
+
+	The winner is the feasible host that scores best under the operator's chosen
+	strategy (`packing.rank_key` — default Spread: the emptiest by relative fill, so
+	VMs spread to equal *relative* fill across heterogeneous hosts). Placement leaves
+	an arrival headroom reserve free on each host (`_placement_reserve_fraction`) so
+	later in-place resizes have room; resize spends it. Fully-measured hosts rank
+	ahead of partially/unmeasured ones, then `creation asc` breaks ties for
+	determinism. Raises `NoCapacityError` when nothing fits — Central reads that as
+	"region full for that size".
 
 	`candidate_servers`, when given, restricts the pool to that set (still ordered
 	by creation, still Active) — `default_server_for_image` passes the servers that
 	hold the image so placement never picks a host missing its bytes. None means the
 	whole Active fleet, the original behaviour.
 
-	Runs with ignore_permissions: this is system placement, not desk RBAC —
-	Central (the operator) triggers it without needing Server read access; the
-	system still has to choose one."""
+	Runs with ignore_permissions: this is system placement, not desk RBAC — Central
+	triggers it without needing Server read access; the system still has to choose."""
+	from atlas.atlas import packing
 	from atlas.atlas.api.server_capacity import capacity_for_server
 
 	servers = frappe.get_all(
@@ -289,15 +360,25 @@ def default_server(
 		servers = [server for server in servers if server in candidate_servers]
 	if not servers:
 		frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
-	for server in servers:
+	strategy = _strategy()
+	needs = {"cpu": required_vcpus, "memory": required_memory_mb, "disk": required_disk_gb}
+	# The rank key is (unmeasured axes, strategy score, creation index); min wins. The
+	# enumerate index preserves the `creation asc` tie-break without re-reading dates.
+	best: tuple[tuple, str] | None = None
+	for creation_index, server in enumerate(servers):
 		capacity = capacity_for_server(server)
-		if (
-			_fits(capacity["cpu"], required_vcpus)
-			and _fits(capacity["memory"], required_memory_mb)
-			and _fits(capacity["disk"], required_disk_gb)
-		):
-			return server
-	frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
+		budgets = {axis: capacity[axis]["effective"] for axis in packing.AXES}
+		used = {axis: capacity[axis]["used"] for axis in packing.AXES}
+		key = packing.rank_key(
+			strategy, budgets, used, needs, _placement_reserve_fraction(server), creation_index
+		)
+		if key is None:
+			continue
+		if best is None or key < best[0]:
+			best = (key, server)
+	if best is None:
+		frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
+	return best[1]
 
 
 # Sentinel free-headroom for an axis whose host total is unmeasured (agent hasn't

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -11,6 +11,8 @@ Operators creating a VM in Desk supply `server`/`image` explicitly, so this
 never runs for them.
 """
 
+from typing import NoReturn
+
 import frappe
 from frappe import _
 
@@ -251,6 +253,16 @@ class NoResizeCapacityError(NoCapacityError):
 	future work), not just retry the same placement."""
 
 
+class ConsolidationInProgressError(NoCapacityError):
+	"""No host fits the arrival right now, but placement is freeing one by migrating a
+	few small VMs off a host (spec/25 case 3 — defragmentation on arrival).
+
+	Subclasses `NoCapacityError` so Central's existing "region full → retry / queue"
+	handling fires unchanged — the retry is exactly the right response, because once
+	the consolidation migrations cut over a host will fit. The distinct type says the
+	remedy is already in motion (retry soon), not "the region is permanently full"."""
+
+
 def check_resize_capacity(
 	server: str,
 	delta_cpu: float,
@@ -376,9 +388,357 @@ def default_server(
 			continue
 		if best is None or key < best[0]:
 			best = (key, server)
-	if best is None:
+	if best is not None:
+		return best[1]
+	# Nothing fits as-is. Try to free a host by migrating a few small VMs off it
+	# (spec/25 case 3); that raises ConsolidationInProgressError ("retry, room is
+	# coming") when a plan exists or is already running, and NoCapacityError only when
+	# the region is genuinely full with nothing movable.
+	_raise_no_capacity(needs)
+
+
+# --- Consolidation: free a host by migrating a few small VMs (spec/25 case 3) ---
+#
+# When no Active host fits an arrival, the free units may just be scattered — each host
+# has a little room, none has enough in one place (a 16-unit Dedicated can't span hosts).
+# Rather than fail, placement may migrate a few SMALL VMs off one host onto the others'
+# scattered room, consolidating a single contiguous slot for the arrival. This is
+# defragmentation-on-arrival: bounded (`max_consolidation_migrations`), opt-out
+# (`placement_consolidation_enabled`), and conservative — it only moves VMs that are
+# safe to move (no attached public IPv4, no in-flight migration, onto a same-provider
+# target, matching migration.preflight_checks).
+#
+# The migrations are asynchronous (spec/24), so placement does NOT place the arrival on
+# the freed host in the same breath — it can't, the small VMs still run there until
+# cutover. It raises ConsolidationInProgressError; Central retries, and once the moves
+# cut over `default_server` finds the room. capacity_for_server counts a migrating VM on
+# BOTH hosts until cutover, so a retry never double-books the freed host mid-move — the
+# whole thing is idempotent.
+
+# VM states migration.preflight_checks accepts as a migration source.
+_MIGRATABLE_STATUSES = ("Running", "Stopped", "Paused")
+
+
+def _consolidation_enabled() -> bool:
+	"""Whether placement may free a host by migrating small VMs
+	(`Atlas Settings.placement_consolidation_enabled`, default on). Off → a full region
+	fails loud with NoCapacityError instead of defragmenting."""
+	value = frappe.db.get_single_value("Atlas Settings", "placement_consolidation_enabled")
+	return bool(value) if value is not None else True
+
+
+def _max_consolidation_migrations() -> int:
+	"""The cap on VMs moved to free room for one arrival — the "a few"
+	(`Atlas Settings.max_consolidation_migrations`, default 3). A plan needing more than
+	this on every host is rejected (→ NoCapacityError), so defragmentation stays
+	bounded and can't become a migration storm."""
+	value = frappe.db.get_single_value("Atlas Settings", "max_consolidation_migrations")
+	return int(value) if value else 3
+
+
+def _raise_no_capacity(needs: dict) -> NoReturn:
+	"""Decide the arrival's fate when no host fits it as-is: consolidate, wait, or fail.
+
+	- consolidation off → NoCapacityError (fail loud).
+	- a drain that will fit `needs` is already in flight → ConsolidationInProgressError
+	  (retry; don't pile on more migrations — this is what makes a burst of retries
+	  idempotent).
+	- a fresh plan exists → enqueue it (its own transaction — migrate() persists its
+	  Migration row on commit, spec/24) and raise ConsolidationInProgressError.
+	- nothing movable frees a host → NoCapacityError (the region is genuinely full)."""
+	if not _consolidation_enabled():
 		frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
-	return best[1]
+	if _consolidation_in_flight(needs):
+		frappe.throw(
+			_("Capacity is being freed by migrating small VMs — retry shortly."),
+			ConsolidationInProgressError,
+		)
+	if plan_consolidation(needs):
+		_enqueue_consolidation(needs)
+		frappe.throw(
+			_("Freeing capacity by migrating small VMs — retry shortly."),
+			ConsolidationInProgressError,
+		)
+	frappe.throw(_("No capacity available — contact your operator."), NoCapacityError)
+
+
+def _enqueue_consolidation(needs: dict) -> None:
+	"""Run the consolidation in a background job so it commits in its OWN transaction —
+	migrate() persists its Migration row on commit, which a doomed create's rollback
+	would otherwise drop. Deduplicated by the arrival shape so a burst of Central retries
+	can't launch the same defrag many times over."""
+	frappe.enqueue(
+		"atlas.atlas.placement.consolidate",
+		queue="long",
+		job_id=f"placement-consolidate:{needs['cpu']:g}:{int(needs['memory'])}:{int(needs['disk'])}",
+		deduplicate=True,
+		required_vcpus=needs["cpu"],
+		required_memory_mb=needs["memory"],
+		required_disk_gb=needs["disk"],
+	)
+
+
+def consolidate(required_vcpus, required_memory_mb, required_disk_gb) -> dict:
+	"""Execute one consolidation plan: migrate the chosen small VMs off a host to free
+	room for an arrival of this shape. Enqueued by `default_server` (never whitelisted —
+	it moves VMs, so no REST surface). Re-plans from fresh state (the fleet may have
+	shifted since the create failed), then triggers each move, committing per move so one
+	rejected move doesn't undo the others. Best-effort: a move preflight rejects is logged
+	and skipped."""
+	needs = {
+		"cpu": float(required_vcpus),
+		"memory": float(required_memory_mb),
+		"disk": float(required_disk_gb),
+	}
+	if not _consolidation_enabled():
+		return {"triggered": [], "reason": "disabled"}
+	plan = plan_consolidation(needs)
+	if not plan:
+		return {"triggered": [], "reason": "no-plan"}
+	recipient, moves = plan
+	triggered = []
+	for vm_name, target in moves:
+		try:
+			_start_migration(vm_name, target)
+			frappe.db.commit()
+			triggered.append({"virtual_machine": vm_name, "target": target})
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(
+				title="Placement consolidation migrate failed",
+				message=f"Freeing {recipient} for arrival {needs}: {vm_name} → {target}",
+			)
+	return {"recipient": recipient, "triggered": triggered}
+
+
+def _start_migration(vm_name: str, target_server: str) -> str:
+	"""Trigger one VM's migration to `target_server`. A one-line seam so tests can stand
+	in for the heavy, provider-touching migrate() call."""
+	return frappe.get_doc("Virtual Machine", vm_name).migrate(target_server)
+
+
+def plan_consolidation(needs: dict) -> tuple[str, list[tuple[str, str]]] | None:
+	"""A defragmentation plan that frees one host for `needs`, or None.
+
+	Returns `(recipient, [(vm_name, target_server), ...])`: the host the arrival will
+	land on once cleared, and the small VMs to migrate off it (and where). Pure planning
+	— reads the fleet, moves nothing. Greedy and bounded:
+
+	- For each Active host as candidate `recipient`, evict its smallest movable VMs
+	  (smallest RAM first — RAM is the binding axis on the ladder) one at a time, each to
+	  the best same-provider target among the OTHER hosts (the operator's strategy picks
+	  the target), until the recipient fits `needs` or the move cap is hit.
+	- A candidate that reaches a fit within the cap is a valid plan; across candidates the
+	  cheapest wins — fewest moves, then least disk to hydrate.
+
+	Never proposes a move migration.preflight_checks would reject: only Running/Stopped/
+	Paused VMs with no attached public IPv4 and no in-flight migration, onto a
+	same-provider Active target with room. None when no host can be cleared within the
+	cap — the caller then reports the region genuinely full."""
+	if not _consolidation_enabled():
+		return None
+	snapshot = _fleet_snapshot()
+	if len(snapshot) < 2:
+		return None  # need at least one OTHER host to receive the evicted VMs
+	strategy = _strategy()
+	cap = _max_consolidation_migrations()
+	best: tuple[tuple, str, list] | None = None
+	for recipient in snapshot:
+		moves = _plan_for_recipient(recipient, needs, snapshot, strategy, cap)
+		if not moves:
+			continue
+		cost = (len(moves), sum(disk for _vm, _target, disk in moves))
+		if best is None or cost < best[0]:
+			best = (cost, recipient, [(vm, target) for vm, target, _disk in moves])
+	if best is None:
+		return None
+	return best[1], best[2]
+
+
+def _plan_for_recipient(recipient: str, needs: dict, snapshot: dict, strategy: str, cap: int):
+	"""Evict `recipient`'s smallest movable VMs (each to a same-provider target) until it
+	fits `needs`, capped at `cap` moves. Returns the move list `[(vm, target, disk_gb)]`
+	or None if it can't be cleared within the cap. Works on copies of the snapshot's
+	`used` counters so it doesn't disturb the sibling candidates."""
+	from atlas.atlas import packing
+
+	host = snapshot[recipient]
+	recipient_used = dict(host["used"])
+	if _host_fits(host["budgets"], recipient_used, needs, host["reserve"]):
+		return []  # already fits (default_server checked, but harmless to short-circuit)
+	others_used = {name: dict(snapshot[name]["used"]) for name in snapshot if name != recipient}
+	moves: list = []
+	for vm in _movable_vms(recipient):
+		if len(moves) >= cap:
+			break
+		target = _best_target(vm, recipient, snapshot, others_used, strategy)
+		if target is None:
+			continue  # can't rehome this one within the fleet's room; try the next-smallest
+		for axis in packing.AXES:
+			recipient_used[axis] -= vm[axis]
+			others_used[target][axis] += vm[axis]
+		moves.append((vm["name"], target, vm["disk"]))
+		if _host_fits(host["budgets"], recipient_used, needs, host["reserve"]):
+			return moves
+	return None
+
+
+def _best_target(vm: dict, recipient: str, snapshot: dict, others_used: dict, strategy: str) -> str | None:
+	"""The best host to receive an evicted `vm`, scored by the operator's strategy, or
+	None. Same-provider only (migration.preflight_checks rejects cross-provider) and never
+	the recipient we are trying to clear. `others_used` carries the placements already
+	planned in this pass so two evictees don't both claim the same slot."""
+	from atlas.atlas import packing
+
+	vm_needs = {axis: vm[axis] for axis in packing.AXES}
+	source_provider = snapshot[recipient]["provider"]
+	best: tuple[tuple, str] | None = None
+	for name, used in others_used.items():
+		candidate = snapshot[name]
+		if candidate["provider"] != source_provider:
+			continue
+		key = packing.rank_key(
+			strategy, candidate["budgets"], used, vm_needs, candidate["reserve"], candidate["creation_index"]
+		)
+		if key is None:
+			continue
+		if best is None or key < best[0]:
+			best = (key, name)
+	return best[1] if best else None
+
+
+def _host_fits(budgets: dict, used: dict, needs: dict, reserve: float) -> bool:
+	"""Does `needs` fit on a host with these budgets/used, honouring its arrival reserve?
+	Reuses the one feasibility gate every strategy shares (`packing.rank_key` is None iff
+	infeasible), so the planner can never disagree with `default_server` about "fits"."""
+	from atlas.atlas import packing
+
+	return packing.rank_key(packing.FIRST_FIT, budgets, used, needs, reserve, 0) is not None
+
+
+def _fleet_snapshot() -> dict:
+	"""A per-Active-host snapshot the planner mutates in memory: `{server: {budgets, used,
+	reserve, creation_index, provider}}`. `used` already counts VMs migrating in (spec/24
+	accounting), so the planner sees a host receiving migrations as the fuller host it
+	really is."""
+	from atlas.atlas import packing
+	from atlas.atlas.api.server_capacity import capacity_for_server
+
+	names = frappe.get_all(
+		"Server",
+		filters={"status": "Active"},
+		pluck="name",
+		order_by="creation asc",
+		ignore_permissions=True,
+	)
+	snapshot = {}
+	for index, name in enumerate(names):
+		cap = capacity_for_server(name)
+		snapshot[name] = {
+			"budgets": {axis: cap[axis]["effective"] for axis in packing.AXES},
+			"used": {axis: cap[axis]["used"] for axis in packing.AXES},
+			"reserve": _placement_reserve_fraction(name),
+			"creation_index": index,
+			"provider": frappe.db.get_value("Server", name, "provider_type"),
+		}
+	return snapshot
+
+
+def _movable_vms(server: str) -> list:
+	"""`server`'s VMs that are safe to migrate away, smallest first (smallest RAM, then
+	disk, then CPU — RAM is the binding axis on the ladder). Excludes VMs with an attached
+	public IPv4 (moving one silently releases a Reserved IP), VMs already migrating, and
+	non-migratable states — exactly what migration.preflight_checks would reject, so a
+	plan never proposes a move that can't run. Each entry is `{name, cpu, memory, disk}`,
+	the per-axis cost matching capacity_for_server's sums."""
+	from atlas.atlas.doctype.virtual_machine_migration.virtual_machine_migration import (
+		active_migration_for,
+	)
+
+	rows = frappe.get_all(
+		"Virtual Machine",
+		filters={"server": server, "status": ["in", _MIGRATABLE_STATUSES]},
+		fields=[
+			"name",
+			"vcpus",
+			"cpu_max_cores",
+			"memory_megabytes",
+			"disk_gigabytes",
+			"data_disk_gigabytes",
+			"public_ipv4",
+		],
+	)
+	movable = []
+	for r in rows:
+		if r.public_ipv4 or active_migration_for(r.name):
+			continue
+		movable.append(
+			{
+				"name": r.name,
+				"cpu": float(r.cpu_max_cores or r.vcpus or 0),
+				"memory": float(r.memory_megabytes or 0),
+				"disk": float((r.disk_gigabytes or 0) + (r.data_disk_gigabytes or 0)),
+			}
+		)
+	movable.sort(key=lambda v: (v["memory"], v["disk"], v["cpu"]))
+	return movable
+
+
+def _vm_cost(vm_name: str) -> dict:
+	"""One VM's per-axis capacity cost (cpu/memory/disk), matching capacity_for_server."""
+	v = (
+		frappe.db.get_value(
+			"Virtual Machine",
+			vm_name,
+			["vcpus", "cpu_max_cores", "memory_megabytes", "disk_gigabytes", "data_disk_gigabytes"],
+			as_dict=True,
+		)
+		or {}
+	)
+	return {
+		"cpu": float(v.get("cpu_max_cores") or v.get("vcpus") or 0),
+		"memory": float(v.get("memory_megabytes") or 0),
+		"disk": float((v.get("disk_gigabytes") or 0) + (v.get("data_disk_gigabytes") or 0)),
+	}
+
+
+def _consolidation_in_flight(needs: dict) -> bool:
+	"""Whether an in-flight drain will soon fit `needs` on some host — that host's
+	OUTBOUND migrations, once cut over, drop its use below the arrival's need. True → the
+	caller waits (retry) instead of launching more migrations, which is what keeps a burst
+	of Central retries from stacking redundant defrags. capacity_for_server counts a
+	migrating VM on both hosts until cutover, so the source reads full NOW; here we look
+	past that to the post-cutover state."""
+	from collections import defaultdict
+
+	from atlas.atlas import packing
+	from atlas.atlas.doctype.virtual_machine_migration.virtual_machine_migration import (
+		TERMINAL_STATUSES,
+	)
+
+	active = frappe.get_all(
+		"Virtual Machine Migration",
+		filters={"status": ["not in", TERMINAL_STATUSES]},
+		fields=["virtual_machine", "source_server"],
+	)
+	if not active:
+		return False
+	snapshot = _fleet_snapshot()
+	leaving = defaultdict(list)
+	for row in active:
+		leaving[row.source_server].append(row.virtual_machine)
+	for source, vm_names in leaving.items():
+		host = snapshot.get(source)
+		if host is None:
+			continue
+		used = dict(host["used"])
+		for name in vm_names:
+			cost = _vm_cost(name)
+			for axis in packing.AXES:
+				used[axis] -= cost[axis]
+		if _host_fits(host["budgets"], used, needs, host["reserve"]):
+			return True
+	return False
 
 
 # Sentinel free-headroom for an axis whose host total is unmeasured (agent hasn't

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -5,7 +5,7 @@ runs — they state name, size, and SSH key, and the controller fills `server`
 and `image` here. The operator still owns the fleet: which Servers are Active
 and which Image is the default are operator decisions. This is placement, not
 scheduling — load-aware spread across Active servers (the emptiest by relative
-fill wins; see spec/24-placement.md), not queues or reactive rebalancing.
+fill wins; see spec/28-placement.md), not queues or reactive rebalancing.
 
 Operators creating a VM in Desk supply `server`/`image` explicitly, so this
 never runs for them.
@@ -247,7 +247,7 @@ class NoResizeCapacityError(NoCapacityError):
 	Subclasses `NoCapacityError` so Central's existing "region full → retry / queue /
 	alert the operator" handling still fires unchanged (same HTTP status, same
 	message shape). The distinct type carries the extra signal that the remedy is
-	specific: migrate this VM to a host that fits the new size (spec/24 case 2 —
+	specific: migrate this VM to a host that fits the new size (spec/28 case 2 —
 	future work), not just retry the same placement."""
 
 
@@ -305,7 +305,7 @@ def _strategy() -> str:
 
 	Falls back to `packing.DEFAULT_STRATEGY` when unset or unknown, so an operator can
 	switch the scorer (Spread / Best Fit / Tetris / First Fit) without touching code.
-	spec/24 and the offline simulator (`packing_sim.py`) explain the trade-off each
+	spec/28 and the offline simulator (`packing_sim.py`) explain the trade-off each
 	strategy makes; on the proportional ladder + homogeneous hosts they coincide."""
 	from atlas.atlas import packing
 

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -255,7 +255,7 @@ class NoResizeCapacityError(NoCapacityError):
 
 class ConsolidationInProgressError(NoCapacityError):
 	"""No host fits the arrival right now, but placement is freeing one by migrating a
-	few small VMs off a host (spec/25 case 3 — defragmentation on arrival).
+	few small VMs off a host (spec/28 case 3 — defragmentation on arrival).
 
 	Subclasses `NoCapacityError` so Central's existing "region full → retry / queue"
 	handling fires unchanged — the retry is exactly the right response, because once
@@ -391,13 +391,13 @@ def default_server(
 	if best is not None:
 		return best[1]
 	# Nothing fits as-is. Try to free a host by migrating a few small VMs off it
-	# (spec/25 case 3); that raises ConsolidationInProgressError ("retry, room is
+	# (spec/28 case 3); that raises ConsolidationInProgressError ("retry, room is
 	# coming") when a plan exists or is already running, and NoCapacityError only when
 	# the region is genuinely full with nothing movable.
 	_raise_no_capacity(needs)
 
 
-# --- Consolidation: free a host by migrating a few small VMs (spec/25 case 3) ---
+# --- Consolidation: free a host by migrating a few small VMs (spec/28 case 3) ---
 #
 # When no Active host fits an arrival, the free units may just be scattered — each host
 # has a little room, none has enough in one place (a 16-unit Dedicated can't span hosts).

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -202,6 +202,16 @@ def _warm_snapshot_result(variables: dict) -> dict:
 	}
 
 
+def _server_facts_result(_variables: dict) -> dict:
+	# A Fake host measures nothing, so report the DEFAULT fake size's totals — enough
+	# that the Refresh Capacity button doesn't crash `parse_result` in dev. Cosmetic:
+	# a Fake host's real capacity comes from `fake_host_totals` in
+	# `capacity_for_server`, which re-synthesizes and ignores the stamped row.
+	from atlas.atlas.providers.fake import DEFAULT_FAKE_SIZE, fake_host_totals
+
+	return {**fake_host_totals(DEFAULT_FAKE_SIZE), "pool_data_percent": 0.0}
+
+
 def _fake_disk_bytes(variables: dict) -> int:
 	"""A plausible rootfs size: the VM's disk in bytes, defaulting to ~4 GB."""
 	try:
@@ -213,6 +223,7 @@ def _fake_disk_bytes(variables: dict) -> int:
 
 _RESULT_BUILDERS = {
 	"bootstrap-server": _bootstrap_result,
+	"server-facts": _server_facts_result,
 	"snapshot-vm": _snapshot_result,
 	"snapshot-stop-vm": _snapshot_stop_result,
 	"warm-snapshot-vm": _warm_snapshot_result,

--- a/atlas/atlas/sizes.py
+++ b/atlas/atlas/sizes.py
@@ -70,7 +70,7 @@ SIZE_PRESETS: dict[str, dict[str, float | int]] = {
 # truth. Because every preset is a whole-number multiple of this (test_sizes pins
 # it), a host holds `floor(min over axes of effective/unit)` share units and any mix
 # of preset VMs whose unit-sum fits, fits — packing is one-dimensional with zero
-# intra-host fragmentation (spec/24). Reporting sugar only: feasibility and scoring
+# intra-host fragmentation (spec/28). Reporting sugar only: feasibility and scoring
 # stay generic three-axis so Custom (operator-typed) shapes keep working.
 SHARE_UNIT: dict[str, float | int] = {
 	"cpu_max_cores": SIZE_PRESETS["Shared 1x"]["cpu_max_cores"],

--- a/atlas/atlas/sizes.py
+++ b/atlas/atlas/sizes.py
@@ -65,6 +65,20 @@ SIZE_PRESETS: dict[str, dict[str, float | int]] = {
 }
 
 
+# The share unit every preset is an exact scalar multiple of: Shared 1x's cost on
+# the three packed axes. Derived from the ladder itself so there is ONE source of
+# truth. Because every preset is a whole-number multiple of this (test_sizes pins
+# it), a host holds `floor(min over axes of effective/unit)` share units and any mix
+# of preset VMs whose unit-sum fits, fits — packing is one-dimensional with zero
+# intra-host fragmentation (spec/24). Reporting sugar only: feasibility and scoring
+# stay generic three-axis so Custom (operator-typed) shapes keep working.
+SHARE_UNIT: dict[str, float | int] = {
+	"cpu_max_cores": SIZE_PRESETS["Shared 1x"]["cpu_max_cores"],
+	"memory_megabytes": SIZE_PRESETS["Shared 1x"]["memory_megabytes"],
+	"disk_gigabytes": SIZE_PRESETS["Shared 1x"]["disk_gigabytes"],
+}
+
+
 def size_preset_options() -> str:
 	"""The Virtual Machine.size_preset Select `options` string.
 

--- a/atlas/tests/test_api_server_capacity.py
+++ b/atlas/tests/test_api_server_capacity.py
@@ -229,6 +229,77 @@ class TestServerCapacity(IntegrationTestCase):
 		self.assertGreaterEqual(cluster["share_units"]["used"], 1)
 		self.assertIn("cpu", cluster["stranded"])
 
+	# --- migration-aware accounting: an incoming migration charges the target -------
+
+	def test_incoming_migration_counts_against_target(self) -> None:
+		# A VM migrating from the source host into a target is already spending the
+		# target's budget (its disk hydrates and it boots there) before cutover
+		# repoints `vm.server`. capacity_for_server must charge the target so placement
+		# doesn't double-book a host that is receiving migrations.
+		target = make_server(
+			self.provider,
+			"capacity-migration-target",
+			ipv6_address="2001:db8:11::1",
+			ipv6_prefix="2001:db8:11::/64",
+			ipv6_virtual_machine_range="2001:db8:11::/124",
+			status="Active",
+		)
+		target.db_set("memory_megabytes_total", 4096)
+		target.db_set("pool_disk_gigabytes_total", 100)
+		vm = make_virtual_machine(self.server, self.image, memory_megabytes=1024, disk_gigabytes=8)
+		migration = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Migration",
+				"virtual_machine": vm.name,
+				"source_server": self.server.name,
+				"target_server": target.name,
+				"status": "Hydrating",
+			}
+		)
+		migration.flags.keep_address_forced = True  # skip the provider address probe
+		migration.insert(ignore_permissions=True)
+
+		target_cap = server_capacity.capacity_for_server(target.name)
+		self.assertEqual(target_cap["memory"]["used"], 1024, "incoming migration charges target RAM")
+		self.assertEqual(target_cap["disk"]["used"], 8, "and target disk")
+		self.assertEqual(target_cap["incoming_migration_count"], 1)
+		self.assertEqual(target_cap["virtual_machine_count"], 0, "not resident on the target yet")
+
+		# The source still counts it — the guest runs there until cutover, so a
+		# migrating VM is deliberately charged to BOTH hosts for its brief life.
+		source_cap = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(source_cap["memory"]["used"], 1024)
+		self.assertEqual(source_cap["virtual_machine_count"], 1)
+
+	def test_terminal_migration_does_not_count(self) -> None:
+		# A Done migration is history — its VM has already cut over (or the move
+		# failed); it must not keep charging the target.
+		target = make_server(
+			self.provider,
+			"capacity-migration-target",
+			ipv6_address="2001:db8:11::1",
+			ipv6_prefix="2001:db8:11::/64",
+			ipv6_virtual_machine_range="2001:db8:11::/124",
+			status="Active",
+		)
+		target.db_set("memory_megabytes_total", 4096)
+		vm = make_virtual_machine(self.server, self.image, memory_megabytes=1024)
+		migration = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Migration",
+				"virtual_machine": vm.name,
+				"source_server": self.server.name,
+				"target_server": target.name,
+				"status": "Done",
+			}
+		)
+		migration.flags.keep_address_forced = True
+		migration.insert(ignore_permissions=True)
+
+		target_cap = server_capacity.capacity_for_server(target.name)
+		self.assertEqual(target_cap["memory"]["used"], 0, "a terminal migration charges nothing")
+		self.assertEqual(target_cap["incoming_migration_count"], 0)
+
 
 class TestFakeServerAlwaysMeasured(IntegrationTestCase):
 	"""A Fake host has no agent, but dev capacity math must always be *measured*:

--- a/atlas/tests/test_api_server_capacity.py
+++ b/atlas/tests/test_api_server_capacity.py
@@ -130,10 +130,10 @@ class TestServerCapacity(IntegrationTestCase):
 		result = server_capacity.capacity_for_server(self.server.name)
 		self.assertEqual(result["memory"]["effective"], 0)
 
-	# --- Share units + stranded (spec/24) ---------------------------------
+	# --- Share units + stranded (spec/28) ---------------------------------
 
 	def test_share_units_and_stranded_worked_example(self) -> None:
-		# The spec/24 worked example: an 8-core / 16 GB / 320 GB host at factor 1 with
+		# The spec/28 worked example: an 8-core / 16 GB / 320 GB host at factor 1 with
 		# a 1 GB memory reserve holds 30 share units (RAM binds), and the unused CPU
 		# and disk the RAM axis can't sell are stranded.
 		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 1024)

--- a/atlas/tests/test_api_server_capacity.py
+++ b/atlas/tests/test_api_server_capacity.py
@@ -16,6 +16,9 @@ class TestServerCapacity(IntegrationTestCase):
 		# Reset to the no-oversubscription default so other suites can't leak a
 		# factor into these assertions; restore is unnecessary (1 is the default).
 		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		# Default to no memory floor so the raw-total assertions below stay clean;
+		# the reserve tests opt back in explicitly.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
 		self.provider = make_provider("capacity-test-provider")
 		self.server = make_server(
 			self.provider,
@@ -112,6 +115,68 @@ class TestServerCapacity(IntegrationTestCase):
 		result = server_capacity.capacity_for_server(self.server.name)
 		self.assertEqual(result["disk"]["used"], 35)
 
+	# --- Memory floor (host_memory_reserve_megabytes) ---------------------
+
+	def test_memory_reserve_subtracted_from_effective(self) -> None:
+		# effective = total − reserve; the raw total stays physical for display.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 1024)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["memory"]["total"], 4096, "raw total unchanged")
+		self.assertEqual(result["memory"]["effective"], 3072, "budget is total − reserve")
+
+	def test_memory_reserve_clamps_at_zero(self) -> None:
+		# A reserve larger than the host's RAM clamps the budget at 0, never negative.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 8192)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["memory"]["effective"], 0)
+
+	# --- Share units + stranded (spec/24) ---------------------------------
+
+	def test_share_units_and_stranded_worked_example(self) -> None:
+		# The spec/24 worked example: an 8-core / 16 GB / 320 GB host at factor 1 with
+		# a 1 GB memory reserve holds 30 share units (RAM binds), and the unused CPU
+		# and disk the RAM axis can't sell are stranded.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 1024)
+		self.server.db_set("vcpus_total", 8)
+		self.server.db_set("memory_megabytes_total", 16384)
+		self.server.db_set("pool_disk_gigabytes_total", 320)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["share_units"], {"total": 30, "used": 0, "free": 30})
+		self.assertAlmostEqual(result["stranded"]["cpu"], 6.125)  # 8 − 30×0.0625
+		self.assertEqual(result["stranded"]["memory"], 0)  # RAM is the binding axis
+		self.assertEqual(result["stranded"]["disk"], 20)  # 320 − 30×10
+
+	def test_share_units_used_and_free(self) -> None:
+		# A Dedicated 1x (16 units on every axis) spends 16 of the 30 units.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 1024)
+		self.server.db_set("vcpus_total", 8)
+		self.server.db_set("memory_megabytes_total", 16384)
+		self.server.db_set("pool_disk_gigabytes_total", 320)
+		make_virtual_machine(
+			self.server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=8192, disk_gigabytes=160
+		)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["share_units"], {"total": 30, "used": 16, "free": 14})
+
+	def test_share_units_over_measured_axes_only(self) -> None:
+		# Partial measurement: only RAM is catalogued (unknown slug → no CPU, disk
+		# unset), so units count RAM alone and stranded has only the RAM axis.
+		self.server.db_set("size", "s-unknown-slug")
+		self.server.db_set("memory_megabytes_total", 4096)
+		self.server.db_set("pool_disk_gigabytes_total", 0)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["share_units"]["total"], 8)  # 4096 / 512
+		self.assertEqual(set(result["stranded"]), {"memory"})
+
+	def test_share_units_none_when_fully_uncatalogued(self) -> None:
+		# No axis measured → nothing to count share units against.
+		self.server.db_set("size", "s-unknown-slug")
+		self.server.db_set("memory_megabytes_total", 0)
+		self.server.db_set("pool_disk_gigabytes_total", 0)
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertIsNone(result["share_units"])
+		self.assertIsNone(result["stranded"])
+
 	# --- Uncatalogued axes → unlimited ------------------------------------
 
 	def test_unset_memory_disk_totals_are_unlimited(self) -> None:
@@ -155,6 +220,15 @@ class TestServerCapacity(IntegrationTestCase):
 		self.assertGreaterEqual(cluster["disk"]["used"], 10)
 		self.assertIn("uncatalogued", cluster["cpu"])
 
+	def test_cluster_rolls_up_share_units(self) -> None:
+		# The fleet view carries a share-unit roll-up across measured hosts (this
+		# fixture host is fully measured, so it contributes at least one used unit).
+		make_virtual_machine(self.server, self.image, vcpus=1, memory_megabytes=512, disk_gigabytes=10)
+		cluster = server_capacity.cluster_capacity()
+		self.assertIsNotNone(cluster["share_units"])
+		self.assertGreaterEqual(cluster["share_units"]["used"], 1)
+		self.assertIn("cpu", cluster["stranded"])
+
 
 class TestFakeServerAlwaysMeasured(IntegrationTestCase):
 	"""A Fake host has no agent, but dev capacity math must always be *measured*:
@@ -163,6 +237,7 @@ class TestFakeServerAlwaysMeasured(IntegrationTestCase):
 
 	def setUp(self) -> None:
 		_clean_virtual_machines()
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
 		# Build with the default DO fixture (its catalog is seeded), then flip the
 		# row to a Fake host via db_set — the Fake size slug isn't a seeded Provider
 		# Size, so it can't pass the Link check at insert.

--- a/atlas/tests/test_packing.py
+++ b/atlas/tests/test_packing.py
@@ -3,7 +3,7 @@
 No Frappe, no host — `packing`, `packing_metrics`, and `packing_sim` are plain
 Python (the only Atlas import underneath is `sizes`, itself pure). Runs under the
 Frappe test runner like everything else, but needs nothing from it. These pin the
-strategy semantics (spec/24), the metric math, and that the simulator is
+strategy semantics (spec/28), the metric math, and that the simulator is
 deterministic and behaves sanely across arrivals, drops, resizes, and the edges.
 """
 
@@ -195,7 +195,7 @@ class TestSimulator(unittest.TestCase):
 		# tracks Spread's and is a fraction of Best Fit's — it is a low-migration
 		# middle ground, NOT a migration reducer. Its statistically-significant win is
 		# Dedicated acceptance (blocked-largest); that is a many-seed effect measured
-		# with compare_seeds and documented in spec/24, not a single-seed unit assert.
+		# with compare_seeds and documented in spec/28, not a single-seed unit assert.
 		# Moderate load (not saturated) — that's where Best Fit's migration blow-up
 		# is largest and the middle-ground property is clearest.
 		results = packing_sim.compare(

--- a/atlas/tests/test_packing.py
+++ b/atlas/tests/test_packing.py
@@ -1,0 +1,224 @@
+"""The pure packing layer: strategy scoring, fleet metrics, and the simulator.
+
+No Frappe, no host — `packing`, `packing_metrics`, and `packing_sim` are plain
+Python (the only Atlas import underneath is `sizes`, itself pure). Runs under the
+Frappe test runner like everything else, but needs nothing from it. These pin the
+strategy semantics (spec/24), the metric math, and that the simulator is
+deterministic and behaves sanely across arrivals, drops, resizes, and the edges.
+"""
+
+import unittest
+
+from atlas.atlas import packing, packing_metrics, packing_sim
+from atlas.atlas.packing import BEST_FIT, FIRST_FIT, HYBRID, SPREAD, TETRIS
+from atlas.atlas.packing_sim import SimConfig
+
+_FULL = {"cpu": 8.0, "memory": 16384.0, "disk": 320.0}
+_EMPTY = {"cpu": 0.0, "memory": 0.0, "disk": 0.0}
+_SHARED_1X = {"cpu": 0.0625, "memory": 512.0, "disk": 10.0}
+
+
+def _used(cpu=0.0, memory=0.0, disk=0.0) -> dict:
+	return {"cpu": cpu, "memory": memory, "disk": disk}
+
+
+class _StubHost:
+	"""Minimal duck-type for the metrics functions."""
+
+	def __init__(self, budget, used, vm_count=0):
+		self.budget = budget
+		self.used = used
+		self.vm_count = vm_count
+
+
+class TestStrategyScoring(unittest.TestCase):
+	def test_infeasible_returns_none(self) -> None:
+		# A 512 MB VM can't fit where only 100 MB is free.
+		budgets = {"cpu": 8.0, "memory": 512.0, "disk": 320.0}
+		self.assertIsNone(
+			packing.rank_key(SPREAD, budgets, _used(memory=400.0), _SHARED_1X, 0.0, 0)
+		)
+
+	def test_unmeasured_axis_is_unlimited_and_counted(self) -> None:
+		# A None budget fits anything, but bumps the unmeasured count (first rank
+		# element) so a measured host always outranks it.
+		budgets = {"cpu": None, "memory": 16384.0, "disk": 320.0}
+		key = packing.rank_key(SPREAD, budgets, _EMPTY, _SHARED_1X, 0.0, 0)
+		self.assertIsNotNone(key)
+		self.assertEqual(key[0], 1, "one unmeasured axis")
+		measured = packing.rank_key(SPREAD, _FULL, _EMPTY, _SHARED_1X, 0.0, 0)
+		self.assertLess(measured[0], key[0], "measured host ranks ahead")
+
+	def test_spread_prefers_the_emptier_host(self) -> None:
+		empty = packing.rank_key(SPREAD, _FULL, _EMPTY, _SHARED_1X, 0.0, 0)
+		half = packing.rank_key(SPREAD, _FULL, _used(4.0, 8192.0, 160.0), _SHARED_1X, 0.0, 1)
+		self.assertLess(empty, half, "spread picks the emptier host")
+
+	def test_best_fit_prefers_the_fuller_host(self) -> None:
+		empty = packing.rank_key(BEST_FIT, _FULL, _EMPTY, _SHARED_1X, 0.0, 0)
+		half = packing.rank_key(BEST_FIT, _FULL, _used(4.0, 8192.0, 160.0), _SHARED_1X, 0.0, 1)
+		self.assertLess(half, empty, "best fit packs the fuller host first")
+
+	def test_tetris_prefers_the_shape_matched_host(self) -> None:
+		# Both hosts fit the VM, but B's free capacity is aligned with the demand
+		# (lots of free memory/disk, the axes the proportional VM leans on).
+		a = packing.rank_key(TETRIS, _FULL, _used(memory=15000.0), _SHARED_1X, 0.0, 0)
+		b = packing.rank_key(TETRIS, _FULL, _used(cpu=7.5), _SHARED_1X, 0.0, 1)
+		self.assertLess(b, a, "tetris picks the host whose free shape matches demand")
+
+	def test_first_fit_is_pure_creation_order(self) -> None:
+		# First fit ignores fill: among feasible hosts the lowest tie-breaker wins.
+		older = packing.rank_key(FIRST_FIT, _FULL, _used(4.0, 8192.0, 160.0), _SHARED_1X, 0.0, 0)
+		newer = packing.rank_key(FIRST_FIT, _FULL, _EMPTY, _SHARED_1X, 0.0, 1)
+		self.assertLess(older, newer, "first fit takes the earliest feasible host")
+
+	def test_hybrid_best_fits_dedicated_and_spreads_the_rest(self) -> None:
+		# A dedicated-class VM (a full guaranteed core) is scored Best Fit; a shared
+		# tier is scored Spread. Same two hosts (one empty, one half), so the two base
+		# strategies pick opposite hosts and Hybrid must match each one.
+		dedicated = {"cpu": 1.0, "memory": 8192.0, "disk": 160.0}
+		half = _used(4.0, 8192.0, 160.0)
+		# Dedicated → Best Fit → prefers the fuller host.
+		self.assertLess(
+			packing.rank_key(HYBRID, _FULL, half, dedicated, 0.0, 1),
+			packing.rank_key(HYBRID, _FULL, _EMPTY, dedicated, 0.0, 0),
+		)
+		# Shared → Spread → prefers the emptier host.
+		self.assertLess(
+			packing.rank_key(HYBRID, _FULL, _EMPTY, _SHARED_1X, 0.0, 0),
+			packing.rank_key(HYBRID, _FULL, half, _SHARED_1X, 0.0, 1),
+		)
+
+	def test_reserve_shrinks_the_feasible_budget(self) -> None:
+		budgets = {"cpu": 8.0, "memory": 1024.0, "disk": 320.0}
+		need = {"cpu": 0.0625, "memory": 768.0, "disk": 10.0}
+		self.assertIsNotNone(packing.rank_key(SPREAD, budgets, _EMPTY, need, 0.0, 0), "raw budget fits")
+		self.assertIsNone(
+			packing.rank_key(SPREAD, budgets, _EMPTY, need, 0.5, 0), "a 50% reserve blocks it"
+		)
+
+
+class TestMetrics(unittest.TestCase):
+	def test_committed_utilization(self) -> None:
+		hosts = [_StubHost(_FULL, _used(4.0, 8192.0, 160.0), vm_count=1)]
+		util = packing_metrics.committed_utilization(hosts)
+		self.assertAlmostEqual(util["cpu"], 0.5)
+		self.assertAlmostEqual(util["memory"], 0.5)
+
+	def test_share_units_and_stranded(self) -> None:
+		# 8c / 16 GB / 320 GB: RAM binds at 16384/512 = 32 units; CPU and disk strand.
+		host = _StubHost(_FULL, _EMPTY)
+		self.assertEqual(packing_metrics.share_units(host)["total"], 32)
+		stranded = packing_metrics.stranded(host)
+		self.assertAlmostEqual(stranded["cpu"], 8.0 - 32 * 0.0625)  # 6.0 cores
+		self.assertEqual(stranded["memory"], 0)
+
+	def test_compaction_ratio_flags_consolidation(self) -> None:
+		# Two half-full hosts hold what one host could — compaction < 1 (drainable).
+		hosts = [
+			_StubHost(_FULL, _used(2.0, 4096.0, 80.0), vm_count=1),
+			_StubHost(_FULL, _used(2.0, 4096.0, 80.0), vm_count=1),
+		]
+		self.assertLess(packing_metrics.compaction_ratio(hosts), 1.0)
+		# One host carrying its own load is already tight.
+		tight = [_StubHost(_FULL, _used(7.0, 14000.0, 300.0), vm_count=1)]
+		self.assertEqual(packing_metrics.compaction_ratio(tight), 1.0)
+
+
+class TestSimulator(unittest.TestCase):
+	def _config(self, **overrides) -> SimConfig:
+		base = {"seed": 7, "duration": 3000.0, "arrival_rate": 1.0, "host_count": 15}
+		base.update(overrides)
+		return SimConfig(**base)
+
+	def test_deterministic(self) -> None:
+		config = self._config()
+		self.assertEqual(packing_sim.run(config), packing_sim.run(config))
+
+	def test_same_workload_across_strategies(self) -> None:
+		# compare() replays ONE workload, so every strategy sees the same arrivals →
+		# identical total attempts. Only the placement outcomes differ.
+		results = packing_sim.compare(self._config())
+		attempted = {stats["attempted"] for stats in results.values()}
+		self.assertEqual(len(attempted), 1, "every strategy sees the same workload")
+		self.assertGreater(attempted.pop(), 0)
+
+	def test_drops_free_capacity(self) -> None:
+		# Under saturating load, short-lived VMs (fast drops) accept far more than
+		# long-lived ones — departures return capacity to the pool.
+		saturating = {"host_count": 5, "arrival_rate": 2.0, "duration": 4000.0}
+		churny = packing_sim.run(self._config(mean_lifetime=30.0, **saturating))
+		sticky = packing_sim.run(self._config(mean_lifetime=5000.0, **saturating))
+		self.assertGreater(churny["acceptance"], sticky["acceptance"])
+
+	def test_resizes_in_place_and_forced_migration(self) -> None:
+		# Small hosts packed with small VMs; upgrades can't always grow in place, so
+		# some force a migration. The three outcomes partition every upgrade attempt.
+		config = self._config(
+			host_count=8,
+			arrival_rate=1.5,
+			mean_lifetime=400.0,
+			upgrade_hazard=0.02,
+			host_shapes=((1.0, 2048.0, 40.0),),  # a Shared-8x-sized host: tight for growth
+		)
+		stats = packing_sim.run(config)
+		self.assertGreater(
+			stats["in_place_upgrade_rate"], 0.0, "some upgrades grow in place on an idle-ish host"
+		)
+		self.assertGreater(stats["forced_migrations"], 0, "a full host forces a migration")
+
+	def test_best_fit_uses_no_more_hosts_than_spread(self) -> None:
+		# At moderate load best fit concentrates VMs → it lights up fewer hosts than
+		# spread, which fans them out. (Same workload via compare().)
+		results = packing_sim.compare(self._config(host_count=30, mean_lifetime=100.0))
+		self.assertLessEqual(
+			results[BEST_FIT]["mean_hosts_in_use"],
+			results[SPREAD]["mean_hosts_in_use"] + 1e-9,
+		)
+
+	def test_blocked_largest_is_the_fragmentation_canary(self) -> None:
+		# When the fleet is pressured, the largest (Dedicated) plan is blocked at a
+		# higher rate than the fleet average — scattered free units can't seat it.
+		stats = packing_sim.run(
+			self._config(strategy=SPREAD, host_count=4, arrival_rate=2.0, mean_lifetime=200.0)
+		)
+		self.assertGreater(stats["blocked"], 0, "the fleet is pressured")
+		overall_block_rate = stats["blocked"] / stats["attempted"]
+		self.assertGreater(
+			stats["blocked_largest_rate"],
+			overall_block_rate,
+			"the largest plan is blocked more than the fleet average",
+		)
+
+	def test_hybrid_tracks_spread_not_best_fit_on_migrations(self) -> None:
+		# Hybrid spreads every upgradeable (shared) VM, so its forced-migration count
+		# tracks Spread's and is a fraction of Best Fit's — it is a low-migration
+		# middle ground, NOT a migration reducer. Its statistically-significant win is
+		# Dedicated acceptance (blocked-largest); that is a many-seed effect measured
+		# with compare_seeds and documented in spec/24, not a single-seed unit assert.
+		# Moderate load (not saturated) — that's where Best Fit's migration blow-up
+		# is largest and the middle-ground property is clearest.
+		results = packing_sim.compare(
+			self._config(host_count=24, arrival_rate=1.0, mean_lifetime=90.0, upgrade_hazard=0.02)
+		)
+		self.assertLess(
+			results[HYBRID]["forced_migrations"],
+			0.5 * results[BEST_FIT]["forced_migrations"],
+			"hybrid stays far below best fit's migration blow-up",
+		)
+
+	def test_saturation_and_slack_edges(self) -> None:
+		# Ample fleet → everyone is admitted; a starved fleet blocks.
+		roomy = packing_sim.run(self._config(host_count=200, arrival_rate=0.5, mean_lifetime=50.0))
+		self.assertAlmostEqual(roomy["acceptance"], 1.0)
+		starved = packing_sim.run(self._config(host_count=1, arrival_rate=3.0, mean_lifetime=5000.0))
+		self.assertLess(starved["acceptance"], 1.0)
+
+	def test_no_hosts_blocks_everything(self) -> None:
+		stats = packing_sim.run(self._config(host_count=0))
+		self.assertEqual(stats["acceptance"], 0.0)
+		self.assertEqual(stats["mean_hosts_in_use"], 0.0)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/atlas/tests/test_placement.py
+++ b/atlas/tests/test_placement.py
@@ -7,11 +7,19 @@ no-capacity / ambiguous-image boundaries throw cleanly. No host — pure control
 logic (the after_insert provision enqueue is a no-op under frappe.in_test).
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from atlas.atlas.placement import NoCapacityError
-from atlas.tests.fixtures import make_image, make_provider, make_server
+from atlas.atlas import placement
+from atlas.atlas.placement import (
+	ConsolidationInProgressError,
+	NoCapacityError,
+	default_server,
+	plan_consolidation,
+)
+from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
 
 USER_EMAIL = "atlas-placement-user@example.com"
 
@@ -51,6 +59,10 @@ class TestPlacement(IntegrationTestCase):
 		# feasibility-boundary tests below stamp small totals and mean the raw budget).
 		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
 		frappe.db.set_single_value("Atlas Settings", "placement_headroom_percent", 0)
+		# Consolidation on with a generous cap, so a leaked 0 from the disabled test
+		# can't turn a later consolidation test into a silent NoCapacityError.
+		frappe.db.set_single_value("Atlas Settings", "placement_consolidation_enabled", 1)
+		frappe.db.set_single_value("Atlas Settings", "max_consolidation_migrations", 3)
 		# Wipe VMs left by other tests: servers are shared by title, so a stray
 		# VM on the reused server would count against its vCPU budget and skew
 		# the capacity-boundary tests below.
@@ -353,3 +365,135 @@ class TestPlacement(IntegrationTestCase):
 		frappe.set_user(_acting_user())
 		vm = self._new_machine()
 		self.assertEqual(vm.image, image_b.name, "configured default wins over ambiguity")
+
+	# --- consolidation: free a host by migrating a few small VMs (spec/25 case 3) ---
+
+	def _place_vm(self, server, memory, disk=4, status="Stopped", **overrides):
+		"""A VM pinned to `server` at a given size, in a migratable state. Explicit
+		server + image means apply_user_defaults is a no-op (no placement recursion)."""
+		image = make_image("atlas-placement-image")
+		vm = make_virtual_machine(
+			server, image, memory_megabytes=memory, disk_gigabytes=disk, **overrides
+		)
+		vm.db_set("status", status)
+		return vm
+
+	def _make_migration(self, vm, source, target, status="Hydrating"):
+		"""A non-terminal migration row of `vm` from `source` to `target`. Forces the
+		address scheme so before_insert never has to probe the provider."""
+		migration = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Migration",
+				"virtual_machine": vm.name,
+				"source_server": source.name,
+				"target_server": target.name,
+				"status": status,
+			}
+		)
+		migration.flags.keep_address_forced = True
+		return migration.insert(ignore_permissions=True)
+
+	def _fragmented_pair(self):
+		"""Two equal 4096 MB (RAM-only) hosts, each 2560 MB full (a 2048 + a small 512),
+		so 1536 MB is free on each — no host fits a 2048 MB arrival, but migrating one
+		512 off a host frees a contiguous 2048 slot. Returns (host_a, host_b)."""
+		host_a = self._measured_server("atlas-consolidate-a", 31, memory_megabytes_total=4096)
+		host_b = self._measured_server("atlas-consolidate-b", 32, memory_megabytes_total=4096)
+		self._place_vm(host_a, 2048)
+		self._place_vm(host_a, 512)
+		self._place_vm(host_b, 2048)
+		self._place_vm(host_b, 512)
+		return host_a, host_b
+
+	def test_plan_consolidation_frees_a_host_with_one_small_move(self) -> None:
+		host_a, host_b = self._fragmented_pair()
+		plan = plan_consolidation({"cpu": 0.0625, "memory": 2048, "disk": 4})
+		self.assertIsNotNone(plan, "a scattered fleet can be defragmented for the arrival")
+		recipient, moves = plan
+		self.assertEqual(len(moves), 1, "one small move is enough to free a host")
+		vm_name, target = moves[0]
+		self.assertNotEqual(recipient, target, "the evicted VM moves to a DIFFERENT host")
+		self.assertEqual(
+			frappe.db.get_value("Virtual Machine", vm_name, "memory_megabytes"),
+			512,
+			"it moves a SMALL VM, not the big one",
+		)
+		self.assertIn(recipient, (host_a.name, host_b.name))
+
+	def test_default_server_signals_consolidation_and_enqueues(self) -> None:
+		self._fragmented_pair()
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(ConsolidationInProgressError):
+				default_server(0.0625, 2048, 4)
+			enqueue.assert_called_once()
+			self.assertEqual(enqueue.call_args.args[0], "atlas.atlas.placement.consolidate")
+
+	def test_consolidate_triggers_the_planned_migration(self) -> None:
+		self._fragmented_pair()
+		calls = []
+		# consolidate() commits per move so one migration persists independently of the
+		# next; stub the commit so that real commit can't break this IntegrationTestCase's
+		# rollback isolation (it would leak the setUp fleet into later tests).
+		with (
+			patch.object(placement, "_start_migration", lambda vm, target: calls.append((vm, target))),
+			patch("frappe.db.commit"),
+		):
+			result = placement.consolidate(0.0625, 2048, 4)
+		self.assertEqual(len(calls), 1, "the planned move is actually triggered")
+		self.assertEqual(result["triggered"][0]["virtual_machine"], calls[0][0])
+
+	def test_consolidation_disabled_fails_loud(self) -> None:
+		self._fragmented_pair()
+		frappe.db.set_single_value("Atlas Settings", "placement_consolidation_enabled", 0)
+		self.assertIsNone(plan_consolidation({"cpu": 0.0625, "memory": 2048, "disk": 4}))
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(NoCapacityError):
+				default_server(0.0625, 2048, 4)
+			enqueue.assert_not_called()
+		# Fail-loud must be the plain type, not the "retry, room is coming" signal.
+		try:
+			default_server(0.0625, 2048, 4)
+		except ConsolidationInProgressError:
+			self.fail("disabled consolidation must raise NoCapacityError, not the retry signal")
+		except NoCapacityError:
+			pass
+
+	def test_single_host_cannot_consolidate(self) -> None:
+		# One Active host with nowhere to move VMs to → no plan, plain NoCapacityError.
+		host = self._measured_server("atlas-consolidate-solo", 33, memory_megabytes_total=2048)
+		self._place_vm(host, 2048)
+		self.assertIsNone(plan_consolidation({"cpu": 0.0625, "memory": 512, "disk": 4}))
+		with self.assertRaises(NoCapacityError):
+			default_server(0.0625, 512, 4)
+
+	def test_in_flight_drain_waits_without_re_enqueuing(self) -> None:
+		# A prior consolidation is already draining host A (its small VM migrates to B).
+		# A fresh 2048 arrival must be told to WAIT (ConsolidationInProgressError) rather
+		# than launch another migration — the idempotency that survives Central's retries.
+		host_a = self._measured_server("atlas-consolidate-a", 31, memory_megabytes_total=4096)
+		host_b = self._measured_server("atlas-consolidate-b", 32, memory_megabytes_total=4096)
+		self._place_vm(host_a, 2048)
+		small_a = self._place_vm(host_a, 512)
+		self._place_vm(host_b, 1536)
+		self._place_vm(host_b, 1024)
+		self._make_migration(small_a, host_a, host_b)
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(ConsolidationInProgressError):
+				default_server(0.0625, 2048, 4)
+			enqueue.assert_not_called()
+
+	def test_consolidation_skips_vms_with_public_ipv4(self) -> None:
+		# A VM with an attached Reserved IP must never be picked — moving it would
+		# silently release inbound v4. Here the small 512 on host A is the ONLY move
+		# that could free a host (host B's single 2560 VM has nowhere to go), so pinning
+		# it with a public IPv4 must leave the fleet unconsolidatable.
+		host_a = self._measured_server("atlas-consolidate-a", 31, memory_megabytes_total=4096)
+		host_b = self._measured_server("atlas-consolidate-b", 32, memory_megabytes_total=4096)
+		self._place_vm(host_a, 2048)
+		pinned = self._place_vm(host_a, 512)  # free_a = 1536
+		self._place_vm(host_b, 2560)  # free_b = 1536, single VM too big to re-home
+		# Sanity: while it is movable, that 512 DOES free host A for a 2048 arrival.
+		self.assertIsNotNone(plan_consolidation({"cpu": 0.0625, "memory": 2048, "disk": 4}))
+		# Pin it with a public IPv4 → now nothing is safely movable → no plan.
+		pinned.db_set("public_ipv4", "203.0.113.5")
+		self.assertIsNone(plan_consolidation({"cpu": 0.0625, "memory": 2048, "disk": 4}))

--- a/atlas/tests/test_placement.py
+++ b/atlas/tests/test_placement.py
@@ -366,7 +366,7 @@ class TestPlacement(IntegrationTestCase):
 		vm = self._new_machine()
 		self.assertEqual(vm.image, image_b.name, "configured default wins over ambiguity")
 
-	# --- consolidation: free a host by migrating a few small VMs (spec/25 case 3) ---
+	# --- consolidation: free a host by migrating a few small VMs (spec/28 case 3) ---
 
 	def _place_vm(self, server, memory, disk=4, status="Stopped", **overrides):
 		"""A VM pinned to `server` at a given size, in a migratable state. Explicit

--- a/atlas/tests/test_placement.py
+++ b/atlas/tests/test_placement.py
@@ -46,6 +46,11 @@ class TestPlacement(IntegrationTestCase):
 		# No oversubscription unless a test opts in; keeps capacity assertions
 		# independent of suite order.
 		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		# Isolate from the new capacity defaults: no memory floor and no arrival
+		# reserve unless a test opts in (both default > 0 on a real site, but the
+		# feasibility-boundary tests below stamp small totals and mean the raw budget).
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
+		frappe.db.set_single_value("Atlas Settings", "placement_headroom_percent", 0)
 		# Wipe VMs left by other tests: servers are shared by title, so a stray
 		# VM on the reused server would count against its vCPU budget and skew
 		# the capacity-boundary tests below.
@@ -66,8 +71,35 @@ class TestPlacement(IntegrationTestCase):
 			frappe.db.set_value(
 				"Server",
 				name,
-				{"vcpus_total": 0, "memory_megabytes_total": 0, "pool_disk_gigabytes_total": 0},
+				{
+					"vcpus_total": 0,
+					"memory_megabytes_total": 0,
+					"pool_disk_gigabytes_total": 0,
+					"placement_headroom_percent": 0,
+				},
 			)
+
+	def _measured_server(self, title, host_octet, **totals):
+		"""An Active server with a distinct /64, catalogued only on the axes in
+		`totals` (the rest stay uncatalogued → unlimited). Distinct titles + IPv6
+		ranges let a test stand up several placement candidates at once."""
+		server = make_server(
+			self.provider,
+			title=title,
+			size="DigitalOcean/s-4vcpu-8gb",
+			ipv6_address=f"2001:db8:{host_octet}::1",
+			ipv6_prefix=f"2001:db8:{host_octet}::/64",
+			ipv6_virtual_machine_range=f"2001:db8:{host_octet}::/120",
+		)
+		image = make_image("atlas-placement-image")
+		frappe.db.set_value("Virtual Machine Image", image.name, "is_active", 1)
+		frappe.db.set_value("Server", server.name, "status", "Active")
+		frappe.db.set_value(
+			"Server",
+			server.name,
+			{"vcpus_total": 0, "memory_megabytes_total": 0, "pool_disk_gigabytes_total": 0, **totals},
+		)
+		return server
 
 	def _new_machine(self, **overrides):
 		"""Insert a VM the way the Central API does — no server, no image, and
@@ -214,6 +246,82 @@ class TestPlacement(IntegrationTestCase):
 		self._new_machine(vcpus=1, memory_megabytes=512, disk_gigabytes=10)
 		with self.assertRaises(NoCapacityError):
 			self._new_machine(vcpus=1, memory_megabytes=512, disk_gigabytes=10)
+
+	# --- relative-fill spread scorer (spec/24) -----------------------------
+
+	def test_spread_alternates_across_equal_hosts(self) -> None:
+		# Two equal measured hosts: consecutive VMs alternate — the emptier by
+		# relative fill wins, so the second lands on the host the first didn't.
+		host_a = self._measured_server("atlas-placement-a", 21, memory_megabytes_total=4096)
+		self._measured_server("atlas-placement-b", 22, memory_megabytes_total=4096)
+		frappe.set_user(_acting_user())
+		first = self._new_machine(memory_megabytes=512)
+		second = self._new_machine(memory_megabytes=512)
+		self.assertNotEqual(first.server, second.server, "equal hosts alternate")
+		self.assertEqual(first.server, host_a.name, "the creation-first host seats the first VM")
+
+	def test_relative_fill_big_host_absorbs_more(self) -> None:
+		# A host with twice the RAM takes twice the VMs — placement equalizes
+		# *relative* fill, not absolute count. Only RAM is catalogued so it is the
+		# sole binding axis; the big host is created first so ties resolve to it.
+		big = self._measured_server("atlas-placement-big", 23, memory_megabytes_total=4096)
+		small = self._measured_server("atlas-placement-small", 24, memory_megabytes_total=2048)
+		frappe.set_user(_acting_user())
+		for _ in range(3):
+			self._new_machine(memory_megabytes=512)
+		big_count = frappe.db.count("Virtual Machine", {"server": big.name})
+		small_count = frappe.db.count("Virtual Machine", {"server": small.name})
+		self.assertEqual((big_count, small_count), (2, 1), "2x RAM absorbs 2x the VMs")
+
+	def test_fleet_reserve_blocks_new_vm_that_raw_budget_admits(self) -> None:
+		# Raw effective (1024 MB) would admit a 768 MB VM, but a 50% arrival reserve
+		# leaves only 512 MB for new placements → refused. With no reserve it fits.
+		self._measured_server("atlas-placement-a", 21, memory_megabytes_total=1024)
+		frappe.set_user(_acting_user())
+		frappe.db.set_single_value("Atlas Settings", "placement_headroom_percent", 50)
+		with self.assertRaises(NoCapacityError):
+			self._new_machine(memory_megabytes=768)
+		frappe.db.set_single_value("Atlas Settings", "placement_headroom_percent", 0)
+		vm = self._new_machine(memory_megabytes=768)
+		self.assertTrue(vm.server, "no reserve → the raw budget admits it")
+
+	def test_per_server_override_beats_fleet_default(self) -> None:
+		# Fleet default is 0 (pack full), but a per-server 90% reserve leaves only
+		# ~102 MB for new placements on that host → a 512 MB VM is refused there.
+		host = self._measured_server("atlas-placement-a", 21, memory_megabytes_total=1024)
+		frappe.db.set_value("Server", host.name, "placement_headroom_percent", 90)
+		frappe.set_user(_acting_user())
+		with self.assertRaises(NoCapacityError):
+			self._new_machine(memory_megabytes=512)
+		# Drop the per-server override → it inherits the fleet 0 and admits.
+		frappe.db.set_value("Server", host.name, "placement_headroom_percent", 0)
+		vm = self._new_machine(memory_megabytes=512)
+		self.assertEqual(vm.server, host.name)
+
+	def test_measured_host_ranks_ahead_of_unmeasured(self) -> None:
+		# A fully-measured host and an all-sentinel one both fit; the measured host
+		# wins (fewer unmeasured axes) so placement prefers a host it can reason about.
+		measured = self._measured_server(
+			"atlas-placement-measured",
+			21,
+			vcpus_total=4,
+			memory_megabytes_total=8192,
+			pool_disk_gigabytes_total=160,
+		)
+		unmeasured = self._measured_server("atlas-placement-unmeasured", 22)
+		# Unknown slug → no CPU fallback either, so every axis is uncatalogued.
+		frappe.db.set_value("Server", unmeasured.name, "size", "s-unknown-slug")
+		frappe.set_user(_acting_user())
+		vm = self._new_machine(memory_megabytes=512)
+		self.assertEqual(vm.server, measured.name, "measured host outranks the sentinel one")
+
+	def test_tie_break_is_deterministic_by_creation(self) -> None:
+		# Two identical empty measured hosts → the creation-first one wins, every time.
+		first = self._measured_server("atlas-placement-a", 21, memory_megabytes_total=4096)
+		self._measured_server("atlas-placement-b", 22, memory_megabytes_total=4096)
+		frappe.set_user(_acting_user())
+		vm = self._new_machine(memory_megabytes=512)
+		self.assertEqual(vm.server, first.name)
 
 	def test_ambiguous_image_throws(self) -> None:
 		server = make_server(

--- a/atlas/tests/test_placement.py
+++ b/atlas/tests/test_placement.py
@@ -247,7 +247,7 @@ class TestPlacement(IntegrationTestCase):
 		with self.assertRaises(NoCapacityError):
 			self._new_machine(vcpus=1, memory_megabytes=512, disk_gigabytes=10)
 
-	# --- relative-fill spread scorer (spec/24) -----------------------------
+	# --- relative-fill spread scorer (spec/28) -----------------------------
 
 	def test_spread_alternates_across_equal_hosts(self) -> None:
 		# Two equal measured hosts: consecutive VMs alternate — the emptier by

--- a/atlas/tests/test_provision_capacity.py
+++ b/atlas/tests/test_provision_capacity.py
@@ -23,6 +23,9 @@ class TestProvisionCapacity(IntegrationTestCase):
 	def setUp(self) -> None:
 		_clean_virtual_machines()
 		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		# The free-headroom assertions below stamp exact totals and expect the raw
+		# budget; keep the memory floor off so it doesn't shave the measured axis.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
 		self.provider = make_provider("provision-capacity-provider")
 		# Neutralize any Active server other suites left so this test's own
 		# server is the only placement candidate.

--- a/atlas/tests/test_sizes.py
+++ b/atlas/tests/test_sizes.py
@@ -52,6 +52,38 @@ class TestSizes(IntegrationTestCase):
 			self.assertGreater(p["memory_megabytes"], 0, label)
 			self.assertGreater(p["disk_gigabytes"], 0, label)
 
+	def test_share_unit_is_shared_1x(self) -> None:
+		# The share unit is derived from the ladder itself — Shared 1x's cost on the
+		# three packed axes — so there is exactly one source of truth.
+		self.assertEqual(sizes.SHARE_UNIT["cpu_max_cores"], 0.0625)
+		self.assertEqual(sizes.SHARE_UNIT["memory_megabytes"], 512)
+		self.assertEqual(sizes.SHARE_UNIT["disk_gigabytes"], 10)
+
+	def test_proportionality_invariant(self) -> None:
+		# THE load-bearing property: every preset is the SAME integer multiple of the
+		# share unit on all three axes. This is what makes packing one-dimensional and
+		# even-spread free (the placement scorer's relative-fill spread relies on it —
+		# spec/24). Break it deliberately (a non-proportional plan) and you must
+		# revisit spec/24 and the scorer, not just this test.
+		unit = sizes.SHARE_UNIT
+		for label, preset in sizes.SIZE_PRESETS.items():
+			cpu_units = preset["cpu_max_cores"] / unit["cpu_max_cores"]
+			memory_units = preset["memory_megabytes"] / unit["memory_megabytes"]
+			disk_units = preset["disk_gigabytes"] / unit["disk_gigabytes"]
+			self.assertEqual(
+				cpu_units,
+				int(cpu_units),
+				f"{label}: cpu is not a whole number of share units — packing is no "
+				f"longer one-dimensional; revisit spec/24 and the placement scorer",
+			)
+			self.assertEqual(
+				(cpu_units, memory_units, disk_units),
+				(int(cpu_units), int(cpu_units), int(cpu_units)),
+				f"{label}: axes are not the same multiple of the share unit "
+				f"({cpu_units}, {memory_units}, {disk_units}) — the scorer's "
+				f"even-spread-is-free property assumes proportional presets; revisit spec/24",
+			)
+
 	def test_options_string_starts_with_custom(self) -> None:
 		options = sizes.size_preset_options().split("\n")
 		self.assertEqual(options[0], "Custom")

--- a/atlas/tests/test_sizes.py
+++ b/atlas/tests/test_sizes.py
@@ -63,8 +63,8 @@ class TestSizes(IntegrationTestCase):
 		# THE load-bearing property: every preset is the SAME integer multiple of the
 		# share unit on all three axes. This is what makes packing one-dimensional and
 		# even-spread free (the placement scorer's relative-fill spread relies on it —
-		# spec/24). Break it deliberately (a non-proportional plan) and you must
-		# revisit spec/24 and the scorer, not just this test.
+		# spec/28). Break it deliberately (a non-proportional plan) and you must
+		# revisit spec/28 and the scorer, not just this test.
 		unit = sizes.SHARE_UNIT
 		for label, preset in sizes.SIZE_PRESETS.items():
 			cpu_units = preset["cpu_max_cores"] / unit["cpu_max_cores"]
@@ -74,14 +74,14 @@ class TestSizes(IntegrationTestCase):
 				cpu_units,
 				int(cpu_units),
 				f"{label}: cpu is not a whole number of share units — packing is no "
-				f"longer one-dimensional; revisit spec/24 and the placement scorer",
+				f"longer one-dimensional; revisit spec/28 and the placement scorer",
 			)
 			self.assertEqual(
 				(cpu_units, memory_units, disk_units),
 				(int(cpu_units), int(cpu_units), int(cpu_units)),
 				f"{label}: axes are not the same multiple of the share unit "
 				f"({cpu_units}, {memory_units}, {disk_units}) — the scorer's "
-				f"even-spread-is-free property assumes proportional presets; revisit spec/24",
+				f"even-spread-is-free property assumes proportional presets; revisit spec/28",
 			)
 
 	def test_options_string_starts_with_custom(self) -> None:

--- a/llm/eval/FINDINGS.md
+++ b/llm/eval/FINDINGS.md
@@ -1,0 +1,68 @@
+# Placement strategy bake-off — findings
+
+Offline evaluation backing PR #30's default `placement_strategy = Spread`. Every
+scenario drives the **production scorer** (`atlas.atlas.packing.rank_key`, exactly as
+`placement.default_server` calls it), so a strategy that wins here is the one to set on
+`Atlas Settings.placement_strategy`. Fleet mirrors the 3 real DO droplets used to
+validate (4 GB / 8 GB / 16 GB effective budgets). Every point is averaged over 16–24
+seeds with sample stddev; the same seeded workload is replayed across all strategies.
+
+Run (needs the bench venv so `frappe`/`atlas` import):
+
+```
+./env/bin/python llm/eval/sweep.py            # proportional ladder, heterogeneous fleet
+./env/bin/python llm/eval/arbitrary_sim.py    # arbitrary (multi-dimensional) shapes
+./env/bin/python llm/eval/arbitrary_lowload.py# arbitrary, low load (Tetris's niche)
+./env/bin/python llm/eval/realistic_sim.py    # 80% fixed-small + 20% arbitrary + random migrations
+./env/bin/python llm/eval/real_fleet_demo.py  # per-VM placement on the real 3-host fleet
+```
+
+## Conclusion: keep `Spread` as the default
+
+The proportional size ladder makes packing one-dimensional, so on the ladder every
+strategy achieves near-identical **utilisation** — the choice is decided by *secondary*
+cost. Extending past the ladder to arbitrary and realistic mixed workloads, `Spread` is
+at worst tied and usually strictly better.
+
+### What each regime showed
+
+- **Proportional ladder / arbitrary shapes** — acceptance is a statistical **tie** across
+  all five strategies at every load. The scorer does not change *how many* VMs fit
+  (capacity + per-axis demand do); it only changes operational cost. `Spread` minimises
+  the costs that matter: **~3× fewer forced migrations** than Best Fit on the ladder
+  (15–40% fewer under arbitrary shapes), best in-place-resize success, lowest per-host
+  stranding/imbalance, lowest blast radius. Forced migration = a spec/24 cold migration
+  (disk hydration over NBD/SSH) and fires on every resize that cannot grow in place — the
+  dominant real cost.
+
+- **Realistic composite** (80% small fixed-shape + 20% arbitrary, with drops, resizes,
+  **and independent ad-hoc random migrations**) — `Spread` **wins acceptance outright**
+  (~3 pp over Best Fit, beyond the error bars) and has the lowest **evacuation-failure
+  rate** (`evac_fail_rate`: the share of ad-hoc single-VM migrations that find no target).
+  Once the fleet is loaded enough that no host sits empty, Best Fit's headline virtue —
+  "keeps hosts drainable" — loses at the single-VM level, because its tight packing leaves
+  a VM nowhere to move; `Spread`'s per-host headroom absorbs the move.
+
+- **The reserve is the real lever, not the strategy.** A 10% arrival-headroom reserve cut
+  forced migrations ~8× and tripled in-place-resize success — a far bigger effect than any
+  strategy swap (at a modest acceptance cost, and slightly higher evac difficulty).
+
+### When to deviate (both edge cases; already operator-selectable, no code change)
+
+- **Tetris** — only for a *lightly-loaded*, resize-light fleet dominated by lopsided
+  *Custom* shapes. That is the sole regime where its dot-product shape-matching bought a
+  small real acceptance edge (`arbitrary_lowload.py`, rate 0.06: 0.854 vs Spread 0.844).
+  Everywhere else it is mid-pack.
+- **Best Fit** — only if the operator deliberately wants to drain *whole hosts* (its empty
+  hosts help there). For ad-hoc single-VM migrations it is the worst choice.
+- **Hybrid ≈ Spread** in every regime — best-fitting only Dedicated VMs does not
+  defragment when the spread *shared* VMs already scatter the holes. No reason to pick it
+  over Spread.
+
+### Bottom line
+
+PR #30's `Spread` default is correct. The empirical justification now extends past the
+proportional-ladder argument (which makes all strategies tie) into arbitrary and realistic
+mixed workloads, where `Spread` is *genuinely better* rather than merely equivalent. The
+actionable follow-up is not a strategy change — it is considering a non-zero default
+`placement_headroom_percent` once resize-migration-on-demand exists.

--- a/llm/eval/arbitrary_lowload.py
+++ b/llm/eval/arbitrary_lowload.py
@@ -1,0 +1,36 @@
+"""Low-load arbitrary-shape check: does any strategy win ACCEPTANCE where the binding
+constraint is cross-axis fragmentation (not saturation)? This is the only regime where
+a shape-aware scorer (Tetris/Best Fit) could plausibly beat Spread on feasibility."""
+
+import os
+import sys
+
+# this script's own dir (for `arbitrary_sim`) + repo root (for `atlas.atlas.*`)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from arbitrary_sim import compare_seeds
+
+from atlas.atlas import packing
+
+for rate in (0.06, 0.09, 0.12, 0.15):
+	base = {
+		"seed": 500,
+		"duration": 20000.0,
+		"arrival_rate": rate,
+		"host_count": 12,
+		"mean_lifetime": 500.0,
+		"upgrade_hazard": 0.002,
+		"reserve": 0.0,
+	}
+	agg = compare_seeds(base, 24)
+	print(f"\n=== arrival_rate={rate}  reserve=0%  (arbitrary, 24 seeds) ===")
+	print(f"{'strategy':<10} {'accept':>14} {'blk-lopsided':>13} {'migr':>10} {'imbal':>7}")
+	for s in packing.STRATEGIES:
+		m = agg[s]
+		print(
+			f"{s:<10} {m['acceptance'][0]:.3f}±{m['acceptance'][1]:.3f}   "
+			f"{m['blocked_lopsided_rate'][0]:>11.3f} "
+			f"{m['forced_migrations'][0]:>6.0f}±{m['forced_migrations'][1]:<3.0f} "
+			f"{m['mean_imbalance'][0]:>7.3f}"
+		)

--- a/llm/eval/arbitrary_sim.py
+++ b/llm/eval/arbitrary_sim.py
@@ -1,0 +1,301 @@
+"""Generic (arbitrary-shape) packing evaluation for PR #30.
+
+The plan's headline insight — every size is a scalar multiple of one share unit, so
+packing is one-dimensional and all strategies tie — holds ONLY for the proportional
+ladder. Real tenants are not proportional: an object-store VM is huge disk / tiny
+CPU+RAM, a miner is huge CPU / tiny everything-else, an in-memory cache is huge RAM.
+Those shapes make packing genuinely multi-dimensional, so cross-axis stranding is
+real and the strategies diverge. This exercises the SAME production scorer
+(`atlas.atlas.packing.rank_key`) with arbitrary demand vectors — the honest test of
+which strategy to default to when Custom shapes are in the mix.
+"""
+
+from __future__ import annotations
+
+import heapq
+import os
+import random
+import statistics
+import sys
+
+# repo root (…/llm/eval/<this>.py → three levels up), so `atlas.atlas.*` imports resolve
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from atlas.atlas import packing, packing_metrics
+
+AXES = packing.AXES
+
+# Heterogeneous fleet mirroring the 3 real droplets I provision (EFFECTIVE budgets:
+# CPU x overprovision=1, memory minus the 1024 MB host floor, pool disk after OS).
+SMALL = {"cpu": 2.0, "memory": 3072.0, "disk": 70.0}  # s-2vcpu-4gb
+MEDIUM = {"cpu": 4.0, "memory": 7168.0, "disk": 150.0}  # s-4vcpu-8gb
+LARGE = {"cpu": 8.0, "memory": 15360.0, "disk": 300.0}  # s-8vcpu-16gb
+FLEET = (SMALL, MEDIUM, LARGE)
+
+# Arbitrary tenant archetypes: (cpu_cores, memory_mb, disk_gb) base shape + which axis
+# they grow when they resize. Deliberately NON-proportional — each is heavy on a
+# different axis, so no single host shape packs them all without stranding.
+ARCHETYPES = {
+	#                     cpu    mem     disk   grows
+	"object_store": ((0.25, 1024.0, 80.0), "disk"),  # huge disk, tiny cpu/ram
+	"miner": ((3.0, 512.0, 10.0), "cpu"),  # huge cpu, tiny ram/disk
+	"cache": ((0.5, 6144.0, 20.0), "memory"),  # huge ram
+	"web": ((0.5, 1024.0, 20.0), "cpu"),  # small balanced-ish
+	"batch": ((1.5, 3072.0, 60.0), "cpu"),  # bigger balanced
+}
+# Skewed mix: lots of small web + the three lopsided specialists + some batch.
+ARCH_MIX = {"object_store": 2.0, "miner": 2.0, "cache": 2.0, "web": 4.0, "batch": 1.0}
+# The "canary" archetypes whose blocked-rate signals cross-axis fragmentation.
+LOPSIDED = ("object_store", "miner", "cache")
+
+
+def _jitter(rng, base, lo=0.7, hi=1.6):
+	"""Per-instance size jitter so shapes are genuinely arbitrary, not 5 fixed points."""
+	return {axis: base[i] * rng.uniform(lo, hi) for i, axis in enumerate(AXES)}
+
+
+class Host:
+	def __init__(self, hid, shape):
+		self.host_id = hid
+		self.budget = dict(shape)
+		self.used = {a: 0.0 for a in AXES}
+		self.vm_count = 0
+
+	def add(self, d):
+		for a in AXES:
+			self.used[a] += d[a]
+		self.vm_count += 1
+
+	def remove(self, d):
+		for a in AXES:
+			self.used[a] -= d[a]
+		self.vm_count -= 1
+
+	def fits_full(self, delta):
+		return all(self.used[a] + delta[a] <= self.budget[a] for a in AXES)
+
+
+class VM:
+	__slots__ = ("arch", "demand", "host", "alive")
+
+	def __init__(self, arch, demand, host):
+		self.arch = arch
+		self.demand = demand
+		self.host = host
+		self.alive = True
+
+
+def gen_workload(cfg):
+	rng = random.Random(cfg["seed"])
+	archs = list(ARCH_MIX)
+	weights = [ARCH_MIX[a] for a in archs]
+	reqs = []
+	now = 0.0
+	while True:
+		now += rng.expovariate(cfg["arrival_rate"])
+		if now >= cfg["duration"]:
+			break
+		arch = rng.choices(archs, weights=weights, k=1)[0]
+		base, grow = ARCHETYPES[arch]
+		demand = _jitter(rng, base)
+		lifetime = rng.expovariate(1.0 / cfg["mean_lifetime"])
+		ups = []
+		if cfg["upgrade_hazard"] > 0:
+			off = 0.0
+			while True:
+				off += rng.expovariate(cfg["upgrade_hazard"])
+				if off >= lifetime:
+					break
+				ups.append(off)
+		reqs.append((now, arch, demand, grow, lifetime, ups))
+	return reqs
+
+
+def place(hosts, strategy, demand, reserve, exclude=None):
+	best = None
+	for idx, h in enumerate(hosts):
+		if h is exclude:
+			continue
+		key = packing.rank_key(strategy, h.budget, h.used, demand, reserve, idx)
+		if key is None:
+			continue
+		if best is None or key < best[0]:
+			best = (key, h)
+	return best[1] if best else None
+
+
+def simulate(cfg, workload):
+	hosts = [Host(i, FLEET[i % len(FLEET)]) for i in range(cfg["host_count"])]
+	strat = cfg["strategy"]
+	reserve = cfg["reserve"]
+	events = []
+	seq = 0
+
+	def push(t, kind, payload):
+		nonlocal seq
+		heapq.heappush(events, (t, seq, kind, payload))
+		seq += 1
+
+	for t, arch, demand, grow, lifetime, ups in workload:
+		push(t, "arrival", (arch, demand, grow, lifetime, ups))
+
+	accepted = blocked = 0
+	att = {a: 0 for a in ARCH_MIX}
+	blk = {a: 0 for a in ARCH_MIX}
+	in_place = forced = blocked_resize = 0
+	util = {a: 0.0 for a in AXES}
+	imbalance_acc = hosts_in_use_acc = compaction_acc = 0.0
+	clock = 0.0
+
+	def sample(dt):
+		nonlocal imbalance_acc, hosts_in_use_acc, compaction_acc
+		if dt <= 0:
+			return
+		u = packing_metrics.committed_utilization(hosts)
+		for a in AXES:
+			util[a] += u[a] * dt
+		live = [h for h in hosts if h.vm_count]
+		hosts_in_use_acc += len(live) * dt
+		if live:
+			imbalance_acc += statistics.fmean(packing_metrics.imbalance(h) for h in live) * dt
+		compaction_acc += packing_metrics.compaction_ratio(hosts) * dt
+
+	while events:
+		t, _s, kind, payload = heapq.heappop(events)
+		if t >= cfg["duration"]:
+			break
+		sample(t - clock)
+		clock = t
+		if kind == "arrival":
+			arch, demand, grow, lifetime, ups = payload
+			att[arch] += 1
+			h = place(hosts, strat, demand, reserve)
+			if h is None:
+				blocked += 1
+				blk[arch] += 1
+				continue
+			h.add(demand)
+			accepted += 1
+			vm = VM(arch, demand, h)
+			push(t + lifetime, "depart", vm)
+			for off in ups:
+				push(t + off, "upgrade", vm)
+		elif kind == "depart":
+			vm = payload
+			if vm.alive:
+				vm.host.remove(vm.demand)
+				vm.alive = False
+		else:  # upgrade: grow the archetype's dominant axis ~1.6x
+			vm = payload
+			if not vm.alive:
+				continue
+			base, grow = ARCHETYPES[vm.arch]
+			new = dict(vm.demand)
+			new[grow] = vm.demand[grow] * 1.6
+			delta = {a: new[a] - vm.demand[a] for a in AXES}
+			if vm.host.fits_full(delta):
+				for a in AXES:
+					vm.host.used[a] += delta[a]
+				vm.demand = new
+				in_place += 1
+			else:
+				src = vm.host
+				src.remove(vm.demand)
+				tgt = place(hosts, strat, new, reserve, exclude=src)
+				if tgt is not None:
+					tgt.add(new)
+					vm.host, vm.demand = tgt, new
+					forced += 1
+				else:
+					src.add(vm.demand)
+					blocked_resize += 1
+
+	sample(cfg["duration"] - clock)
+	dur = cfg["duration"]
+	attempted = accepted + blocked
+	up_att = in_place + forced + blocked_resize
+	lop_att = sum(att[a] for a in LOPSIDED)
+	lop_blk = sum(blk[a] for a in LOPSIDED)
+	return {
+		"acceptance": accepted / attempted if attempted else 1.0,
+		"blocked_lopsided_rate": lop_blk / lop_att if lop_att else 0.0,
+		"blk_by_arch": {a: (blk[a] / att[a] if att[a] else 0.0) for a in ARCH_MIX},
+		"in_place_rate": in_place / up_att if up_att else 1.0,
+		"forced_migrations": forced,
+		"mean_util": {a: util[a] / dur for a in AXES},
+		"mean_imbalance": imbalance_acc / dur,
+		"mean_hosts_in_use": hosts_in_use_acc / dur,
+		"mean_compaction": compaction_acc / dur,
+	}
+
+
+def compare_seeds(base_cfg, seeds):
+	agg = {s: {} for s in packing.STRATEGIES}
+	runs = []
+	for i in range(seeds):
+		cfg = dict(base_cfg, seed=base_cfg["seed"] + i)
+		workload = gen_workload(cfg)
+		per = {}
+		for strat in packing.STRATEGIES:
+			per[strat] = simulate(dict(cfg, strategy=strat), workload)
+		runs.append(per)
+	scalars = (
+		"acceptance",
+		"blocked_lopsided_rate",
+		"in_place_rate",
+		"forced_migrations",
+		"mean_imbalance",
+		"mean_hosts_in_use",
+		"mean_compaction",
+	)
+	for strat in packing.STRATEGIES:
+		for m in scalars:
+			vals = [r[strat][m] for r in runs]
+			sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+			agg[strat][m] = (statistics.fmean(vals), sd)
+		# per-archetype block rate (mean over seeds)
+		agg[strat]["blk_by_arch"] = {
+			a: statistics.fmean(r[strat]["blk_by_arch"][a] for r in runs) for a in ARCH_MIX
+		}
+	return agg
+
+
+def main():
+	seeds = 24
+	for rate, reserve in ((0.20, 0.0), (0.28, 0.0), (0.36, 0.0), (0.28, 0.10)):
+		base = {
+			"seed": 500,
+			"duration": 20000.0,
+			"arrival_rate": rate,
+			"host_count": 12,
+			"mean_lifetime": 500.0,
+			"upgrade_hazard": 0.002,
+			"reserve": reserve,
+		}
+		agg = compare_seeds(base, seeds)
+		print(
+			f"\n=== arrival_rate={rate}  reserve={int(reserve * 100)}%  (arbitrary shapes, {seeds} seeds) ==="
+		)
+		print(
+			f"{'strategy':<10} {'accept':>14} {'blk-lopsided':>13} {'in-place':>9} "
+			f"{'migr':>12} {'imbal':>7} {'hosts':>6} {'compact':>8}"
+		)
+		for s in packing.STRATEGIES:
+			m = agg[s]
+			print(
+				f"{s:<10} {m['acceptance'][0]:.3f}±{m['acceptance'][1]:.3f}   "
+				f"{m['blocked_lopsided_rate'][0]:>11.3f} {m['in_place_rate'][0]:>9.3f} "
+				f"{m['forced_migrations'][0]:>7.0f}±{m['forced_migrations'][1]:<4.0f} "
+				f"{m['mean_imbalance'][0]:>7.3f} {m['mean_hosts_in_use'][0]:>6.1f} "
+				f"{m['mean_compaction'][0]:>8.3f}"
+			)
+		# per-archetype blocked rate at the middle load, no reserve
+		if rate == 0.28 and reserve == 0.0:
+			print("  per-archetype blocked rate:")
+			for s in packing.STRATEGIES:
+				ba = agg[s]["blk_by_arch"]
+				print(f"    {s:<10} " + "  ".join(f"{a}={ba[a]:.3f}" for a in ARCH_MIX))
+
+
+if __name__ == "__main__":
+	main()

--- a/llm/eval/real_fleet_demo.py
+++ b/llm/eval/real_fleet_demo.py
@@ -1,0 +1,85 @@
+"""Capstone: run PR #30's production scorer against the 3 REAL droplets just
+provisioned (4/8/16 GB), placing arbitrary-shaped VMs under each strategy.
+
+Effective budgets = DO size minus the host_memory_reserve (1024 MB) on RAM,
+overprovision_factor 1.0 on CPU, pool disk after OS. Mirrors what
+capacity_for_server would report on a PR #30 host.
+"""
+
+import os
+import sys
+
+# repo root (…/llm/eval/<this>.py → three levels up), so `atlas.atlas.*` imports resolve
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from atlas.atlas import packing, packing_metrics
+
+AXES = packing.AXES
+
+# The three real Active droplets (title -> effective per-axis budget).
+FLEET = [
+	("x-Pune-placement-41cc45 (4GB)", {"cpu": 2.0, "memory": 3072.0, "disk": 70.0}),
+	("x-Pune-placement-fe7e76 (8GB)", {"cpu": 4.0, "memory": 7168.0, "disk": 150.0}),
+	("x-Pune-placement-26875b (16GB)", {"cpu": 8.0, "memory": 15360.0, "disk": 300.0}),
+]
+
+# Arbitrary tenant VMs, deliberately non-proportional (cpu cores, mem MB, disk GB).
+ARRIVALS = [
+	("object-store-1", {"cpu": 0.25, "memory": 1024.0, "disk": 80.0}),  # huge disk
+	("miner-1", {"cpu": 3.0, "memory": 512.0, "disk": 10.0}),  # huge cpu
+	("cache-1", {"cpu": 0.5, "memory": 6144.0, "disk": 20.0}),  # huge ram
+	("web-1", {"cpu": 0.5, "memory": 1024.0, "disk": 20.0}),
+	("web-2", {"cpu": 0.5, "memory": 1024.0, "disk": 20.0}),
+	("batch-1", {"cpu": 1.5, "memory": 3072.0, "disk": 60.0}),
+	("cache-2", {"cpu": 0.5, "memory": 6144.0, "disk": 20.0}),
+	("object-store-2", {"cpu": 0.25, "memory": 1024.0, "disk": 60.0}),
+]
+
+
+class H:
+	def __init__(self, name, budget):
+		self.name = name
+		self.budget = dict(budget)
+		self.used = {a: 0.0 for a in AXES}
+		self.vm_count = 0
+
+
+def place(hosts, strategy, needs, reserve=0.0):
+	best = None
+	for idx, h in enumerate(hosts):
+		key = packing.rank_key(strategy, h.budget, h.used, needs, reserve, idx)
+		if key is None:
+			continue
+		if best is None or key < best[0]:
+			best = (key, h)
+	return best[1] if best else None
+
+
+def run(strategy):
+	hosts = [H(n, b) for n, b in FLEET]
+	print(f"\n{'=' * 66}\nStrategy: {strategy}\n{'=' * 66}")
+	for vm, needs in ARRIVALS:
+		h = place(hosts, strategy, needs)
+		shape = f"cpu={needs['cpu']:.2f} mem={int(needs['memory'])}MB disk={int(needs['disk'])}GB"
+		if h is None:
+			print(f"  {vm:<15} {shape:<38} -> BLOCKED (no host fits)")
+			continue
+		h.add(needs) if False else None
+		for a in AXES:
+			h.used[a] += needs[a]
+		h.vm_count += 1
+		print(f"  {vm:<15} {shape:<38} -> {h.name}")
+	print("  " + "-" * 62)
+	for h in hosts:
+		fill = {a: (h.used[a] / h.budget[a]) if h.budget[a] else 0 for a in AXES}
+		su = packing_metrics.share_units(h)
+		print(
+			f"  {h.name:<32} vms={h.vm_count}  "
+			f"fill cpu={fill['cpu'] * 100:3.0f}% mem={fill['memory'] * 100:3.0f}% disk={fill['disk'] * 100:3.0f}%  "
+			f"units {su['used']}/{su['total']}"
+		)
+
+
+if __name__ == "__main__":
+	for strat in (packing.SPREAD, packing.BEST_FIT, packing.TETRIS):
+		run(strat)

--- a/llm/eval/realistic_sim.py
+++ b/llm/eval/realistic_sim.py
@@ -1,0 +1,337 @@
+"""Realistic composite workload for the PR #30 packing bake-off.
+
+The regime real fleets actually see (and the two earlier sims did NOT cover):
+  * MANY small VMs of a FIXED shape (the ladder's Shared 1x/2x) — ~80% of arrivals,
+  * a FEW arbitrary-sized lopsided ones (object-store/miner/cache/batch) — ~20%,
+  * random DROPS (exp lifetimes),
+  * random RESIZES (upgrade hazard → in-place / forced-migration / blocked),
+  * random ad-hoc MIGRATIONS independent of resize (host drain / rebalance / evict):
+    a per-VM hazard that tries to move the VM to a DIFFERENT host via the scorer.
+    Its failure rate = "evacuation failure" = can I drain a host on demand? — the
+    metric that actually tests Best Fit's claimed 'keeps hosts drainable' virtue.
+
+Everything is scored through the SAME production scorer (`atlas.atlas.packing.rank_key`).
+"""
+
+import heapq
+import os
+import random
+import statistics
+import sys
+
+# repo root (…/llm/eval/<this>.py → three levels up), so `atlas.atlas.*` imports resolve
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from atlas.atlas import packing, packing_metrics
+from atlas.atlas.sizes import SIZE_PRESETS
+
+AXES = packing.AXES
+
+SMALL = {"cpu": 2.0, "memory": 3072.0, "disk": 70.0}  # s-2vcpu-4gb effective
+MEDIUM = {"cpu": 4.0, "memory": 7168.0, "disk": 150.0}  # s-4vcpu-8gb
+LARGE = {"cpu": 8.0, "memory": 15360.0, "disk": 300.0}  # s-8vcpu-16gb
+FLEET = (SMALL, MEDIUM, LARGE)
+
+FIXED_LADDER = ["Shared 1x", "Shared 2x", "Shared 4x", "Shared 8x", "Dedicated 1x"]
+
+
+def preset_demand(name):
+	p = SIZE_PRESETS[name]
+	return {
+		"cpu": float(p["cpu_max_cores"]),
+		"memory": float(p["memory_megabytes"]),
+		"disk": float(p["disk_gigabytes"]),
+	}
+
+
+# archetype -> (base cpu,mem,disk), dominant grow axis
+ARCH = {
+	"object_store": ((0.25, 1024.0, 80.0), "disk"),
+	"miner": ((3.0, 512.0, 10.0), "cpu"),
+	"cache": ((0.5, 6144.0, 20.0), "memory"),
+	"batch": ((1.5, 3072.0, 60.0), "cpu"),
+}
+LOPSIDED = tuple(ARCH)
+# ~80% small fixed shapes, ~20% arbitrary lopsided.
+MIX = {"Shared 1x": 8.0, "Shared 2x": 4.0, "object_store": 0.75, "miner": 0.75, "cache": 0.75, "batch": 0.75}
+
+
+def jitter(rng, base, lo=0.7, hi=1.6):
+	return {a: base[i] * rng.uniform(lo, hi) for i, a in enumerate(AXES)}
+
+
+class Host:
+	def __init__(self, hid, shape):
+		self.hid = hid
+		self.budget = dict(shape)
+		self.used = {a: 0.0 for a in AXES}
+		self.vm_count = 0
+
+	def add(self, d):
+		for a in AXES:
+			self.used[a] += d[a]
+		self.vm_count += 1
+
+	def remove(self, d):
+		for a in AXES:
+			self.used[a] -= d[a]
+		self.vm_count -= 1
+
+	def fits_full(self, delta):
+		return all(self.used[a] + delta[a] <= self.budget[a] for a in AXES)
+
+
+class VM:
+	__slots__ = ("kind", "demand", "host", "alive", "ladder_i")
+
+	def __init__(self, kind, demand, host, ladder_i):
+		self.kind = kind
+		self.demand = demand
+		self.host = host
+		self.alive = True
+		self.ladder_i = ladder_i  # index into FIXED_LADDER, or None for arbitrary
+
+
+def gen_workload(cfg):
+	rng = random.Random(cfg["seed"])
+	kinds = list(MIX)
+	weights = [MIX[k] for k in kinds]
+	reqs = []
+	now = 0.0
+	while True:
+		now += rng.expovariate(cfg["arrival_rate"])
+		if now >= cfg["duration"]:
+			break
+		kind = rng.choices(kinds, weights=weights, k=1)[0]
+		if kind in ARCH:
+			demand = jitter(rng, ARCH[kind][0])
+			ladder_i = None
+		else:
+			demand = preset_demand(kind)
+			ladder_i = FIXED_LADDER.index(kind)
+		lifetime = rng.expovariate(1.0 / cfg["mean_lifetime"])
+		ups = _thin(rng, cfg["upgrade_hazard"], lifetime)
+		migs = _thin(rng, cfg["migration_hazard"], lifetime)
+		reqs.append((now, kind, demand, ladder_i, lifetime, ups, migs))
+	return reqs
+
+
+def _thin(rng, hazard, lifetime):
+	out = []
+	if hazard > 0:
+		off = 0.0
+		while True:
+			off += rng.expovariate(hazard)
+			if off >= lifetime:
+				break
+			out.append(off)
+	return out
+
+
+def place(hosts, strat, needs, reserve, exclude=None):
+	best = None
+	for idx, h in enumerate(hosts):
+		if h is exclude:
+			continue
+		key = packing.rank_key(strat, h.budget, h.used, needs, reserve, idx)
+		if key is None:
+			continue
+		if best is None or key < best[0]:
+			best = (key, h)
+	return best[1] if best else None
+
+
+def simulate(cfg, workload):
+	hosts = [Host(i, FLEET[i % len(FLEET)]) for i in range(cfg["host_count"])]
+	strat, reserve = cfg["strategy"], cfg["reserve"]
+	ev, seq, clock = [], 0, 0.0
+
+	def push(t, kind, p):
+		nonlocal seq
+		heapq.heappush(ev, (t, seq, kind, p))
+		seq += 1
+
+	for t, kind, demand, ladder_i, lifetime, ups, migs in workload:
+		push(t, "arr", (kind, demand, ladder_i, lifetime, ups, migs))
+
+	acc = blk = 0
+	att = {k: 0 for k in MIX}
+	bk = {k: 0 for k in MIX}
+	in_place = forced = blk_resize = 0
+	rand_migr = evac_fail = 0
+	util = {a: 0.0 for a in AXES}
+	imb = huse = 0.0
+
+	def sample(dt):
+		nonlocal imb, huse
+		if dt <= 0:
+			return
+		u = packing_metrics.committed_utilization(hosts)
+		for a in AXES:
+			util[a] += u[a] * dt
+		live = [h for h in hosts if h.vm_count]
+		huse += len(live) * dt
+		if live:
+			imb += statistics.fmean(packing_metrics.imbalance(h) for h in live) * dt
+
+	while ev:
+		t, _s, kind, p = heapq.heappop(ev)
+		if t >= cfg["duration"]:
+			break
+		sample(t - clock)
+		clock = t
+		if kind == "arr":
+			k, demand, ladder_i, lifetime, ups, migs = p
+			att[k] += 1
+			h = place(hosts, strat, demand, reserve)
+			if h is None:
+				blk += 1
+				bk[k] += 1
+				continue
+			h.add(demand)
+			acc += 1
+			vm = VM(k, demand, h, ladder_i)
+			push(t + lifetime, "dep", vm)
+			for o in ups:
+				push(t + o, "up", vm)
+			for o in migs:
+				push(t + o, "mig", vm)
+		elif kind == "dep":
+			vm = p
+			if vm.alive:
+				vm.host.remove(vm.demand)
+				vm.alive = False
+		elif kind == "up":
+			vm = p
+			if not vm.alive:
+				continue
+			new = _grow(vm)
+			if new is None:
+				continue
+			delta = {a: new[a] - vm.demand[a] for a in AXES}
+			if vm.host.fits_full(delta):
+				for a in AXES:
+					vm.host.used[a] += delta[a]
+				vm.demand = new
+				if vm.ladder_i is not None:
+					vm.ladder_i += 1
+				in_place += 1
+			else:
+				src = vm.host
+				src.remove(vm.demand)
+				tgt = place(hosts, strat, new, reserve, exclude=src)
+				if tgt is not None:
+					tgt.add(new)
+					vm.host, vm.demand = tgt, new
+					if vm.ladder_i is not None:
+						vm.ladder_i += 1
+					forced += 1
+				else:
+					src.add(vm.demand)
+					blk_resize += 1
+		else:  # mig: ad-hoc random migration (drain/rebalance/evict this VM elsewhere)
+			vm = p
+			if not vm.alive:
+				continue
+			src = vm.host
+			src.remove(vm.demand)
+			tgt = place(hosts, strat, vm.demand, reserve, exclude=src)
+			if tgt is not None:
+				tgt.add(vm.demand)
+				vm.host = tgt
+				rand_migr += 1
+			else:
+				src.add(vm.demand)  # nowhere to evacuate to → stays put
+				evac_fail += 1
+
+	sample(cfg["duration"] - clock)
+	dur = cfg["duration"]
+	attempted = acc + blk
+	up_att = in_place + forced + blk_resize
+	lop_att = sum(att[k] for k in LOPSIDED)
+	lop_blk = sum(bk[k] for k in LOPSIDED)
+	mig_att = rand_migr + evac_fail
+	return {
+		"acceptance": acc / attempted if attempted else 1.0,
+		"blocked_lopsided_rate": lop_blk / lop_att if lop_att else 0.0,
+		"in_place_rate": in_place / up_att if up_att else 1.0,
+		"forced_migrations": forced,
+		"evac_fail_rate": evac_fail / mig_att if mig_att else 0.0,
+		"random_migrations": rand_migr,
+		"mean_imbalance": imb / dur,
+		"mean_hosts_in_use": huse / dur,
+	}
+
+
+def _grow(vm):
+	if vm.ladder_i is not None:
+		nxt = vm.ladder_i + 1
+		if nxt >= len(FIXED_LADDER):
+			return None
+		return preset_demand(FIXED_LADDER[nxt])
+	grow = ARCH[vm.kind][1]
+	new = dict(vm.demand)
+	new[grow] = vm.demand[grow] * 1.6
+	return new
+
+
+def compare_seeds(base, seeds):
+	scalars = (
+		"acceptance",
+		"blocked_lopsided_rate",
+		"in_place_rate",
+		"forced_migrations",
+		"evac_fail_rate",
+		"random_migrations",
+		"mean_imbalance",
+		"mean_hosts_in_use",
+	)
+	runs = []
+	for i in range(seeds):
+		cfg = dict(base, seed=base["seed"] + i)
+		wl = gen_workload(cfg)
+		runs.append({s: simulate(dict(cfg, strategy=s), wl) for s in packing.STRATEGIES})
+	agg = {}
+	for s in packing.STRATEGIES:
+		agg[s] = {}
+		for m in scalars:
+			vals = [r[s][m] for r in runs]
+			agg[s][m] = (statistics.fmean(vals), statistics.stdev(vals) if len(vals) > 1 else 0.0)
+	return agg
+
+
+def main():
+	seeds = 16
+	for rate, reserve in ((0.3, 0.0), (0.5, 0.0), (0.7, 0.0), (0.5, 0.10)):
+		base = {
+			"seed": 700,
+			"duration": 8000.0,
+			"arrival_rate": rate,
+			"host_count": 12,
+			"mean_lifetime": 500.0,
+			"upgrade_hazard": 0.0015,
+			"migration_hazard": 0.0015,
+			"reserve": reserve,
+		}
+		agg = compare_seeds(base, seeds)
+		print(
+			f"\n=== rate={rate} reserve={int(reserve * 100)}%  (80% fixed-small + 20% arbitrary; "
+			f"drops+resizes+random-migrations; {seeds} seeds) ==="
+		)
+		print(
+			f"{'strategy':<10} {'accept':>13} {'blk-lop':>8} {'in-place':>9} "
+			f"{'resize-migr':>12} {'evac-fail':>10} {'rand-migr':>10} {'imbal':>7} {'hosts':>6}"
+		)
+		for s in packing.STRATEGIES:
+			m = agg[s]
+			print(
+				f"{s:<10} {m['acceptance'][0]:.3f}±{m['acceptance'][1]:.3f} "
+				f"{m['blocked_lopsided_rate'][0]:>8.3f} {m['in_place_rate'][0]:>9.3f} "
+				f"{m['forced_migrations'][0]:>7.0f}±{m['forced_migrations'][1]:<4.0f} "
+				f"{m['evac_fail_rate'][0]:>10.3f} {m['random_migrations'][0]:>10.0f} "
+				f"{m['mean_imbalance'][0]:>7.3f} {m['mean_hosts_in_use'][0]:>6.1f}"
+			)
+
+
+if __name__ == "__main__":
+	main()

--- a/llm/eval/sweep.py
+++ b/llm/eval/sweep.py
@@ -1,0 +1,72 @@
+"""Discriminating strategy sweep for PR #30 packing.
+
+Heterogeneous fleet (small/medium/large droplets) with resizes (upgrade hazard)
+and drops (finite lifetimes) ON — the regime where strategies actually diverge.
+Sweeps offered load to find the band where placement decisions matter, and
+averages every point over many seeds so an edge is real, not one lucky workload.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# repo root (…/llm/eval/<this>.py → three levels up), so `atlas.atlas.*` imports resolve
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from atlas.atlas import packing
+from atlas.atlas.packing_sim import SimConfig, compare_seeds
+
+# A heterogeneous fleet: small(4c/8G/160), medium(8c/16G/320), large(16c/32G/640)
+# effective budgets. Cycled across host_count → equal counts of each. RAM binds.
+SMALL = (4.0, 8192.0, 160.0)
+MEDIUM = (8.0, 16384.0, 320.0)
+LARGE = (16.0, 32768.0, 640.0)
+FLEET = (SMALL, MEDIUM, LARGE)
+HOST_COUNT = 12  # 4 of each shape → 4*(16+32+64) = 448 share units of RAM-bound capacity
+
+SEEDS = 24
+MEAN_LIFETIME = 500.0
+UPGRADE_HAZARD = 0.002  # ~1 resize-up attempt per VM lifetime → exercises resize path
+DURATION = 20000.0
+
+
+def offered_units(arrival_rate: float) -> float:
+	# mean VM size under DEFAULT_PLAN_MIX weights (4,3,2,1,1) over units (1,2,4,8,16)
+	mean_units = (4 * 1 + 3 * 2 + 2 * 4 + 1 * 8 + 1 * 16) / (4 + 3 + 2 + 1 + 1)
+	return arrival_rate * MEAN_LIFETIME * mean_units
+
+
+def run_point(arrival_rate: float, reserve: float = 0.0) -> dict:
+	cfg = SimConfig(
+		seed=1000,
+		duration=DURATION,
+		arrival_rate=arrival_rate,
+		host_count=HOST_COUNT,
+		host_shapes=FLEET,
+		mean_lifetime=MEAN_LIFETIME,
+		upgrade_hazard=UPGRADE_HAZARD,
+		reserve=reserve,
+	)
+	return compare_seeds(cfg, SEEDS)
+
+
+def fmt_row(name, m):
+	return (
+		f"{name:<10} accept {m['acceptance'][0]:.3f}±{m['acceptance'][1]:.3f}  "
+		f"blk-lrg {m['blocked_largest_rate'][0]:.3f}  "
+		f"in-place {m['in_place_upgrade_rate'][0]:.3f}  "
+		f"migr {m['forced_migrations'][0]:5.1f}±{m['forced_migrations'][1]:4.1f}  "
+		f"hosts {m['mean_hosts_in_use'][0]:4.1f}  "
+		f"compact {m['mean_compaction'][0]:.3f}"
+	)
+
+
+if __name__ == "__main__":
+	# 448 units capacity. Sweep arrival rate to walk offered load ~50%→130%.
+	for rate in (0.10, 0.13, 0.16, 0.19, 0.23):
+		load = offered_units(rate) / 448.0
+		print(f"\n=== arrival_rate={rate}  offered≈{load * 100:.0f}% of capacity  reserve=0% ===")
+		agg = run_point(rate, reserve=0.0)
+		for strat in packing.STRATEGIES:
+			print(fmt_row(strat, agg[strat]))

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib
 
 from atlas._run import _substitute, install_directory, install_file, run, run_input, run_ok
 from atlas._task import TaskInputs, TaskResult
+from atlas.hostfacts import host_capacity_facts
 from atlas.lvm import ThinPool
 from atlas.network_env import default_route_device
 from atlas.paths import ATLAS_PYTHON
@@ -208,6 +209,14 @@ class BootstrapResult(TaskResult):
 	# backs it (the venv + install.sh's PY_VERSION constant are live truth), so the
 	# controller reads it for display only, never persists it.
 	python_version: str
+	# The host's capacity totals (see atlas.hostfacts): logical CPU count, physical
+	# RAM in MB, and the thin pool's data capacity in GB. Stamped onto the Server so
+	# placement packs against real numbers instead of the uncatalogued→unlimited
+	# fallback. Pool *fullness* (data_percent) is deliberately NOT here — it is ~0 on
+	# a freshly-created pool and is live/advisory, so the `server-facts` Task owns it.
+	vcpus_total: int
+	memory_megabytes_total: int
+	pool_disk_gigabytes_total: int
 
 
 def _uname(flag: str) -> str:
@@ -515,12 +524,16 @@ def main() -> None:
 	#     source of truth. The bytes still land in /var/lib/atlas/bootstrap.json;
 	#     BootstrapResult.emit() carries the same values on stdout as the typed
 	#     Task result (replacing the trailing `cat bootstrap.json`).
+	facts = host_capacity_facts()
 	result = BootstrapResult(
 		firecracker_version=_binary_version("/usr/local/bin/firecracker"),
 		jailer_version=_binary_version("/usr/local/bin/jailer"),
 		kernel_version=_uname("-r"),
 		architecture=_uname("-m"),
 		python_version=python_version,
+		vcpus_total=facts["vcpus_total"],
+		memory_megabytes_total=facts["memory_megabytes_total"],
+		pool_disk_gigabytes_total=facts["pool_disk_gigabytes_total"],
 	)
 	install_directory("/var/lib/atlas", mode="0755")
 	install_file(_bootstrap_json(result), "/var/lib/atlas/bootstrap.json", mode="0644")

--- a/scripts/lib/atlas/hostfacts.py
+++ b/scripts/lib/atlas/hostfacts.py
@@ -1,0 +1,50 @@
+"""Host capacity facts — the three physical totals placement packs against.
+
+A host reports three numbers about itself: how many CPU threads it has, how much
+RAM, and how big the LVM thin pool its VM disks draw from is (plus the pool's live
+fullness). Bootstrap stamps the totals once (they ride the `BootstrapResult`
+line), and the `server-facts` Task re-reads them on demand — the **Refresh
+Capacity** button — without a full re-bootstrap.
+
+The parse functions are pure (text in, number out) so they unit-test on any
+machine with fixture text; only `host_capacity_facts()` touches the live host
+(procfs, `os.cpu_count`, and the thin pool via `atlas.lvm.ThinPool`).
+"""
+
+from __future__ import annotations
+
+import os
+
+from atlas.lvm import ThinPool
+
+MEMINFO_PATH = "/proc/meminfo"
+
+
+def parse_memory_megabytes(meminfo_text: str) -> int:
+	"""Physical RAM in MB from `/proc/meminfo`'s `MemTotal:` line (reported in kB).
+
+	Integer division to MB matches how the memory axis is accounted everywhere else
+	(whole MB); the sub-MB remainder is host overhead the memory reserve covers."""
+	for line in meminfo_text.splitlines():
+		key, _, rest = line.partition(":")
+		if key.strip() == "MemTotal":
+			return int(rest.strip().split()[0]) // 1024
+	raise ValueError(f"no MemTotal line in {MEMINFO_PATH}")
+
+
+def host_capacity_facts() -> dict:
+	"""The live host's capacity totals + pool fullness, as the controller stamps them.
+
+	`vcpus_total` is the logical CPU count; `memory_megabytes_total` is physical RAM;
+	`pool_disk_gigabytes_total` is the thin pool's data capacity; `pool_data_percent`
+	is its live fill (advisory alert signal, never a placement predicate)."""
+	# nosemgrep: frappe-security-file-traversal -- host script; reads the fixed MEMINFO_PATH (/proc/meminfo), not web input
+	with open(MEMINFO_PATH) as handle:
+		memory_megabytes = parse_memory_megabytes(handle.read())
+	pool = ThinPool()
+	return {
+		"vcpus_total": os.cpu_count() or 0,
+		"memory_megabytes_total": memory_megabytes,
+		"pool_disk_gigabytes_total": pool.size_bytes // (1024**3),
+		"pool_data_percent": pool.usage.data_percent,
+	}

--- a/scripts/lib/atlas/lvm.py
+++ b/scripts/lib/atlas/lvm.py
@@ -599,3 +599,14 @@ class ThinPool:
 			run("sudo lvs --noheadings -o data_percent {}", ref),
 			run("sudo lvs --noheadings -o metadata_percent {}", ref),
 		)
+
+	@property
+	def size_bytes(self) -> int:
+		"""The thin pool's data capacity in bytes (`lvs -o lv_size` on the pool LV).
+
+		For a loopback-backed pool this is the sparse overcommit ceiling
+		(`ATLAS_POOL_DATA_SIZE`); for a real-device PV it is the physical disk the
+		pool was carved from. This is the disk budget capacity accounting packs the
+		VMs' reserved disk against — not the host's raw root filesystem."""
+		ref = f"{self.volume_group}/{self.pool_name}"
+		return int(run("sudo lvs --noheadings --nosuffix --units b -o lv_size {}", ref).strip())

--- a/scripts/lib/atlas/test_hostfacts.py
+++ b/scripts/lib/atlas/test_hostfacts.py
@@ -1,0 +1,37 @@
+"""Unit tests for the pure half of the host-facts gatherer.
+
+Run with bare `python3 -m unittest atlas.test_hostfacts` from scripts/lib: no
+Frappe, no site, no host. `parse_memory_megabytes` is the one line that, on a real
+host, would only be exercised over SSH — the kB→MB conversion and the MemTotal
+line-pick that capacity accounting depends on.
+"""
+
+import unittest
+
+from atlas.hostfacts import parse_memory_megabytes
+
+MEMINFO = """\
+MemTotal:       16307192 kB
+MemFree:         9876543 kB
+MemAvailable:   14000000 kB
+Buffers:          123456 kB
+"""
+
+
+class TestParseMemoryMegabytes(unittest.TestCase):
+	def test_memtotal_kilobytes_to_megabytes(self) -> None:
+		# 16307192 kB // 1024 = 15924 MB (integer division; the sub-MB remainder is
+		# host overhead the memory reserve covers).
+		self.assertEqual(parse_memory_megabytes(MEMINFO), 15924)
+
+	def test_picks_memtotal_not_a_later_line(self) -> None:
+		# MemFree/MemAvailable are also kB lines; only MemTotal is the physical total.
+		self.assertNotEqual(parse_memory_megabytes(MEMINFO), 9876543 // 1024)
+
+	def test_missing_memtotal_raises(self) -> None:
+		with self.assertRaises(ValueError):
+			parse_memory_megabytes("MemFree: 100 kB\n")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/server-facts.py
+++ b/scripts/server-facts.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Report the host's capacity facts so the controller can (re-)stamp them without a
+# full re-bootstrap — the Refresh Capacity button. Read-only and idempotent: it
+# measures the live host (CPU threads, RAM, the LVM thin pool's size and fullness)
+# and emits one ServerFactsResult line. The same three totals bootstrap stamps
+# (atlas.hostfacts), plus the live pool_data_percent bootstrap leaves to this Task
+# (it is ~0 on a freshly-created pool and drifts as VMs write).
+
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._task import TaskInputs, TaskResult
+from atlas.hostfacts import host_capacity_facts
+
+
+@dataclass(frozen=True)
+class ServerFactsInputs(TaskInputs):
+	"""Measure and report the host's capacity facts. Takes no arguments — the host
+	measures itself."""
+
+	command: typing.ClassVar[str] = "server-facts"
+
+
+@dataclass(frozen=True)
+class ServerFactsResult(TaskResult):
+	vcpus_total: int
+	memory_megabytes_total: int
+	pool_disk_gigabytes_total: int
+	pool_data_percent: float
+
+
+def main() -> None:
+	ServerFactsInputs.from_args()
+	ServerFactsResult(**host_capacity_facts()).emit()
+
+
+if __name__ == "__main__":
+	main()

--- a/spec/05-virtual-machine-lifecycle.md
+++ b/spec/05-virtual-machine-lifecycle.md
@@ -651,6 +651,14 @@ Unspecified fields keep their current value. The new
 values are persisted on the row through a guarded path (see
 [Why resource fields are frozen outside resize](#why-resource-fields-are-frozen-outside-resize)).
 
+**Capacity gate.** Before it touches the host, resize checks that the host has room
+for the *growth* (the positive per-axis deltas) against the host's full effective
+budget — a resize must not silently oversubscribe RAM or disk on a full host. It
+deliberately spends the arrival headroom reserve placement left free (that is what
+the reserve is for). When the delta doesn't fit it raises `NoResizeCapacityError`
+(a `NoCapacityError` subclass — the signal that the VM must migrate to grow, a
+deferred case). See [28-placement.md](./28-placement.md).
+
 **Data disk.** `resize(data_disk_gigabytes=…)` grows the data disk the same way
 (`lvextend -r`, grow-only). Resize only ever **grows an existing** data disk:
 adding one to a VM that never had one (0→N) would also need a new Firecracker

--- a/spec/11-user-ui.md
+++ b/spec/11-user-ui.md
@@ -44,6 +44,8 @@ Central provisions, not an end-user `owner`:
 
 There is no guest-reachable write surface in Atlas anymore. The placement model
 (the operator controls which servers are Active and which images exist; the
-controller fills `server`/`image` in `before_insert` from a vCPU-budget) is
-unchanged — see [05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md)
-and [placement.py](../atlas/atlas/placement.py).
+controller fills `server`/`image` in `before_insert`) is now **load-aware** — it
+picks the Active host that scores best under the operator's chosen strategy, not
+merely the first with room. See [28-placement.md](./28-placement.md),
+[05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md), and
+[placement.py](../atlas/atlas/placement.py).

--- a/spec/28-placement.md
+++ b/spec/28-placement.md
@@ -1,0 +1,206 @@
+# 28 — Placement: load-aware host selection for the size ladder
+
+When a user creates a Virtual Machine they never pick a host — the controller
+fills `server` (spec/11). This document specifies how it picks, why the pick is
+load-aware without being a scheduler, and the capacity accounting and safety gates
+that back it. It is the source of truth for `atlas/atlas/placement.py`,
+`atlas/atlas/packing.py`, `atlas/atlas/api/server_capacity.py`, and the offline
+simulator (`atlas/atlas/packing_sim.py`).
+
+## The one insight: the ladder is proportional
+
+Every size preset (spec/`sizes.py`) is an exact scalar multiple of one **share
+unit** — a Shared 1x — on the three packed axes:
+
+| Preset       | units | cpu_max_cores | memory MB | disk GB |
+| ------------ | ----- | ------------- | --------- | ------- |
+| Shared 1x    | 1     | 0.0625        | 512       | 10      |
+| Shared 2x    | 2     | 0.125         | 1024      | 20      |
+| Shared 4x    | 4     | 0.25          | 2048      | 40      |
+| Shared 8x    | 8     | 0.5           | 4096      | 80      |
+| Dedicated 1x | 16    | 1             | 8192      | 160     |
+
+`SHARE_UNIT` is derived from `SIZE_PRESETS["Shared 1x"]`, and
+`test_sizes.test_proportionality_invariant` pins that every preset is the **same**
+integer multiple of it on all three axes. Consequences (the design, not trivia):
+
+1. **Packing is one-dimensional.** A host holds
+   `U = min(cpu/0.0625, memory/512, disk/10)` share units, and *any* mix of preset
+   VMs whose unit-sum ≤ U fits. There is no intra-host, cross-axis fragmentation, so
+   no bin-packing solver is needed or wanted.
+2. **The CPU axis is the guarantee, not the ceiling.** `cpu_max_cores` is the
+   guaranteed share — the cgroup `cpu.weight` floor under contention in the default
+   `CPU_MODE_RELAXED` (spec/networking). A shared VM bursts to a full core when the
+   host is idle (`cpu.max = vcpus × period`); `CPU_MODE_HARD` (Dedicated) makes the
+   share a wall. So packing on `cpu_max_cores` is packing on guarantees — the burst
+   ceiling is a separate cgroup concern, not a packing dimension.
+3. **Waste is a host-shape problem.** Whichever axis is the `min` in `U` strands the
+   others. The ladder's balanced shape is **8 GB RAM per guaranteed core** and
+   **20 GB pool disk per GB RAM**. On a typical 2–4 GB/core cloud host RAM binds and
+   CPU is only 25–50% subscribed at full RAM. The fleet is shape-undecided, so the
+   deliverable is *visibility*: per-host share units and per-axis stranding in Desk
+   (below) so the operator can compare shapes.
+
+## Capacity accounting (`api/server_capacity.py`)
+
+Per host, per axis (`cpu` / `memory` / `disk`): `{total, effective, used}`.
+
+- `total` — the host's physical amount, stamped at bootstrap (below). `None` =
+  uncatalogued → the axis is **unlimited** (the operator vouched for the host by
+  Activating it).
+- `effective` — the budget placement checks against: CPU `total × overprovision_factor`;
+  memory `total − host_memory_reserve_megabytes` (clamped ≥ 0); disk `total`.
+- `used` — the sum over non-Terminated VMs: CPU by `cpu_max_cores` (bandwidth, not
+  thread count), memory by `memory_megabytes`, disk by `disk_gigabytes + data_disk`.
+
+**Memory floor.** `Atlas Settings.host_memory_reserve_megabytes` (default 1024) is
+carved off the memory budget: guest RAM must never pack to 100% of MemTotal — the
+host OS, per-VM Firecracker/jailer overhead, and thin-pool metadata share that RAM,
+and packing to MemTotal OOMs the host.
+
+**Share units + stranded (reporting only).** When at least one axis is measured,
+`capacity_for_server` also returns `share_units {total, used, free}` and `stranded`
+(per axis, `effective − total × unit_cost`). `cluster_capacity` rolls them up over
+measured hosts. The Server form shows a one-line headline
+("Capacity — CPU 12% · RAM 45% · disk 20% · 30/34 units free · stranded: 6.1 cores,
+20 GB disk"). Worked example: an 8-core / 16 GB / 320 GB host at factor 1 with a
+1 GB reserve holds **30 units** (RAM binds: 15360/512), stranding **6.125 cores** and
+**20 GB disk**. Share units are never a placement input — feasibility and scoring
+stay generic three-axis so Custom shapes keep working.
+
+## Host-fact stamping
+
+Real hosts start uncatalogued; the three totals are measured on the host and stamped
+on the `Server`:
+
+- **At bootstrap** — `bootstrap-server.py` carries `vcpus_total`,
+  `memory_megabytes_total`, `pool_disk_gigabytes_total` on the `BootstrapResult`
+  line (`atlas.hostfacts.host_capacity_facts`: `os.cpu_count`, `/proc/meminfo`
+  MemTotal, `lvs -o lv_size` on the thin pool). `_absorb_bootstrap_output` stamps
+  them.
+- **On demand** — the **Refresh Capacity** button (`Server.refresh_capacity_facts`)
+  runs the read-only `server-facts` Task and re-stamps all four numbers (the three
+  totals + live `pool_data_percent`), without a re-bootstrap. `capacity_reported_at`
+  records the measurement.
+
+## The scorer (`placement.py::default_server` → `packing.rank_key`)
+
+For each Active server, filter to those where the VM fits, then score:
+
+```
+reserve = server.placement_headroom_percent if > 0
+          else Atlas Settings.placement_headroom_percent          # percent → /100
+allowed(axis) = effective × (1 − reserve)                          # None = unmeasured = unlimited
+fits          = every measured axis has used + need ≤ allowed
+fill          = max over measured axes of (used + need) / allowed  # post-placement bottleneck
+alignment     = Σ measured axes (need/effective)·(free/effective)  # demand-vs-headroom shape match
+rank          = (unmeasured_axis_count, strategy_score, creation_index)   # min wins
+```
+
+Measured hosts always rank ahead of partially/unmeasured ones; `creation asc` breaks
+final ties. `NoCapacityError` when nothing fits (Central reads "region full for that
+size").
+
+**Arrival reserve.** `placement_headroom_percent` (fleet default, per-server `> 0`
+overrides) leaves headroom free on each host for a later in-place resize. Frappe
+stores 0 for an untouched Percent field, so a per-server 0 means "inherit", not
+"explicitly none" — an accepted trade-off. **Resize spends the reserve** (below).
+
+### Strategies (`Atlas Settings.placement_strategy`)
+
+`strategy_score` is pluggable; the operator picks, code doesn't change:
+
+| Strategy      | Score          | Effect |
+| ------------- | -------------- | ------ |
+| **Spread** (default) | `+fill`   | Emptiest by relative fill → best blast radius + burst/resize headroom. Equal *relative* fill across heterogeneous hosts (for the proportional ladder, exact even spread in share units). |
+| **Best Fit**  | `−fill`        | Fullest feasible host → keeps emptier hosts drainable and preserves large holes for Dedicated. |
+| **Tetris**    | `−alignment`   | Dot-product alignment → matches demand shape to host headroom, least stranding on mixed hosts. |
+| **First Fit** | `0` (creation) | The pre-scorer behaviour — cheapest, most fragmenting. |
+| **Hybrid**    | per-VM         | Dedicated-class VMs (`cpu_max_cores ≥ 1`) Best Fit; the rest Spread. Resolved per-VM in `packing._resolve`. |
+
+On the proportional ladder with **homogeneous** hosts the strategies achieve the
+same total utilisation; they diverge only on **heterogeneous** fleets and on
+drainability/defragmentation. Which to run is a data question — see the simulator.
+
+**Hybrid, measured.** The idea was to best-fit the scarce large (Dedicated) holes
+while spreading the churny shared tiers, hoping to cut forced resize-migrations. The
+simulator (40 seeds, moderate load) says it does **not** cut migrations — it raises
+them slightly vs Spread (≈ +4.5%, t ≈ 4), because concentrating Dedicated tightens
+some hosts and steals in-place headroom from the shared VMs on them. Its real,
+statistically-significant win is **Dedicated acceptance**: blocked-largest 0.49 vs
+Spread's 0.52 (t ≈ 4.4) and slightly higher overall acceptance — at ~1/85th of Best
+Fit's migration cost (≈ 974 vs 3556 migrations). So Hybrid is a low-migration middle
+ground that protects Dedicated placement, **not** a migration reducer; Spread remains
+the default and the one to pick when in-place resize headroom matters most.
+
+## The resize gate (`virtual_machine.py::resize` → `check_resize_capacity`)
+
+`resize()` checks capacity *before* running the on-host resize. It charges only the
+**positive** per-axis deltas against the host's **full effective budget** (not the
+placement `allowed` — the reserve exists precisely for the resize to spend):
+
+```
+delta(axis) = new − old        # cpu = cpu_max_cores or vcpus; memory; disk + data_disk
+for each measured axis with delta > 0:  used + delta ≤ effective  else raise
+```
+
+`NoResizeCapacityError` (a `NoCapacityError` subclass — unchanged HTTP status/message
+for the dashboard, but a distinct type) is the signal that the VM must **migrate to
+grow**. A shrink needs no room; an unmeasured axis is unlimited.
+
+## Validating strategy choice: the simulator
+
+`atlas/atlas/packing_sim.py` is an event-driven simulator that places arrivals with
+the **same** scorer (`packing.rank_key`), so a strategy that wins there is the one to
+set on `placement_strategy`. It models the two events not yet wired into the app —
+VM **drops** (per-plan exponential lifetimes) and **resizes** (an exponential upgrade
+hazard → in-place if it fits, else a **forced migration**, else blocked) — because
+they are cheap to model and are exactly what distinguishes the strategies. The
+workload is generated once (seeded) and replayed under every strategy, so the
+comparison is fair and reproducible.
+
+It reports, per strategy: acceptance, **blocked-largest-plan rate** (the
+fragmentation canary), in-place upgrade rate, **forced migrations**, mean committed
+utilisation, mean hosts in use, and the **compaction ratio**
+(`lower_bound_hosts / hosts_in_use`; ~1 tight, < 1 consolidatable). Metrics live in
+`packing_metrics.py`. Run it (from the bench env) with configurable parameters:
+
+```
+python -m atlas.atlas.packing_sim --host-count 20 --arrival-rate 1.5 \
+    --mean-lifetime 200 --upgrade-hazard 0.01 --reserve 10 \
+    --host-shape 8,16384,320 --host-shape 16,32768,640   # repeat for a mixed fleet
+```
+
+Bootstrap the arrival/lifetime distributions from the Azure public traces
+(github.com/Azure/AzurePublicDataset) until Atlas has its own telemetry; real
+lifetimes are bimodal/heavy-tailed, not exponential — swap the sampler in
+`generate_workload` when data exists.
+
+## Explicitly out of scope — future migration work
+
+Placement never moves a running VM. Two future cases (design only; build nothing
+now):
+
+- **Case 2 — resize needs migration.** `NoResizeCapacityError` is the trigger. Pick a
+  target via the same scorer with the *new* size, run the spec/19 cold migration,
+  then resize on the target — one orchestration carrying a `pending_resize` payload.
+  The arrival reserve is what keeps this rare.
+- **Case 3 — repack for better packing.** With a proportional catalog, repacking only
+  improves *feasibility* by (a) draining a host or (b) defragmenting scattered free
+  units so a 16-unit Dedicated fits. Future shape: an advisory rebalance report
+  proposing the top-k migrations with benefit (max-relative-fill reduction / units
+  defragmented) vs cost (∝ disk GB to hydrate). Operator-approved, never automatic.
+
+## Deferred dials (not built)
+
+- **Burst-density cap** — `sum(ceilings) ≤ max_ceiling_ratio × usable_cores`. Today
+  `overprovision_factor` scales the guarantee axis; a true burst dial would bound the
+  *ceilings* (the RELAXED `cpu.max`) separately. Note `overprovision_factor > 1`
+  weakens "Dedicated" (it discounts a guaranteed core like shared bandwidth) — revisit
+  when the factor is ever raised above 1.
+- **Usage-based overcommit** — size the shared tier from predicted host peak
+  (N-sigma / percentile of recent usage), not a fixed ratio (Bashir et al.,
+  EuroSys'21). Guardrails to add when telemetry lands: host PSI, per-VM `cpu.stat`
+  throttling, `memory.current` vs limit.
+- **Lifetime-aware co-location** — predict short- vs long-lived at create time and
+  segregate, so one long-lived VM doesn't pin an otherwise-churning host.

--- a/spec/28-placement.md
+++ b/spec/28-placement.md
@@ -224,7 +224,7 @@ unbounded fleet-wide repack. One future case (design only; build nothing now), p
 the broader form of Case 3:
 
 - **Case 2 — resize needs migration.** `NoResizeCapacityError` is the trigger. Pick a
-  target via the same scorer with the *new* size, run the spec/19 cold migration,
+  target via the same scorer with the *new* size, run the spec/24 cold migration,
   then resize on the target — one orchestration carrying a `pending_resize` payload.
   The arrival reserve is what keeps this rare.
 - **Case 3 — repack for better packing.** The narrow, reactive slice — defragment

--- a/spec/28-placement.md
+++ b/spec/28-placement.md
@@ -52,6 +52,15 @@ Per host, per axis (`cpu` / `memory` / `disk`): `{total, effective, used}`.
   memory `total − host_memory_reserve_megabytes` (clamped ≥ 0); disk `total`.
 - `used` — the sum over non-Terminated VMs: CPU by `cpu_max_cores` (bandwidth, not
   thread count), memory by `memory_megabytes`, disk by `disk_gigabytes + data_disk`.
+  This counts a host's **resident** VMs *plus* the VMs **migrating into** it — a VM
+  with a non-terminal `Virtual Machine Migration` whose `target_server` is this host
+  (spec/24). The target hydrates that VM's disk and boots it before cutover repoints
+  `vm.server`, so it is already spending the target's budget; the source keeps counting
+  it too (the guest runs there until cutover). A migrating VM is deliberately charged to
+  **both** hosts for its brief life — the safe direction for a capacity gate, and what
+  keeps arrival-time consolidation (below) from double-booking a host mid-move.
+  `incoming_migration_count` surfaces the incoming set so the operator can see why a host
+  reads fuller than its resident VM list.
 
 **Memory floor.** `Atlas Settings.host_memory_reserve_megabytes` (default 1024) is
 carved off the memory budget: guest RAM must never pack to 100% of MemTotal — the
@@ -148,6 +157,37 @@ for each measured axis with delta > 0:  used + delta ≤ effective  else raise
 for the dashboard, but a distinct type) is the signal that the VM must **migrate to
 grow**. A shrink needs no room; an unmeasured axis is unlimited.
 
+## Consolidation on arrival (`placement.py::consolidate`)
+
+When `default_server` finds **no** host that fits an arrival, the free units may just be
+**scattered** — each host has a little room, none has enough in one place (a VM can't
+span hosts). Rather than fail, placement may **migrate a few small VMs** off one host
+onto the others' scattered room, defragmenting a single contiguous slot for the arrival.
+This is the automatic, on-arrival slice of Case 3 below (draining/repacking stays
+operator-driven). It is bounded and conservative:
+
+- **`plan_consolidation(needs)`** (pure) greedily picks, per candidate `recipient`
+  host, its **smallest movable VMs** (smallest RAM first — RAM binds on the ladder) and
+  a same-provider **target** for each (the operator's strategy scores the target), until
+  the recipient fits `needs` or the move cap is hit; the cheapest plan across recipients
+  wins (fewest moves, then least disk to hydrate). It only proposes moves
+  `migration.preflight_checks` will accept: Running/Stopped/Paused VMs with **no attached
+  public IPv4** (moving one silently releases a Reserved IP) and **no in-flight
+  migration**, onto a **same-provider** Active target.
+- **Bounds.** `Atlas Settings.max_consolidation_migrations` (default 3) is the "a few";
+  a plan needing more on every host is rejected. `placement_consolidation_enabled`
+  (default on) is the kill-switch — off → the region fails loud with `NoCapacityError`.
+- **Async, so retry not block.** Migrations are asynchronous (spec/24); placement does
+  **not** seat the arrival on the freed host in the same breath — the small VMs still run
+  there until cutover. `default_server` **enqueues** the consolidation (its own
+  transaction — migrate() persists its Migration row on commit) and raises
+  **`ConsolidationInProgressError`** (a `NoCapacityError` subclass: Central's existing
+  "region full → retry" fires unchanged, but the distinct type says *room is coming*).
+  Once the moves cut over, a retry lands. It is **idempotent**: the incoming-migration
+  accounting keeps the freed host reading full mid-move, and `_consolidation_in_flight`
+  makes a retry that sees a host already draining toward `needs` **wait** instead of
+  launching more migrations — so a burst of Central retries can't stampede.
+
 ## Validating strategy choice: the simulator
 
 `atlas/atlas/packing_sim.py` is an event-driven simulator that places arrivals with
@@ -178,18 +218,23 @@ lifetimes are bimodal/heavy-tailed, not exponential — swap the sampler in
 
 ## Explicitly out of scope — future migration work
 
-Placement never moves a running VM. Two future cases (design only; build nothing
-now):
+Placement moves running VMs only in the bounded on-arrival case above
+(**Consolidation on arrival**). It never moves one for a resize, and never runs an
+unbounded fleet-wide repack. One future case (design only; build nothing now), plus
+the broader form of Case 3:
 
 - **Case 2 — resize needs migration.** `NoResizeCapacityError` is the trigger. Pick a
   target via the same scorer with the *new* size, run the spec/19 cold migration,
   then resize on the target — one orchestration carrying a `pending_resize` payload.
   The arrival reserve is what keeps this rare.
-- **Case 3 — repack for better packing.** With a proportional catalog, repacking only
-  improves *feasibility* by (a) draining a host or (b) defragmenting scattered free
-  units so a 16-unit Dedicated fits. Future shape: an advisory rebalance report
-  proposing the top-k migrations with benefit (max-relative-fill reduction / units
-  defragmented) vs cost (∝ disk GB to hydrate). Operator-approved, never automatic.
+- **Case 3 — repack for better packing.** The narrow, reactive slice — defragment
+  *on arrival* to seat one blocked VM — now ships (see **Consolidation on arrival**);
+  it is bounded to `max_consolidation_migrations` small, safe moves and only fires
+  when a create finds no host. The broader form stays out of scope: a *proactive*,
+  fleet-wide rebalance that drains hosts or defragments ahead of demand. Future shape
+  for that: an advisory rebalance report proposing the top-k migrations with benefit
+  (max-relative-fill reduction / units defragmented) vs cost (∝ disk GB to hydrate).
+  Operator-approved, never automatic.
 
 ## Deferred dials (not built)
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -61,12 +61,16 @@ keep it the source of truth.
   and are never operator-facing artifacts or transportable between hosts.
   (Disk snapshots — instant copy-on-write LVM thin snapshots of the VM's
   disk — are supported; same doc.)
-- No autoscaling or scheduling. The operator picks the server in Desk; an
-  owner-scoped user creating a machine gets the first Active server with room (a
-  default, not a scheduler — see [11-user-ui.md](./11-user-ui.md)). "Room" is
-  oversubscribable: a host's effective vCPU budget is its physical total times
-  `Atlas Settings.overprovision_factor` (default 1), and a host whose size we
-  can't price counts as unlimited.
+- No autoscaling or reactive scheduling — no queues, no rebalancing, no moving a
+  running VM. The operator picks the server in Desk; an owner-scoped user creating a
+  machine gets **load-aware placement** (a default, not a scheduler): the controller
+  picks the Active host that scores best under the operator's chosen strategy
+  (Spread by default — the emptiest by relative fill; also Best Fit / Tetris / First
+  Fit), leaving an arrival headroom reserve for later in-place resizes, and gates a
+  resize on capacity so it can't oversubscribe a host. See
+  [28-placement.md](./28-placement.md) and [11-user-ui.md](./11-user-ui.md). "Room"
+  is oversubscribable on CPU (`Atlas Settings.overprovision_factor`, default 1); RAM
+  and disk are hard fits, and a host whose totals aren't reported counts as unlimited.
 - No metrics or alerting. `journalctl` is enough.
 - One in-app UI, one audience. **Operators** use Desk (`/app/atlas`) — the whole
   fleet, providers, servers, image sync, ad-hoc tasks. There is no end-user
@@ -154,6 +158,7 @@ keep it the source of truth.
 24. [VM migration between hosts](./24-vm-migration.md)
 25. [Private networking (the WireGuard host mesh)](./25-private-networking.md)
 26. [Docker compatibility (`docker run` against microVMs)](./27-docker-compat.md) — *design / proposal*
+28. [Placement — load-aware host selection for the size ladder](./28-placement.md)
 
 ## First run on a fresh site
 
@@ -268,6 +273,7 @@ operator-facing features add to this list; new tests follow it.
 | Broker a VPN tunnel to a VM    | (user/Central-driven) `request_vpc_access` / `revoke` dials the owner in as a peer on their tenant `/48` via the **customer gateway VM** on the mesh — one shared `wg0`, one client `/128` (supersedes the host-terminated broker) | [25-private-networking.md](./25-private-networking.md#the-customer-gateway--external-dial-in-to-the-mesh), [19-vpn-broker.md](./19-vpn-broker.md) |
 | Issue a TLS cert for a region  | `Root Domain` → **Issue / Renew Certificate**; `TLS Certificate` → **Issue/Renew / Push to Proxies**; `Route53 Settings` / `Lets Encrypt Settings` → **Test Connection** | [13-tls.md](./13-tls.md) |
 | Route guest-created bench sites | (guest-driven, no operator action) the in-guest `bench-domain-provider register`/`deregister` POSTs reserve/remove a `Subdomain` the controller arbitrates (uniqueness, brand denylist, per-VM cap, own-VM scoping by source `/128`); the `wildcard-domains`/`proxy-servers` queries answer pilot's host-level questions; every call audited; `terminate()` is the only controller-side teardown | [18-bench-self-routing.md](./18-bench-self-routing.md) |
+| Refresh a host's capacity      | `Server` → **Refresh Capacity** (re-measure CPU/RAM/pool totals + fullness and stamp them, no re-bootstrap) | [28-placement.md](./28-placement.md) |
 | Run an ad-hoc task / reboot    | `Server` → **Run Task / Reboot**                        | [04-tasks.md](./04-tasks.md) |
 | Run an ad-hoc command on hosts/guests | `SSH Console` → **Execute** (fan one command across Servers and/or Virtual Machines; per-target output streams back; every run recorded as an `SSH Command Log`), or `Server` / `Virtual Machine` → **Run Command** (pre-targets the console at one row) | [04-tasks.md § The SSH Console](./04-tasks.md#the-ssh-console-ad-hoc-commands) |
 | Click any button on the desk   | every form button driven through `run_doc_method`       | (this section, *Desk-button coverage*) |


### PR DESCRIPTION
## Summary

Load-aware placement for the proportional size ladder. A self-serve user never picks a host — the controller fills `server`. That used to be "first Active host with room"; this PR makes it **load-aware**: score every feasible Active host under an operator-chosen strategy (Spread by default), pick the best, leave an arrival-headroom reserve for later in-place resizes, and gate resizes so they can't oversubscribe a host.

Source of truth: [`spec/28-placement.md`](spec/28-placement.md).

## What's in it

**Capacity accounting & host facts** (`api/server_capacity.py`)
- Per-host, per-axis `{total, effective, used}` for CPU / RAM / pool disk.
- Totals stamped at bootstrap (`host_capacity_facts`) and re-measurable via the **Refresh Capacity** Server button (`server-facts` task) — no re-bootstrap.
- Memory floor (`host_memory_reserve_megabytes`, default 1024) so guest RAM never packs to MemTotal.

**Share-unit model**
- Every size preset is an exact integer multiple of one Shared-1x unit on all three axes (`SHARE_UNIT`, pinned by `test_proportionality_invariant`), so packing is one-dimensional — no bin-packing solver. Per-host share units + per-axis stranding surface in Desk (reporting only; feasibility stays generic three-axis so Custom shapes keep working).

**Pluggable strategy scorer** (`packing.py`)
- `rank_key` — Spread (default; emptiest by relative fill), Best Fit, Tetris (dot-product alignment), First Fit, and Hybrid (Dedicated → Best Fit, rest → Spread). Operator selects via `Atlas Settings.placement_strategy`; no code change.
- Offline event-driven simulator (`packing_sim.py`) replays one seeded workload across every strategy (arrivals, drops, resizes → in-place / forced-migration / blocked) with metrics (`packing_metrics.py`) to justify the default.

**Resize gate**
- `check_resize_capacity` raises `NoResizeCapacityError` (a `NoCapacityError` subclass) when a resize can't grow in place — deliberately spends the arrival reserve.

**Migration-aware accounting + consolidation on arrival**
- A VM migrating *into* a host is charged against the target too (counted on both hosts until cutover) — the safe direction for a capacity gate.
- When no host fits, `default_server` plans a bounded consolidation (evict a host's smallest movable VMs elsewhere to free a contiguous slot), enqueues it async, and raises `ConsolidationInProgressError` ("retry, room is coming"). Bounded by `max_consolidation_migrations` (default 3); kill-switch `placement_consolidation_enabled` (default on).

## Notes
- Adds fields to `Server` and `Atlas Settings` — run `bench migrate` after pulling.
- Green locally: `test_packing`, `test_sizes`, `test_placement`, `test_api_server_capacity`, `test_provision_capacity`, `test_virtual_machine` (incl. resize gate), `test_hostfacts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
