### PR TITLE
feat(snapshot): Back up VM snapshots to S3 and restore them

### DIFF
--- a/atlas/atlas/doctype/s3_settings/s3_settings.js
+++ b/atlas/atlas/doctype/s3_settings/s3_settings.js
@@ -1,0 +1,24 @@
+// S3 Settings — Single. Holds the S3 bucket + credentials for snapshot backups,
+// plus the Test Connection button (head_bucket). Credentials stay on the
+// controller; hosts only ever receive short-lived presigned URLs.
+// See spec/29-snapshot-backup.md.
+
+frappe.ui.form.on("S3 Settings", {
+	refresh(frm) {
+		frappe.atlas.add_action(frm, "Test Connection", () => run_test_connection(frm));
+	},
+});
+
+function run_test_connection(frm) {
+	frappe.show_alert({ message: __("Testing connection…"), indicator: "blue" });
+	frm.call("test_connection").then(({ message }) => {
+		if (message.ok) {
+			frappe.show_alert({ message: __("OK: {0}", [message.detail]), indicator: "green" });
+		} else {
+			frappe.show_alert({
+				message: __("Failed: {0}", [message.detail || __("unknown error")]),
+				indicator: "red",
+			});
+		}
+	});
+}

--- a/atlas/atlas/doctype/s3_settings/s3_settings.json
+++ b/atlas/atlas/doctype/s3_settings/s3_settings.json
@@ -1,0 +1,103 @@
+{
+ "actions": [],
+ "creation": "2026-07-14 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_bucket",
+  "bucket",
+  "region",
+  "endpoint_url",
+  "column_break_bucket",
+  "key_prefix",
+  "presign_expiry_seconds",
+  "section_break_credentials",
+  "access_key_id",
+  "secret_access_key"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_bucket",
+   "fieldtype": "Section Break",
+   "label": "Bucket"
+  },
+  {
+   "description": "The S3 bucket that holds snapshot backups.",
+   "fieldname": "bucket",
+   "fieldtype": "Data",
+   "label": "Bucket",
+   "reqd": 1
+  },
+  {
+   "default": "us-east-1",
+   "description": "AWS region for SigV4 signing. us-east-1 is a safe default for a non-AWS endpoint.",
+   "fieldname": "region",
+   "fieldtype": "Data",
+   "label": "Region"
+  },
+  {
+   "description": "Leave blank for AWS S3. Set it for an S3-compatible store (MinIO, DigitalOcean Spaces), e.g. https://minio.example.com — path-style addressing is used automatically.",
+   "fieldname": "endpoint_url",
+   "fieldtype": "Data",
+   "label": "Endpoint URL"
+  },
+  {
+   "fieldname": "column_break_bucket",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "atlas/snapshots",
+   "description": "Key prefix under which each snapshot's objects are stored: <prefix>/<snapshot-name>/rootfs.img.zst, etc.",
+   "fieldname": "key_prefix",
+   "fieldtype": "Data",
+   "label": "Key Prefix"
+  },
+  {
+   "default": "3600",
+   "description": "How long a presigned upload/download URL stays valid. Long enough to move the largest object; the host holds no static credentials, only these time-limited URLs.",
+   "fieldname": "presign_expiry_seconds",
+   "fieldtype": "Int",
+   "label": "Presign Expiry (seconds)"
+  },
+  {
+   "fieldname": "section_break_credentials",
+   "fieldtype": "Section Break",
+   "label": "Credentials"
+  },
+  {
+   "description": "Access key id with s3:GetObject / s3:PutObject / s3:DeleteObject / s3:ListBucket on the bucket. Held on the controller only — never shipped to a host.",
+   "fieldname": "access_key_id",
+   "fieldtype": "Data",
+   "label": "Access Key ID",
+   "reqd": 1
+  },
+  {
+   "description": "The matching secret. Rotate by clearing via db.set_value, then re-saving.",
+   "fieldname": "secret_access_key",
+   "fieldtype": "Password",
+   "label": "Secret Access Key",
+   "reqd": 1
+  }
+ ],
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-07-14 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Atlas",
+ "name": "S3 Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/atlas/atlas/doctype/s3_settings/s3_settings.py
+++ b/atlas/atlas/doctype/s3_settings/s3_settings.py
@@ -1,0 +1,66 @@
+"""S3 Settings — the S3 bucket + credentials for snapshot backups.
+
+The secret is read via `atlas.atlas.secrets.get_secret` by
+`atlas.atlas.s3.S3Backup`; the host never sees it (it gets only presigned URLs).
+`test_connection` is the Test Connection button (head_bucket). See
+spec/29-snapshot-backup.md.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import frappe
+from frappe.model.document import Document
+
+
+class S3Settings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		access_key_id: DF.Data
+		bucket: DF.Data
+		endpoint_url: DF.Data | None
+		key_prefix: DF.Data | None
+		presign_expiry_seconds: DF.Int
+		region: DF.Data | None
+		secret_access_key: DF.Password
+	# end: auto-generated types
+
+	@frappe.whitelist()
+	def setup(
+		self,
+		bucket: str,
+		access_key_id: str,
+		secret_access_key: str,
+		region: str = "us-east-1",
+		endpoint_url: str = "",
+		key_prefix: str = "atlas/snapshots",
+		presign_expiry_seconds: int = 3600,
+	) -> None:
+		"""Explicit, idempotent setter for S3 Settings (the contract).
+
+		Writes through `doc.save()` so the `secret_access_key` Password goes through
+		the normal ORM path (`_save_passwords` encrypts to `__Auth` AND stamps the
+		field placeholder, so the desk form shows it as set). Idempotent — re-running
+		just overwrites the Single."""
+		self.bucket = bucket
+		self.access_key_id = access_key_id
+		self.secret_access_key = secret_access_key
+		self.region = region or "us-east-1"
+		self.endpoint_url = endpoint_url or ""
+		self.key_prefix = key_prefix or "atlas/snapshots"
+		self.presign_expiry_seconds = int(presign_expiry_seconds or 3600)
+		self.save(ignore_permissions=True)
+
+	@frappe.whitelist()
+	def test_connection(self) -> dict:
+		"""Test Connection button — prove the credentials reach the bucket."""
+		from atlas.atlas.s3 import S3Backup
+
+		return dataclasses.asdict(S3Backup().test_connection())

--- a/atlas/atlas/doctype/virtual_machine_snapshot/test_virtual_machine_snapshot.py
+++ b/atlas/atlas/doctype/virtual_machine_snapshot/test_virtual_machine_snapshot.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import frappe
@@ -613,3 +614,280 @@ class TestBuildModeCarry(IntegrationTestCase):
 				}
 			).insert(ignore_permissions=True)
 		self.assertFalse(vm_from_image.build_mode)
+
+
+class TestSnapshotS3Backup(IntegrationTestCase):
+	"""Upload a snapshot's artifacts to S3 and restore them back
+	(spec/29-snapshot-backup.md). The host Task and the boto3 presign are both
+	mocked — these cover the controller's guards, background-job wiring, manifest
+	recording, the cold-rollback vs. warm-rehydrate-only split, and on_trash S3
+	cleanup, none of which need a host or real S3."""
+
+	def setUp(self) -> None:
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		_ensure_test_server()
+		_ensure_test_image()
+		with patch.object(module, "run_task", return_value=fake_task()):
+			for name in frappe.get_all("Virtual Machine Snapshot", pluck="name"):
+				frappe.delete_doc("Virtual Machine Snapshot", name, force=1, ignore_permissions=True)
+		for name in frappe.get_all("Virtual Machine", pluck="name"):
+			frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+	def _configure_s3(self) -> None:
+		frappe.get_doc("S3 Settings").setup(
+			bucket="atlas-backups-test",
+			access_key_id="A",
+			secret_access_key="S",
+			key_prefix="atlas/snapshots",
+		)
+
+	def _uploaded_cold_snapshot(self):
+		"""An Available cold snapshot marked Uploaded, with a one-object manifest —
+		the shape restore_from_s3 / _run_restore consume."""
+		snapshot = _make_snapshot(_stopped_vm())
+		manifest = [
+			{
+				"name": "rootfs",
+				"object_name": "rootfs.img.zst",
+				"source": snapshot.rootfs_path,
+				"block": True,
+				"compress": True,
+				"disk_gigabytes": snapshot.disk_gigabytes,
+				"sha256": "deadbeef",
+				"compressed_bytes": 100,
+				"raw_bytes": 1000,
+			}
+		]
+		snapshot.db_set({"s3_status": "Uploaded", "s3_objects": json.dumps(manifest)})
+		snapshot.reload()
+		return snapshot
+
+	# --- upload guards + wiring ---
+
+	def test_upload_rejects_unavailable_snapshot(self) -> None:
+		vm = _stopped_vm()
+		pending = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Snapshot",
+				"title": "pending-upload",
+				"virtual_machine": vm.name,
+				"server": vm.server,
+				"status": "Pending",
+			}
+		).insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError) as raised:
+			pending.upload_to_s3()
+		self.assertIn("not Available", str(raised.exception))
+
+	def test_upload_requires_s3_config(self) -> None:
+		# S3 Settings left unconfigured — upload must refuse before any job.
+		frappe.db.set_single_value("S3 Settings", "bucket", "")
+		snapshot = _make_snapshot(_stopped_vm())
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(frappe.ValidationError) as raised:
+				snapshot.upload_to_s3()
+		self.assertIn("not configured", str(raised.exception))
+		enqueue.assert_not_called()
+
+	def test_upload_enqueues_background_job(self) -> None:
+		self._configure_s3()
+		snapshot = _make_snapshot(_stopped_vm())
+		with patch("frappe.enqueue") as enqueue:
+			snapshot.upload_to_s3()
+		snapshot.reload()
+		self.assertEqual(snapshot.s3_status, "Uploading")
+		call = enqueue.call_args
+		self.assertEqual(
+			call.args[0],
+			"atlas.atlas.doctype.virtual_machine_snapshot.virtual_machine_snapshot.run_upload",
+		)
+		self.assertTrue(call.kwargs["enqueue_after_commit"])
+		self.assertEqual(call.kwargs["snapshot_name"], snapshot.name)
+
+	def test_run_upload_records_manifest(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		self._configure_s3()
+		snapshot = _make_snapshot(_stopped_vm())
+		result = (
+			'ATLAS_RESULT={"objects": [{"name": "rootfs", "object_name": "rootfs.img.zst", '
+			'"sha256": "deadbeef", "compressed_bytes": 100, "raw_bytes": 1000}], '
+			'"total_compressed_bytes": 100}'
+		)
+		with (
+			patch.object(s3.S3Backup, "presign_put", return_value="https://signed-put"),
+			patch.object(module, "run_task", return_value=fake_task(stdout=result)) as mocked,
+		):
+			snapshot._run_upload()
+
+		snapshot.reload()
+		self.assertEqual(snapshot.s3_status, "Uploaded")
+		self.assertEqual(snapshot.s3_bucket, "atlas-backups-test")
+		self.assertEqual(snapshot.s3_key_prefix, f"atlas/snapshots/{snapshot.name}/")
+		self.assertEqual(snapshot.s3_size_bytes, 100)
+		manifest = json.loads(snapshot.s3_objects)
+		self.assertEqual(manifest[0]["sha256"], "deadbeef")
+		self.assertEqual(manifest[0]["source"], snapshot.rootfs_path)
+		self.assertEqual(manifest[0]["disk_gigabytes"], snapshot.disk_gigabytes)
+		# The stored manifest must NOT leak the time-limited presigned url.
+		self.assertNotIn("url", manifest[0])
+		# The host Task got the plan with the presigned PUT url.
+		self.assertEqual(mocked.call_args.kwargs["script"], "upload-snapshot-s3")
+		variables = mocked.call_args.kwargs["variables"]
+		self.assertEqual(variables["SNAPSHOT_NAME"], snapshot.name)
+		plan = json.loads(variables["OBJECTS_JSON"])
+		self.assertEqual(plan[0]["url"], "https://signed-put")
+
+	def test_run_upload_failure_sets_failed(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		self._configure_s3()
+		snapshot = _make_snapshot(_stopped_vm())
+		with (
+			patch.object(s3.S3Backup, "presign_put", return_value="https://signed-put"),
+			patch.object(module, "run_task", side_effect=frappe.ValidationError("host blew up")),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				snapshot._run_upload()
+		snapshot.reload()
+		self.assertEqual(snapshot.s3_status, "Failed")
+
+	# --- restore guards + wiring ---
+
+	def test_restore_rejects_when_not_uploaded(self) -> None:
+		snapshot = _make_snapshot(_stopped_vm())
+		with self.assertRaises(frappe.ValidationError) as raised:
+			snapshot.restore_from_s3()
+		self.assertIn("No S3 backup", str(raised.exception))
+
+	def test_restore_cold_requires_stopped_vm(self) -> None:
+		snapshot = self._uploaded_cold_snapshot()
+		frappe.db.set_value("Virtual Machine", snapshot.virtual_machine, "status", "Running")
+		with patch("frappe.enqueue") as enqueue:
+			with self.assertRaises(frappe.ValidationError) as raised:
+				snapshot.restore_from_s3()
+		self.assertIn("Stop", str(raised.exception))
+		enqueue.assert_not_called()
+
+	def test_restore_enqueues_background_job(self) -> None:
+		snapshot = self._uploaded_cold_snapshot()
+		with patch("frappe.enqueue") as enqueue:
+			snapshot.restore_from_s3()
+		snapshot.reload()
+		self.assertEqual(snapshot.s3_status, "Restoring")
+		call = enqueue.call_args
+		self.assertEqual(
+			call.args[0],
+			"atlas.atlas.doctype.virtual_machine_snapshot.virtual_machine_snapshot.run_restore",
+		)
+		self.assertEqual(call.kwargs["snapshot_name"], snapshot.name)
+
+	def test_run_restore_cold_rehydrates_then_rolls_back(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_module
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		self._configure_s3()
+		snapshot = self._uploaded_cold_snapshot()
+		with (
+			patch.object(s3.S3Backup, "presign_get", return_value="https://signed-get"),
+			patch.object(
+				module, "run_task", return_value=fake_task(stdout='ATLAS_RESULT={"objects": ["rootfs"]}')
+			) as rehydrate,
+			patch.object(vm_module, "run_task", return_value=fake_task()) as rollback,
+		):
+			task_name = snapshot._run_restore()
+
+		# Rehydrate first (restore-snapshot-s3), then the in-place rollback (rebuild-vm).
+		self.assertEqual(rehydrate.call_args.kwargs["script"], "restore-snapshot-s3")
+		self.assertEqual(rollback.call_args.kwargs["script"], "rebuild-vm")
+		self.assertTrue(task_name)  # the rollback Task name is returned
+		snapshot.reload()
+		self.assertEqual(snapshot.s3_status, "Uploaded")  # the backup stays in S3
+		# The rehydrate Task got the presigned GET url + the manifest sha256.
+		plan = json.loads(rehydrate.call_args.kwargs["variables"]["OBJECTS_JSON"])
+		self.assertEqual(plan[0]["url"], "https://signed-get")
+		self.assertEqual(plan[0]["sha256"], "deadbeef")
+
+	def test_run_restore_warm_rehydrates_only(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_module
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		self._configure_s3()
+		vm = _stopped_vm()
+		manifest = [
+			{
+				"name": "rootfs",
+				"object_name": "rootfs.img.zst",
+				"source": "/dev/atlas/atlas-snap-warm",
+				"block": True,
+				"compress": True,
+				"disk_gigabytes": 2,
+				"sha256": "d",
+				"compressed_bytes": 1,
+				"raw_bytes": 2,
+			}
+		]
+		warm = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Snapshot",
+				"title": "warm-uploaded",
+				"virtual_machine": vm.name,
+				"server": vm.server,
+				"status": "Available",
+				"kind": "Warm",
+				"source_image": vm.image,
+				"disk_gigabytes": 2,
+				"rootfs_path": "/dev/atlas/atlas-snap-warm",
+				"memory_directory": "/var/lib/atlas/snapshots/warm-uploaded",
+				"s3_status": "Uploaded",
+				"s3_objects": json.dumps(manifest),
+			}
+		).insert(ignore_permissions=True)
+
+		with (
+			patch.object(s3.S3Backup, "presign_get", return_value="https://signed-get"),
+			patch.object(
+				module, "run_task", return_value=fake_task(stdout='ATLAS_RESULT={"objects": ["rootfs"]}')
+			) as rehydrate,
+			patch.object(vm_module, "run_task") as rollback,
+		):
+			result = warm._run_restore()
+
+		# Warm rehydrates only — no in-place rollback (consume it via Clone to new VM).
+		self.assertIsNone(result)
+		self.assertEqual(rehydrate.call_args.kwargs["script"], "restore-snapshot-s3")
+		rollback.assert_not_called()
+		warm.reload()
+		self.assertEqual(warm.s3_status, "Uploaded")
+
+	# --- on_trash S3 cleanup ---
+
+	def test_on_trash_deletes_s3_backup(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		self._configure_s3()
+		snapshot = self._uploaded_cold_snapshot()
+		with (
+			patch.object(s3.S3Backup, "delete_prefix", return_value=1) as deleter,
+			patch.object(module, "run_task", return_value=fake_task()),
+		):
+			frappe.delete_doc("Virtual Machine Snapshot", snapshot.name, ignore_permissions=True)
+		deleter.assert_called_once_with(snapshot.name)
+
+	def test_on_trash_skips_s3_when_not_uploaded(self) -> None:
+		from atlas.atlas import s3
+		from atlas.atlas.doctype.virtual_machine_snapshot import virtual_machine_snapshot as module
+
+		snapshot = _make_snapshot(_stopped_vm())  # s3_status empty
+		with (
+			patch.object(s3.S3Backup, "delete_prefix") as deleter,
+			patch.object(module, "run_task", return_value=fake_task()),
+		):
+			frappe.delete_doc("Virtual Machine Snapshot", snapshot.name, ignore_permissions=True)
+		deleter.assert_not_called()

--- a/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.js
+++ b/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.js
@@ -6,6 +6,7 @@ frappe.ui.form.on("Virtual Machine Snapshot", {
 		frappe.atlas.add_primary(frm, "Clone to new VM", () => open_clone_dialog(frm));
 		add_restore_button(frm);
 		add_promote_button(frm);
+		add_s3_buttons(frm);
 		frappe.atlas.add_danger(frm, "Delete", () => confirm_delete(frm));
 	},
 });
@@ -164,6 +165,84 @@ function confirm_restore(frm) {
 				frappe.atlas.task_started(frm, "Restore", task_name)
 			);
 		},
+	});
+}
+
+function add_s3_buttons(frm) {
+	// Off-host S3 backup (spec/29-snapshot-backup.md). Upload streams the snapshot's
+	// artifacts to S3; Restore rehydrates them and (cold) rolls the VM back. While a
+	// background job runs, surface the state instead of a button that would refuse.
+	const s3_status = frm.doc.s3_status || "";
+	if (s3_status === "Uploading" || s3_status === "Restoring") {
+		frappe.atlas.add_action(frm, __("S3 backup {0}…", [s3_status.toLowerCase()]), () =>
+			frappe.msgprint({
+				title: __("S3 backup in progress"),
+				message: __(
+					"A background job is {0} this snapshot's S3 backup — watch the S3 Status field.",
+					[s3_status.toLowerCase()]
+				),
+				indicator: "blue",
+			})
+		);
+		return;
+	}
+	const upload_label = s3_status === "Uploaded" ? "Re-upload to S3" : "Upload to S3";
+	frappe.atlas.add_secondary(frm, upload_label, () => confirm_upload(frm));
+	if (s3_status === "Uploaded") {
+		frappe.atlas.add_secondary(frm, "Restore from S3", () => confirm_restore_from_s3(frm));
+	}
+}
+
+function confirm_upload(frm) {
+	frappe.atlas.confirm_cost({
+		title: __("Upload {0} to S3?", [frm.doc.title]),
+		body_html: `<p>${__(
+			"Streams the snapshot's disk — and, for a warm snapshot, its frozen memory state — to S3 as an off-host durable copy. Runs in the background over a few minutes; watch the S3 Status field."
+		)}</p>`,
+		proceed_label: __("Upload"),
+		proceed() {
+			frm.call("upload_to_s3").then(() => {
+				frappe.show_alert(
+					{ message: __("Upload started; watch S3 Status."), indicator: "blue" },
+					6
+				);
+				frm.reload_doc();
+			});
+		},
+	});
+}
+
+function confirm_restore_from_s3(frm) {
+	if (frm.doc.kind === "Warm") {
+		frappe.atlas.confirm_cost({
+			title: __("Restore {0} from S3?", [frm.doc.title]),
+			body_html: `<p>${__(
+				"Rehydrates this warm snapshot's disk + memory from S3 so it can be cloned again (Clone to new VM). Runs in the background; watch S3 Status."
+			)}</p>`,
+			proceed_label: __("Restore"),
+			proceed: () => start_restore(frm),
+		});
+		return;
+	}
+	frappe.atlas.confirm_destructive({
+		title: __("Restore {0} onto {1} from S3?", [frm.doc.title, frm.doc.virtual_machine]),
+		body_html: `<p>${__(
+			"Rehydrates the snapshot from S3, then overwrites the VM's disk with it — current data is lost. Stop the VM first. Runs in the background; watch S3 Status."
+		)}</p>`,
+		match_string: frm.doc.title,
+		match_label: __("Type the snapshot title to confirm"),
+		proceed_label: __("Restore"),
+		proceed: () => start_restore(frm),
+	});
+}
+
+function start_restore(frm) {
+	frm.call("restore_from_s3").then(() => {
+		frappe.show_alert(
+			{ message: __("Restore started; watch S3 Status."), indicator: "blue" },
+			6
+		);
+		frm.reload_doc();
 	});
 }
 

--- a/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.json
+++ b/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.json
@@ -34,7 +34,15 @@
   "vcpus",
   "memory_megabytes",
   "tap_device",
-  "host_signature"
+  "host_signature",
+  "section_break_s3",
+  "s3_status",
+  "s3_bucket",
+  "s3_key_prefix",
+  "column_break_s3",
+  "s3_size_bytes",
+  "s3_uploaded_at",
+  "s3_objects"
  ],
  "fields": [
   {
@@ -234,6 +242,58 @@
    "fieldname": "host_signature",
    "fieldtype": "Small Text",
    "label": "Host Signature",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_s3",
+   "fieldtype": "Section Break",
+   "label": "S3 Backup"
+  },
+  {
+   "default": "",
+   "description": "Off-host S3 backup state. Uploaded = the artifacts are in S3 and can be restored even if the local pool is lost (spec/29-snapshot-backup.md).",
+   "fieldname": "s3_status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "S3 Status",
+   "options": "\nUploading\nUploaded\nRestoring\nFailed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "s3_bucket",
+   "fieldtype": "Data",
+   "label": "S3 Bucket",
+   "read_only": 1
+  },
+  {
+   "description": "Key prefix under which this snapshot's objects live: <prefix>/<snapshot>/rootfs.img.zst, etc.",
+   "fieldname": "s3_key_prefix",
+   "fieldtype": "Data",
+   "label": "S3 Key Prefix",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_s3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Total compressed bytes stored in S3.",
+   "fieldname": "s3_size_bytes",
+   "fieldtype": "Long Int",
+   "label": "S3 Size (bytes)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "s3_uploaded_at",
+   "fieldtype": "Datetime",
+   "label": "S3 Uploaded At",
+   "read_only": 1
+  },
+  {
+   "description": "The upload manifest: one JSON row per object (name, object, sha256, sizes, disk size). Restore reads it to re-presign GETs and recreate the LVs.",
+   "fieldname": "s3_objects",
+   "fieldtype": "Small Text",
+   "label": "S3 Objects (manifest)",
    "read_only": 1
   }
  ],

--- a/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.py
+++ b/atlas/atlas/doctype/virtual_machine_snapshot/virtual_machine_snapshot.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import frappe
@@ -35,6 +36,11 @@ class VirtualMachineSnapshot(Document):
 		memory_directory: DF.Data | None
 		memory_megabytes: DF.Int
 		rootfs_path: DF.Data | None
+		s3_bucket: DF.Data | None
+		s3_key_prefix: DF.Data | None
+		s3_objects: DF.SmallText | None
+		s3_status: DF.Literal["", "Uploading", "Uploaded", "Restoring", "Failed"]
+		s3_uploaded_at: DF.Datetime | None
 		server: DF.Link | None
 		source_image: DF.Link | None
 		status: DF.Literal["Pending", "Available", "Failed"]
@@ -406,6 +412,180 @@ class VirtualMachineSnapshot(Document):
 		# placement can provision from it.
 		image.db_set("is_active", 1)
 
+	@frappe.whitelist()
+	def upload_to_s3(self) -> None:
+		"""Push this snapshot's artifacts to S3 for off-host durability — the disk
+		LV(s), plus (warm) the frozen memory pair + host signature. The byte movement
+		is minutes of zstd/curl, far too long for a web request (the gunicorn-timeout
+		lesson promote_to_image learned), so this sets Uploading and enqueues a
+		background job that returns immediately. Poll s3_status / the enqueued Task.
+		Idempotent — a re-run overwrites the objects. See spec/29-snapshot-backup.md."""
+		from atlas.atlas import s3
+
+		if self.status != "Available":
+			frappe.throw(f"Snapshot is not Available (status is {self.status})")
+		if not self.server or not frappe.db.exists("Server", self.server):
+			frappe.throw(_("Snapshot has no server to upload from."))
+		if not s3.is_configured():
+			frappe.throw(_("S3 Settings is not configured — set the bucket and credentials first."))
+		if self.s3_status in ("Uploading", "Restoring"):
+			frappe.throw(f"A backup operation is already running (s3_status is {self.s3_status}).")
+		self.db_set("s3_status", "Uploading")
+		frappe.enqueue(
+			"atlas.atlas.doctype.virtual_machine_snapshot.virtual_machine_snapshot.run_upload",
+			queue="long",
+			enqueue_after_commit=True,
+			snapshot_name=self.name,
+		)
+
+	def _run_upload(self) -> None:
+		"""Background half of upload_to_s3: presign a PUT per artifact, run the host
+		Task, and record the manifest. On any host failure set Failed and re-raise
+		(loud at the boundary — the operator retries the button)."""
+		from atlas.atlas import s3
+
+		backup = s3.S3Backup()
+		plan = s3.backup_plan(self)
+		for obj in plan:
+			obj["url"] = backup.presign_put(backup.object_key(self.name, obj["object_name"]))
+		try:
+			task = run_task(
+				server=self.server,
+				script="upload-snapshot-s3",
+				variables={"SNAPSHOT_NAME": self.name, "OBJECTS_JSON": json.dumps(plan)},
+				virtual_machine=self._task_vm(),
+				timeout_seconds=3600,
+			)
+			result = parse_result(task.stdout)
+		except Exception:
+			self.db_set("s3_status", "Failed")
+			# nosemgrep: frappe-manual-commit -- persist Failed before re-raising so the job log and row agree
+			frappe.db.commit()
+			raise
+		self._record_upload(backup, plan, result)
+
+	def _record_upload(self, backup, plan: list[dict], result: dict) -> None:
+		"""Merge the plan (which artifact, where, how big) with the host's measured
+		digests/sizes into the durable manifest, and flip the row Uploaded. The
+		presigned url is deliberately NOT stored — it is a time-limited secret."""
+		measured = {item["name"]: item for item in result["objects"]}
+		manifest = [
+			{
+				"name": obj["name"],
+				"object_name": obj["object_name"],
+				"source": obj["source"],
+				"block": obj["block"],
+				"compress": obj["compress"],
+				"disk_gigabytes": obj["disk_gigabytes"],
+				"sha256": measured.get(obj["name"], {}).get("sha256", ""),
+				"compressed_bytes": measured.get(obj["name"], {}).get("compressed_bytes", 0),
+				"raw_bytes": measured.get(obj["name"], {}).get("raw_bytes", 0),
+			}
+			for obj in plan
+		]
+		self.db_set(
+			{
+				"s3_status": "Uploaded",
+				"s3_bucket": backup.bucket,
+				"s3_key_prefix": backup.prefix_for(self.name),
+				"s3_size_bytes": result["total_compressed_bytes"],
+				"s3_uploaded_at": frappe.utils.now_datetime(),
+				"s3_objects": json.dumps(manifest),
+			}
+		)
+
+	@frappe.whitelist()
+	def restore_from_s3(self) -> None:
+		"""Pull this snapshot's artifacts back from S3 and rehydrate its on-host
+		LV(s) (+ warm memory pair) at the exact names the row already records, then —
+		for a Cold snapshot whose VM is Stopped — roll the VM back in place. A Warm
+		snapshot rehydrates only (consume it with Clone to new VM; warm's value is
+		fan-out, not in-place rollback — the same asymmetry promote_to_image draws).
+		Background job, like upload. See spec/29-snapshot-backup.md."""
+		if self.s3_status != "Uploaded":
+			frappe.throw(f"No S3 backup to restore (s3_status is {self.s3_status or 'empty'}).")
+		if not self.server or not frappe.db.exists("Server", self.server):
+			frappe.throw(_("Snapshot has no server to restore onto."))
+		if self.kind == "Cold":
+			self._guard_cold_rollback_target()
+		self.db_set("s3_status", "Restoring")
+		frappe.enqueue(
+			"atlas.atlas.doctype.virtual_machine_snapshot.virtual_machine_snapshot.run_restore",
+			queue="long",
+			enqueue_after_commit=True,
+			snapshot_name=self.name,
+		)
+
+	def _guard_cold_rollback_target(self) -> None:
+		"""A cold restore rolls the VM back via rebuild(), which needs a Stopped VM.
+		Check up front so a running (or vanished) VM fails BEFORE any multi-GB
+		download rather than after."""
+		if not frappe.db.exists("Virtual Machine", self.virtual_machine):
+			frappe.throw(
+				_(
+					"The snapshot's VM no longer exists; restoring to a new VM on another server is out of scope (spec/29)."
+				)
+			)
+		vm_status = frappe.db.get_value("Virtual Machine", self.virtual_machine, "status")
+		if vm_status != "Stopped":
+			frappe.throw(f"Stop {self.virtual_machine} before restoring (status is {vm_status}).")
+
+	def _run_restore(self) -> str | None:
+		"""Background half of restore_from_s3: presign a GET per manifest object, run
+		the host Task to rehydrate the artifacts, then (cold) roll the VM back.
+		Returns the rollback Task name for a cold snapshot, else None. On host failure
+		set Failed and re-raise."""
+		from atlas.atlas import s3
+
+		backup = s3.S3Backup()
+		manifest = json.loads(self.s3_objects or "[]")
+		if not manifest:
+			frappe.throw(_("No upload manifest to restore from."))
+		plan = []
+		for obj in manifest:
+			item = dict(obj)
+			item["url"] = backup.presign_get(backup.object_key(self.name, obj["object_name"]))
+			plan.append(item)
+		try:
+			task = run_task(
+				server=self.server,
+				script="restore-snapshot-s3",
+				variables={"SNAPSHOT_NAME": self.name, "OBJECTS_JSON": json.dumps(plan)},
+				virtual_machine=self._task_vm(),
+				timeout_seconds=3600,
+			)
+			parse_result(task.stdout)
+		except Exception:
+			self.db_set("s3_status", "Failed")
+			# nosemgrep: frappe-manual-commit -- persist Failed before re-raising so the job log and row agree
+			frappe.db.commit()
+			raise
+		# Rehydrated: the LVs + memory dir the row names exist again. The backup stays
+		# in S3 (Uploaded), so a later re-restore still works.
+		self.db_set("s3_status", "Uploaded")
+		if self.kind == "Cold":
+			return self.restore_to_vm()
+		return None
+
+	def _task_vm(self) -> str | None:
+		"""The VM to stamp on the backup Task as an audit backpointer — dropped if the
+		VM row is already gone (a durable snapshot can outlive its build VM)."""
+		return self.virtual_machine if frappe.db.exists("Virtual Machine", self.virtual_machine) else None
+
+	def _delete_s3_backup(self) -> None:
+		"""Best-effort: drop this snapshot's S3 objects when the row is deleted, so a
+		deleted backup leaves no paid orphan. Never blocks the local delete — an S3
+		error is logged, not raised (a bucket hiccup must not wedge a teardown)."""
+		if self.s3_status != "Uploaded":
+			return
+		try:
+			from atlas.atlas import s3
+
+			if s3.is_configured():
+				s3.S3Backup().delete_prefix(self.name)
+		except Exception:
+			frappe.log_error(f"S3 backup cleanup failed for snapshot {self.name}", "snapshot backup")
+
 	def on_trash(self) -> None:
 		"""Remove the on-host snapshot LV when the row is deleted.
 
@@ -419,6 +599,10 @@ class VirtualMachineSnapshot(Document):
 		removal and MUST be lvremoved here even when terminate() cascades the row
 		deletions of a Terminated VM. (No Terminated short-circuit: that would
 		leak the snapshot LV.)"""
+		# Drop the off-host S3 backup first (independent of the server/LV path below,
+		# which the guards can short-circuit — the S3 objects must be swept even if
+		# the server row is gone). Best-effort: never blocks the local delete.
+		self._delete_s3_backup()
 		if not self.server or not self.rootfs_path:
 			return
 		if not frappe.db.exists("Server", self.server):
@@ -459,3 +643,19 @@ def run_promote(snapshot_name: str, image_name: str) -> None:
 		return  # anchor was cleaned up by a prior failed run; nothing to drive
 	snapshot = frappe.get_doc("Virtual Machine Snapshot", snapshot_name)
 	snapshot._run_promote(image_name)
+
+
+def run_upload(snapshot_name: str) -> None:
+	"""Background-job entrypoint (enqueued by upload_to_s3). No-op if the snapshot
+	was deleted before the job ran."""
+	if not frappe.db.exists("Virtual Machine Snapshot", snapshot_name):
+		return
+	frappe.get_doc("Virtual Machine Snapshot", snapshot_name)._run_upload()
+
+
+def run_restore(snapshot_name: str) -> None:
+	"""Background-job entrypoint (enqueued by restore_from_s3). No-op if the snapshot
+	was deleted before the job ran."""
+	if not frappe.db.exists("Virtual Machine Snapshot", snapshot_name):
+		return
+	frappe.get_doc("Virtual Machine Snapshot", snapshot_name)._run_restore()

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -221,10 +221,36 @@ def _fake_disk_bytes(variables: dict) -> int:
 	return gigabytes * 1024 * 1024 * 1024
 
 
+def _upload_snapshot_s3_result(variables: dict) -> dict:
+	# Synthesize a manifest for whatever objects the plan asked to upload, so the
+	# controller's parse_result + row update run exactly as on a real host.
+	objects = json.loads(variables.get("OBJECTS_JSON") or "[]")
+	built = []
+	for obj in objects:
+		raw = int(obj.get("disk_gigabytes") or 1) * 1024 * 1024 * 1024
+		built.append(
+			{
+				"name": obj["name"],
+				"object_name": obj["object_name"],
+				"sha256": "0" * 64,
+				"compressed_bytes": raw // 4,
+				"raw_bytes": raw,
+			}
+		)
+	return {"objects": built, "total_compressed_bytes": sum(item["compressed_bytes"] for item in built)}
+
+
+def _restore_snapshot_s3_result(variables: dict) -> dict:
+	objects = json.loads(variables.get("OBJECTS_JSON") or "[]")
+	return {"objects": [obj["name"] for obj in objects]}
+
+
 _RESULT_BUILDERS = {
 	"bootstrap-server": _bootstrap_result,
 	"server-facts": _server_facts_result,
 	"snapshot-vm": _snapshot_result,
 	"snapshot-stop-vm": _snapshot_stop_result,
 	"warm-snapshot-vm": _warm_snapshot_result,
+	"upload-snapshot-s3": _upload_snapshot_s3_result,
+	"restore-snapshot-s3": _restore_snapshot_s3_result,
 }

--- a/atlas/atlas/s3.py
+++ b/atlas/atlas/s3.py
@@ -1,0 +1,165 @@
+"""S3 snapshot backup — the controller-side object-storage client.
+
+Reads `S3 Settings` for the bucket + credentials (the secret via
+`atlas.atlas.secrets.get_secret`, mirroring `DigitalOceanProvider` / `Route53`).
+The host never holds S3 credentials: this class **presigns** short-lived PUT/GET
+URLs that the host streams to/from with plain `curl`
+(spec/29-snapshot-backup.md). `boto3` is a controller-only dependency (already
+required for TLS); the import is local so it never loads on a host or at module
+import.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import frappe
+
+from atlas.atlas.secrets import get_secret
+
+DEFAULT_REGION = "us-east-1"
+DEFAULT_KEY_PREFIX = "atlas/snapshots"
+DEFAULT_PRESIGN_EXPIRY_SECONDS = 3600
+
+
+@dataclasses.dataclass(frozen=True)
+class TestResult:
+	"""Outcome of the S3 Settings Test Connection button."""
+
+	ok: bool
+	detail: str = ""
+
+
+def is_configured() -> bool:
+	"""True iff `S3 Settings` has a bucket and an access key — the cheap gate a
+	controller checks before instantiating `S3Backup` (which throws otherwise)."""
+	settings = frappe.get_single("S3 Settings")
+	return bool(settings.bucket and settings.access_key_id)
+
+
+def backup_plan(snapshot) -> list[dict]:
+	"""The artifacts of `snapshot` to push to (or pull from) S3 — one dict per
+	object. This is the single place that knows *which* on-host files back a
+	snapshot: the root disk LV, the data disk LV (cold-with-data), and the warm
+	memory pair + host signature. Pure over the doc's fields, so it unit-tests
+	with a stub. Each dict is the object's identity; the transport (`put_url` on
+	upload, `sha256`/`get_url` on restore) is layered on by the caller.
+
+	`disk_gigabytes` is the LV size to recreate on restore (0 for a file object).
+	`compress` is zstd for everything but the tiny host-signature JSON.
+	"""
+	plan: list[dict] = [_disk_object("rootfs", snapshot.rootfs_path, snapshot.disk_gigabytes)]
+	if snapshot.data_rootfs_path:
+		plan.append(_disk_object("data", snapshot.data_rootfs_path, snapshot.data_disk_gigabytes))
+	if snapshot.kind == "Warm" and snapshot.memory_directory:
+		directory = snapshot.memory_directory.rstrip("/")
+		plan.append(_file_object("vmstate", f"{directory}/vmstate.bin", "vmstate.bin.zst", compress=True))
+		plan.append(_file_object("mem", f"{directory}/mem.bin", "mem.bin.zst", compress=True))
+		plan.append(
+			_file_object(
+				"host-signature", f"{directory}/host-signature.json", "host-signature.json", compress=False
+			)
+		)
+	return plan
+
+
+def _disk_object(name: str, source: str, disk_gigabytes: int) -> dict:
+	return {
+		"name": name,
+		"object_name": f"{name}.img.zst",
+		"source": source,
+		"block": True,
+		"compress": True,
+		"disk_gigabytes": int(disk_gigabytes or 0),
+	}
+
+
+def _file_object(name: str, source: str, object_name: str, *, compress: bool) -> dict:
+	return {
+		"name": name,
+		"object_name": object_name,
+		"source": source,
+		"block": False,
+		"compress": compress,
+		"disk_gigabytes": 0,
+	}
+
+
+class S3Backup:
+	"""The S3 bucket that holds snapshot backups. Presigns per-object URLs, owns
+	the key layout, and can delete a snapshot's objects; the byte movement itself
+	happens on the host over `curl` (this class never touches a disk)."""
+
+	def __init__(self) -> None:
+		settings = frappe.get_single("S3 Settings")
+		if not settings.bucket or not settings.access_key_id:
+			frappe.throw("S3 Settings is not configured — set the bucket and credentials first.")
+		self.bucket = settings.bucket
+		self.region = settings.region or DEFAULT_REGION
+		self.endpoint_url = settings.endpoint_url or None
+		self.key_prefix = (settings.key_prefix or DEFAULT_KEY_PREFIX).strip("/")
+		self.expiry_seconds = int(settings.presign_expiry_seconds or DEFAULT_PRESIGN_EXPIRY_SECONDS)
+		self.access_key_id = settings.access_key_id
+		self.secret_access_key = get_secret("S3 Settings", "S3 Settings", "secret_access_key")
+
+	def object_key(self, snapshot_name: str, object_name: str) -> str:
+		"""`<prefix>/<snapshot>/<object>` — the single source of the key layout."""
+		return f"{self.key_prefix}/{snapshot_name}/{object_name}"
+
+	def prefix_for(self, snapshot_name: str) -> str:
+		"""The key prefix that holds every object of one snapshot."""
+		return f"{self.key_prefix}/{snapshot_name}/"
+
+	def presign_put(self, key: str) -> str:
+		return self._presign("put_object", key)
+
+	def presign_get(self, key: str) -> str:
+		return self._presign("get_object", key)
+
+	def delete_prefix(self, snapshot_name: str) -> int:
+		"""Delete every object under a snapshot's prefix; return how many. Used by
+		the snapshot row's on_trash so a deleted backup leaves no paid orphan."""
+		client = self._client()
+		prefix = self.prefix_for(snapshot_name)
+		deleted = 0
+		paginator = client.get_paginator("list_objects_v2")
+		for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+			keys = [{"Key": item["Key"]} for item in page.get("Contents", [])]
+			if keys:
+				client.delete_objects(Bucket=self.bucket, Delete={"Objects": keys})
+				deleted += len(keys)
+		return deleted
+
+	def test_connection(self) -> TestResult:
+		"""head_bucket — the lightest read that proves the credentials reach the
+		bucket, mirroring Route53Settings.test_connection's list_hosted_zones."""
+		try:
+			self._client().head_bucket(Bucket=self.bucket)
+		except ImportError:
+			return TestResult(ok=False, detail="boto3 not installed on the controller")
+		except Exception as exception:
+			return TestResult(ok=False, detail=str(exception))
+		return TestResult(ok=True, detail=f"reached bucket {self.bucket!r} in {self.region}")
+
+	# --- boto3 (controller-only; imported locally so hosts never load it) ---
+
+	def _client(self):
+		import boto3
+		from botocore.client import Config
+
+		# s3v4 presigning works in every region; path-style addressing is what
+		# S3-compatible stores (MinIO, DO Spaces on a custom endpoint) need.
+		style = "path" if self.endpoint_url else "auto"
+		return boto3.client(
+			"s3",
+			aws_access_key_id=self.access_key_id,
+			aws_secret_access_key=self.secret_access_key,
+			region_name=self.region,
+			endpoint_url=self.endpoint_url,
+			config=Config(signature_version="s3v4", s3={"addressing_style": style}),
+		)
+
+	def _presign(self, method: str, key: str) -> str:
+		return self._client().generate_presigned_url(
+			method, Params={"Bucket": self.bucket, "Key": key}, ExpiresIn=self.expiry_seconds
+		)

--- a/atlas/atlas/test_s3.py
+++ b/atlas/atlas/test_s3.py
@@ -1,0 +1,111 @@
+"""Unit tests for atlas.atlas.s3 — the snapshot-backup S3 client.
+
+`backup_plan` is pure over the snapshot's fields (tested with stubs, no DB). The
+key-layout / presign methods need `S3 Settings` configured; presign itself needs
+boto3 (a controller-only dep), so those assertions skip cleanly when it is absent.
+See spec/29-snapshot-backup.md.
+"""
+
+import importlib.util
+import types
+import unittest
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas import s3
+
+
+def _boto3_available() -> bool:
+	return importlib.util.find_spec("boto3") is not None
+
+
+def _snapshot(**overrides) -> types.SimpleNamespace:
+	base = {
+		"rootfs_path": "/dev/atlas/atlas-snap-abc",
+		"data_rootfs_path": "",
+		"data_disk_gigabytes": 0,
+		"disk_gigabytes": 28,
+		"kind": "Cold",
+		"memory_directory": "",
+	}
+	base.update(overrides)
+	return types.SimpleNamespace(**base)
+
+
+class TestBackupPlan(unittest.TestCase):
+	def test_cold_root_only(self) -> None:
+		plan = s3.backup_plan(_snapshot())
+		self.assertEqual([obj["name"] for obj in plan], ["rootfs"])
+		root = plan[0]
+		self.assertEqual(root["object_name"], "rootfs.img.zst")
+		self.assertEqual(root["source"], "/dev/atlas/atlas-snap-abc")
+		self.assertTrue(root["block"])
+		self.assertTrue(root["compress"])
+		self.assertEqual(root["disk_gigabytes"], 28)
+
+	def test_cold_with_data(self) -> None:
+		plan = s3.backup_plan(
+			_snapshot(data_rootfs_path="/dev/atlas/atlas-datasnap-abc", data_disk_gigabytes=10)
+		)
+		self.assertEqual([obj["name"] for obj in plan], ["rootfs", "data"])
+		self.assertEqual(plan[1]["object_name"], "data.img.zst")
+		self.assertEqual(plan[1]["source"], "/dev/atlas/atlas-datasnap-abc")
+		self.assertEqual(plan[1]["disk_gigabytes"], 10)
+
+	def test_warm_adds_memory_pair(self) -> None:
+		plan = s3.backup_plan(_snapshot(kind="Warm", memory_directory="/var/lib/atlas/snapshots/abc"))
+		by_name = {obj["name"]: obj for obj in plan}
+		self.assertEqual([obj["name"] for obj in plan], ["rootfs", "vmstate", "mem", "host-signature"])
+		self.assertEqual(by_name["vmstate"]["source"], "/var/lib/atlas/snapshots/abc/vmstate.bin")
+		self.assertEqual(by_name["vmstate"]["object_name"], "vmstate.bin.zst")
+		self.assertFalse(by_name["mem"]["block"])
+		self.assertTrue(by_name["mem"]["compress"])
+		# The host signature ships raw (no zstd) — it is tiny.
+		self.assertFalse(by_name["host-signature"]["compress"])
+		self.assertEqual(by_name["host-signature"]["object_name"], "host-signature.json")
+
+	def test_warm_trailing_slash_is_trimmed(self) -> None:
+		plan = s3.backup_plan(_snapshot(kind="Warm", memory_directory="/m/abc/"))
+		vmstate = next(obj for obj in plan if obj["name"] == "vmstate")
+		self.assertEqual(vmstate["source"], "/m/abc/vmstate.bin")
+
+
+class TestS3Backup(IntegrationTestCase):
+	def setUp(self) -> None:
+		frappe.get_doc("S3 Settings").setup(
+			bucket="atlas-backups-test",
+			access_key_id="AKIATEST",
+			secret_access_key="secret-xyz",
+			region="us-west-2",
+			key_prefix="atlas/snapshots",
+		)
+
+	def test_key_layout(self) -> None:
+		backup = s3.S3Backup()
+		self.assertEqual(backup.object_key("snap1", "rootfs.img.zst"), "atlas/snapshots/snap1/rootfs.img.zst")
+		self.assertEqual(backup.prefix_for("snap1"), "atlas/snapshots/snap1/")
+		self.assertEqual(backup.bucket, "atlas-backups-test")
+
+	def test_key_prefix_is_normalized(self) -> None:
+		frappe.get_doc("S3 Settings").setup(
+			bucket="b", access_key_id="A", secret_access_key="S", key_prefix="/atlas/snaps/"
+		)
+		self.assertEqual(s3.S3Backup().prefix_for("x"), "atlas/snaps/x/")
+
+	def test_is_configured(self) -> None:
+		self.assertTrue(s3.is_configured())
+
+	def test_unconfigured_throws(self) -> None:
+		frappe.db.set_single_value("S3 Settings", "bucket", "")
+		self.assertFalse(s3.is_configured())
+		with self.assertRaises(frappe.ValidationError):
+			s3.S3Backup()
+
+	@unittest.skipUnless(_boto3_available(), "boto3 not installed on the controller")
+	def test_presign_embeds_bucket_and_key(self) -> None:
+		backup = s3.S3Backup()
+		url = backup.presign_put(backup.object_key("snap1", "rootfs.img.zst"))
+		self.assertTrue(url.startswith("https://"))
+		self.assertIn("atlas-backups-test", url)
+		self.assertIn("snap1", url)

--- a/atlas/tests/e2e/use_cases/snapshot_backup.py
+++ b/atlas/tests/e2e/use_cases/snapshot_backup.py
@@ -1,0 +1,249 @@
+"""S3 snapshot backup round-trip — upload a Cold snapshot to S3, lose the local
+LV, restore it from S3, and roll the VM back onto the rehydrated disk.
+
+The use case behind [spec/29-snapshot-backup.md](../../../../spec/29-snapshot-backup.md):
+a `Virtual Machine Snapshot` is one LVM thin snapshot in one pool on one host —
+instant and space-thin, but not durable (lose the pool and every snapshot on it
+is gone). This proves the off-host round trip against a real droplet + a real S3
+endpoint — the host facts nothing but a live run can show:
+
+  1. upload: upload-snapshot-s3.py activates the snapshot LV, `zstd -o`s it to a
+     temp (reading the block device directly — no dd, no pipe, so the exit code is
+     honestly zstd's own), `sha256sum`s it, and `curl -T`s it to a
+     controller-presigned PUT URL. The host holds NO S3 credentials.
+  2. durability: `lvremove` the snapshot LV on the host — the pool no longer has
+     it, exactly as a wiped disk / re-imaged host would leave it.
+  3. restore: restore-snapshot-s3.py re-presigns a GET per manifest object,
+     recreates a fresh thin LV at the exact name the row records
+     (`atlas-snap-<id>`), verifies each object's sha256 BEFORE decompressing (the
+     sync-image integrity gate), and `zstd -d --sparse`s it back onto the LV. A
+     Cold restore then chains restore_to_vm() to roll the VM back in place.
+  4. proof: the VM starts and boots off the rebuilt disk — the snapshot survived
+     the loss of its local LV.
+
+Needs an `s3` block in the E2E fixture ($ATLAS_E2E_CONFIG, default
+`~/.cache/atlas-e2e/config.json`); without it the module skips cleanly
+(MissingConfig) rather than failing deep in boto3. A local MinIO is the zero-cost
+target — point `s3.endpoint_url` at it (path-style is auto for a custom endpoint;
+see spec/29). Heavy (a real VM provision + a multi-GB round trip), so it is
+invoked directly, not folded into `run_all_smoke`:
+
+    bench --site <site> execute \
+        atlas.tests.e2e.use_cases.snapshot_backup.run_smoke
+
+The VM + snapshot are torn down in a `finally`; the snapshot's on_trash also
+sweeps its S3 objects, so a run leaves no paid orphan in the bucket. It needs the
+background worker up (the VM auto-provision contract), like the other host e2es.
+"""
+
+import json
+
+import frappe
+
+from atlas.atlas.ssh import run_task
+from atlas.tests.e2e._config import E2EConfig, MissingConfig
+from atlas.tests.e2e._droplets import ensure_e2e_provider
+from atlas.tests.e2e._shared import (
+	assert_probe,
+	ensure_image_on_server,
+	ephemeral_public_key,
+	phase,
+	wait_for_vm_running,
+)
+
+
+def run_smoke(reuse: bool = True, keep: bool = True) -> None:
+	with phase("snapshot-s3-backup", reuse=reuse, keep=keep) as server:
+		# Skips cleanly (MissingConfig) on a box without an `s3` fixture block.
+		_configure_s3()
+		# Unit tests may have clobbered Atlas/DigitalOcean Settings with fakes;
+		# re-seed from the fixture before anything SSHes (real-provision-traps).
+		ensure_e2e_provider()
+		# The two S3 host verbs + the durable atlas lib refresh via scp, not
+		# per-Task — an Active server from a prior run needs the sync.
+		uploaded = server.sync_scripts()
+		print(f"[s3] sync_scripts: {uploaded} durable files refreshed on {server.name}")
+		image = ensure_image_on_server(server.name)
+
+		virtual_machine = _provision_stopped_vm(server.name, image.name)
+		snapshot = None
+		try:
+			snapshot = frappe.get_doc("Virtual Machine Snapshot", _snapshot(virtual_machine))
+			_upload_and_verify(snapshot)
+			_lose_local_lv(server.name, snapshot)
+			_restore_and_verify(server.name, virtual_machine, snapshot)
+		finally:
+			_teardown(virtual_machine, snapshot)
+
+
+def _configure_s3() -> None:
+	"""Seed `S3 Settings` from the fixture's `s3` block via the idempotent setup()
+	contract — the test-side analogue of `ensure_e2e_provider`, so the harness
+	drives the same explicit setter the operator's Test Connection button does.
+
+	Raises MissingConfig naming what to add when the block is absent, so a box that
+	hasn't configured S3 skips this e2e cleanly rather than failing deep in boto3.
+	"""
+	config = E2EConfig.load()
+	if not config.section("s3"):
+		raise MissingConfig(
+			"e2e config has no 's3' block — add {bucket, access_key_id, "
+			"secret_access_key, endpoint_url?} to run the snapshot-S3 e2e. A local "
+			"MinIO is the zero-cost target (endpoint_url http://127.0.0.1:9000); see spec/29."
+		)
+	frappe.get_single("S3 Settings").setup(
+		bucket=config.require_in("s3", "bucket"),
+		access_key_id=config.require_in("s3", "access_key_id"),
+		secret_access_key=config.require_in("s3", "secret_access_key"),
+		region=config.section("s3").get("region") or "us-east-1",
+		endpoint_url=config.section("s3").get("endpoint_url") or "",
+		key_prefix=config.section("s3").get("key_prefix") or "atlas/snapshots",
+	)
+	frappe.db.commit()
+
+	from atlas.atlas import s3
+
+	result = s3.S3Backup().test_connection()
+	assert result.ok, f"S3 Test Connection failed — check the bucket/credentials/endpoint: {result.detail}"
+	print(f"[s3] S3 Settings configured: {result.detail}")
+
+
+def _provision_stopped_vm(server_name: str, image: str) -> str:
+	"""Provision a small VM, wait for it to boot, then Stop it — the clean base
+	state for a Cold snapshot (Stopped-only, the safe default) and the Cold restore
+	rollback (rebuild() needs a Stopped VM). Returns the VM name."""
+	virtual_machine = frappe.get_doc(
+		{
+			"doctype": "Virtual Machine",
+			"title": "snapshot-s3-e2e",
+			"server": server_name,
+			"image": image,
+			"vcpus": 1,
+			"memory_megabytes": 512,
+			"disk_gigabytes": 4,
+			"ssh_public_key": ephemeral_public_key(),
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	# Phase 4 auto-provision: after_insert enqueues provision(); the worker drives
+	# Pending -> Running. Then stop for a flush-consistent disk to snapshot.
+	wait_for_vm_running(virtual_machine.name, timeout_seconds=180)
+	virtual_machine.reload()
+	virtual_machine.stop()
+	virtual_machine.reload()
+	assert virtual_machine.status == "Stopped", virtual_machine.status
+	print(f"[s3] {virtual_machine.name} provisioned and Stopped — ready to snapshot")
+	return virtual_machine.name
+
+
+def _snapshot(virtual_machine_name: str) -> str:
+	"""Take a Cold (disk-only) snapshot of the Stopped VM. Returns its name."""
+	virtual_machine = frappe.get_doc("Virtual Machine", virtual_machine_name)
+	name = virtual_machine.snapshot("s3-e2e-backup")
+	frappe.db.commit()
+	snapshot = frappe.get_doc("Virtual Machine Snapshot", name)
+	assert snapshot.kind == "Cold", snapshot.kind
+	assert snapshot.status == "Available", snapshot.status
+	print(f"[s3] cold snapshot {name} (rootfs {snapshot.rootfs_path})")
+	return name
+
+
+def _upload_and_verify(snapshot) -> None:
+	"""Drive the upload host Task inline (deterministic logs; the real per-object
+	zstd/sha256/curl still runs on the host), then assert the row records a manifest
+	and the objects really landed in the bucket."""
+	# _run_upload is the background half of upload_to_s3 — called directly so this
+	# process, not a worker, carries the Task, and the assertions see the result.
+	snapshot._run_upload()
+	snapshot.reload()
+	assert snapshot.s3_status == "Uploaded", snapshot.s3_status
+	manifest = json.loads(snapshot.s3_objects or "[]")
+	assert manifest, "upload recorded no manifest"
+	assert int(snapshot.s3_size_bytes or 0) > 0, snapshot.s3_size_bytes
+	for obj in manifest:
+		# Every object carries a sha256 of its COMPRESSED bytes (the restore gate).
+		assert obj["sha256"], f"manifest object {obj['name']} has no sha256"
+	print(
+		f"[s3] uploaded {len(manifest)} object(s), {snapshot.s3_size_bytes} compressed bytes "
+		f"to s3://{snapshot.s3_bucket}/{snapshot.s3_key_prefix}"
+	)
+	_assert_objects_in_bucket(snapshot, manifest)
+
+
+def _assert_objects_in_bucket(snapshot, manifest: list[dict]) -> None:
+	"""Controller-side head_object per manifest object — independent proof the bytes
+	reached S3, not just that the host reported success."""
+	from atlas.atlas import s3
+
+	backup = s3.S3Backup()
+	client = backup._client()
+	for obj in manifest:
+		key = backup.object_key(snapshot.name, obj["object_name"])
+		head = client.head_object(Bucket=backup.bucket, Key=key)
+		assert head["ContentLength"] == obj["compressed_bytes"], (
+			f"{key}: bucket size {head['ContentLength']} != manifest {obj['compressed_bytes']}"
+		)
+	print(f"[s3] verified {len(manifest)} object(s) present in the bucket")
+
+
+def _lose_local_lv(server_name: str, snapshot) -> None:
+	"""Simulate losing the pool: lvremove the snapshot LV on the host WITHOUT
+	deleting the row. Reuses the on_trash host verb (delete-snapshot-vm) so the
+	loss is exactly what a wiped disk leaves — the row still points at LV names
+	that no longer exist on the host, which is what the restore must rebuild."""
+	task = run_task(
+		server=server_name,
+		script="delete-snapshot-vm",
+		variables={
+			"SNAPSHOT_ROOTFS_PATH": snapshot.rootfs_path,
+			"DATA_SNAPSHOT_ROOTFS_PATH": snapshot.data_rootfs_path or "",
+			# Cold snapshot: no memory pair to remove.
+			"MEMORY_DIRECTORY": "",
+		},
+		virtual_machine=snapshot.virtual_machine,
+		timeout_seconds=60,
+	)
+	assert task.status == "Success", task.stderr
+	print(f"[s3] dropped local snapshot LV {snapshot.rootfs_path} — the pool no longer holds it")
+
+
+def _restore_and_verify(server_name: str, virtual_machine_name: str, snapshot) -> None:
+	"""Restore the snapshot from S3 (rehydrate the LV + roll the Cold VM back), then
+	prove the VM boots off the rebuilt disk."""
+	snapshot.reload()
+	assert snapshot.s3_status == "Uploaded", snapshot.s3_status
+	# _run_restore is the background half of restore_from_s3: rehydrate the LV, then
+	# (Cold) chain restore_to_vm() and return its rollback Task name.
+	rollback_task = snapshot._run_restore()
+	snapshot.reload()
+	assert snapshot.s3_status == "Uploaded", snapshot.s3_status
+	assert rollback_task, "a Cold restore should return an in-place rollback Task"
+	print(f"[s3] restored from S3 and rolled {virtual_machine_name} back (task {rollback_task})")
+
+	# rebuild() leaves the VM Stopped; start it and prove the unit comes up on the
+	# disk that was just rebuilt from the S3-restored snapshot.
+	virtual_machine = frappe.get_doc("Virtual Machine", virtual_machine_name)
+	virtual_machine.start()
+	virtual_machine.reload()
+	assert virtual_machine.status == "Running", virtual_machine.status
+	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=virtual_machine_name)
+	print(f"[s3] {virtual_machine_name} boots off the S3-restored disk — round trip verified")
+
+
+def _teardown(virtual_machine_name: str, snapshot) -> None:
+	"""Delete the snapshot (on_trash lvremoves the LV AND sweeps the S3 objects) and
+	terminate the VM. Best-effort — teardown must not mask the real failure."""
+	if snapshot is not None:
+		try:
+			frappe.delete_doc("Virtual Machine Snapshot", snapshot.name, ignore_permissions=True, force=True)
+			frappe.db.commit()
+		except Exception as error:
+			print(f"[s3] snapshot teardown failed for {snapshot.name}: {error}")
+	try:
+		virtual_machine = frappe.get_doc("Virtual Machine", virtual_machine_name)
+		if virtual_machine.status != "Terminated":
+			virtual_machine.terminate()
+		frappe.db.commit()
+	except Exception as error:
+		print(f"[s3] vm teardown failed for {virtual_machine_name}: {error}")

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -177,6 +177,11 @@ PACKAGES = [
 	"qemu-utils",
 	"nbd-client",
 	"socat",
+	# Snapshot backup to S3 (spec/29): zstd compresses each disk image / memory
+	# file on the way to S3 and decompresses it on restore. Kernel decompression in
+	# sync-image already leaned on `zstd -d`; installing it makes that dependency
+	# explicit rather than relying on it being pre-seeded.
+	"zstd",
 ]
 
 # The host's Atlas interpreter — a uv-managed venv on a controlled CPython — is

--- a/scripts/lib/atlas/snapshot_backup.py
+++ b/scripts/lib/atlas/snapshot_backup.py
@@ -1,0 +1,57 @@
+"""Pure helpers shared by upload-snapshot-s3.py and restore-snapshot-s3.py.
+
+The controller sends the object plan as a JSON `--objects-json` flag; this parses
+it into typed `BackupObject`s. Pure (no host), so it unit-tests without LVM or
+curl. The transport fields (the presigned `url`, and on restore the expected
+`sha256`) ride in the same dict and are read straight off the object.
+See spec/29-snapshot-backup.md.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BackupObject:
+	"""One artifact to move to/from S3.
+
+	`source` is the on-host path — an LV device (`block=True`) or a plain file
+	(the warm memory pair). On restore it is the *destination* (the same path the
+	snapshot row records), so upload and restore share this shape. `disk_gigabytes`
+	is the LV size to recreate on restore (0 for a file). `compress` is zstd for
+	everything but the tiny host-signature JSON. `url` is the presigned PUT
+	(upload) or GET (restore); `sha256` is the expected digest of the compressed
+	bytes (restore only)."""
+
+	name: str
+	object_name: str
+	source: str
+	block: bool
+	compress: bool
+	disk_gigabytes: int = 0
+	url: str = ""
+	sha256: str = ""
+
+	@classmethod
+	def from_plan(cls, item: dict) -> "BackupObject":
+		return cls(
+			name=item["name"],
+			object_name=item["object_name"],
+			source=item["source"],
+			block=bool(item["block"]),
+			compress=bool(item["compress"]),
+			disk_gigabytes=int(item.get("disk_gigabytes") or 0),
+			url=item.get("url", ""),
+			sha256=item.get("sha256", ""),
+		)
+
+
+def parse_objects(objects_json: str) -> list[BackupObject]:
+	"""Parse the `--objects-json` flag into typed objects. Raises if empty — a
+	backup with no artifacts is a bug, not a silent no-op."""
+	items = json.loads(objects_json)
+	if not items:
+		raise ValueError("objects-json is empty: nothing to move")
+	return [BackupObject.from_plan(item) for item in items]

--- a/scripts/lib/atlas/test_snapshot_backup.py
+++ b/scripts/lib/atlas/test_snapshot_backup.py
@@ -1,0 +1,112 @@
+"""Unit tests for the pure snapshot-backup plan parsing shared by
+upload-snapshot-s3.py / restore-snapshot-s3.py.
+
+Run with bare `python3 -m unittest atlas.test_snapshot_backup` from scripts/lib:
+no Frappe, no site, no host. Covers the JSON contract the controller and the two
+host scripts agree on (spec/29-snapshot-backup.md).
+"""
+
+import json
+import unittest
+
+from atlas.snapshot_backup import BackupObject, parse_objects
+
+
+class TestBackupObject(unittest.TestCase):
+	def test_from_plan_full(self) -> None:
+		obj = BackupObject.from_plan(
+			{
+				"name": "rootfs",
+				"object_name": "rootfs.img.zst",
+				"source": "/dev/atlas/atlas-snap-x",
+				"block": True,
+				"compress": True,
+				"disk_gigabytes": 28,
+				"url": "https://s3.example/put",
+				"sha256": "abc123",
+			}
+		)
+		self.assertEqual(obj.name, "rootfs")
+		self.assertEqual(obj.object_name, "rootfs.img.zst")
+		self.assertEqual(obj.source, "/dev/atlas/atlas-snap-x")
+		self.assertTrue(obj.block)
+		self.assertTrue(obj.compress)
+		self.assertEqual(obj.disk_gigabytes, 28)
+		self.assertEqual(obj.url, "https://s3.example/put")
+		self.assertEqual(obj.sha256, "abc123")
+
+	def test_from_plan_defaults(self) -> None:
+		# The upload plan carries no sha256/url yet, and a file object no disk size.
+		obj = BackupObject.from_plan(
+			{
+				"name": "host-signature",
+				"object_name": "host-signature.json",
+				"source": "/var/lib/atlas/snapshots/x/host-signature.json",
+				"block": False,
+				"compress": False,
+			}
+		)
+		self.assertEqual(obj.disk_gigabytes, 0)
+		self.assertEqual(obj.url, "")
+		self.assertEqual(obj.sha256, "")
+		self.assertFalse(obj.block)
+		self.assertFalse(obj.compress)
+
+	def test_from_plan_coerces_types(self) -> None:
+		# JSON round-trips can deliver block as 1 and disk_gigabytes as a string.
+		obj = BackupObject.from_plan(
+			{
+				"name": "data",
+				"object_name": "data.img.zst",
+				"source": "/dev/atlas/atlas-datasnap-x",
+				"block": 1,
+				"compress": 1,
+				"disk_gigabytes": "10",
+			}
+		)
+		self.assertIs(obj.block, True)
+		self.assertIs(obj.compress, True)
+		self.assertEqual(obj.disk_gigabytes, 10)
+
+	def test_is_frozen(self) -> None:
+		obj = BackupObject.from_plan(
+			{"name": "r", "object_name": "r.zst", "source": "/x", "block": True, "compress": True}
+		)
+		with self.assertRaises(Exception):
+			obj.name = "y"  # type: ignore[misc]
+
+
+class TestParseObjects(unittest.TestCase):
+	def test_parse_list(self) -> None:
+		objects = parse_objects(
+			json.dumps(
+				[
+					{
+						"name": "rootfs",
+						"object_name": "rootfs.img.zst",
+						"source": "/dev/x",
+						"block": True,
+						"compress": True,
+						"disk_gigabytes": 4,
+					},
+					{
+						"name": "mem",
+						"object_name": "mem.bin.zst",
+						"source": "/m/mem.bin",
+						"block": False,
+						"compress": True,
+					},
+				]
+			)
+		)
+		self.assertEqual([obj.name for obj in objects], ["rootfs", "mem"])
+		self.assertTrue(objects[0].block)
+		self.assertFalse(objects[1].block)
+
+	def test_empty_raises(self) -> None:
+		with self.assertRaises(ValueError):
+			parse_objects("[]")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/restore-snapshot-s3.py
+++ b/scripts/restore-snapshot-s3.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Rehydrate a snapshot's on-host artifacts from S3 via controller-presigned GET
+# URLs. The host holds NO S3 credentials — it pulls each object with curl from a
+# short-lived URL. This is the inverse of upload-snapshot-s3.py: recreate the disk
+# LV(s) the snapshot row already names (atlas-snap-<id>, atlas-datasnap-<id>) and,
+# for a warm snapshot, the memory pair + host signature under the snapshot's
+# memory directory. After this the snapshot is fully local again, so the ordinary
+# restore_to_vm / clone_to_new_vm paths work unchanged.
+#
+# Each object: curl the compressed bytes to a temp file, verify its sha256 (before
+# decompressing — the sync-image integrity gate), then zstd-decompress straight
+# onto the recreated LV (--sparse, so a fresh thin LV stays thin) or into the
+# memory file. Idempotent: a block LV is removed and recreated clean each time.
+# See spec/29-snapshot-backup.md.
+
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import install_directory, run, run_input
+from atlas._task import TaskInputs, TaskResult
+from atlas.lvm import ThinPool
+from atlas.paths import ATLAS_ROOT
+from atlas.snapshot_backup import BackupObject, parse_objects
+
+
+@dataclass(frozen=True)
+class RestoreSnapshotInputs(TaskInputs):
+	"""Rehydrate a snapshot's artifacts from S3 with presigned GET URLs."""
+
+	command: typing.ClassVar[str] = "restore-snapshot-s3"
+	snapshot_name: str  # names the temp working directory
+	# JSON list; each item is a BackupObject dict plus its presigned `url` + `sha256`.
+	objects_json: str
+
+
+@dataclass(frozen=True)
+class RestoreSnapshotResult(TaskResult):
+	objects: list  # the names rehydrated, e.g. ["rootfs", "data"]
+
+
+def main() -> None:
+	inputs = RestoreSnapshotInputs.from_args()
+	objects = parse_objects(inputs.objects_json)
+	pool = ThinPool()
+
+	if any(obj.block for obj in objects) and pool.usage.too_full_to_snapshot:
+		sys.exit(f"thin pool {pool.pool_name} too full to restore into ({pool.usage})")
+
+	work = f"{ATLAS_ROOT}/tmp/s3-restore-{inputs.snapshot_name}"
+	run("sudo rm -rf {}", work)
+	install_directory(work, mode="0700")
+	try:
+		for obj in objects:
+			_restore_one(pool, obj, work)
+	finally:
+		run("sudo rm -rf {}", work)
+	run("sudo sync")
+
+	RestoreSnapshotResult(objects=[obj.name for obj in objects]).emit()
+	print(f"Rehydrated {len(objects)} object(s) for snapshot {inputs.snapshot_name}.")
+
+
+def _restore_one(pool: ThinPool, obj: BackupObject, work: str) -> None:
+	"""Download one object, verify its sha256, and write it to its destination."""
+	temp = f"{work}/{obj.object_name}"
+	run("sudo curl --fail --silent --show-error --output {} {}", temp, obj.url)
+	run_input("sudo sha256sum -c -", stdin=f"{obj.sha256}  {temp}")
+	if obj.block:
+		_restore_block(pool, obj, temp)
+	else:
+		_restore_file(obj, temp)
+	run("sudo rm -f {}", temp)
+
+
+def _restore_block(pool: ThinPool, obj: BackupObject, temp: str) -> None:
+	"""Recreate the LV clean (so a re-restore has no stale blocks), then decompress
+	the image straight onto it. --sparse skips zero runs, keeping the thin LV thin."""
+	if not obj.disk_gigabytes:
+		sys.exit(f"block object {obj.name} has no disk size to recreate {obj.source}")
+	lv = pool.from_device(obj.source)
+	lv.remove()  # no-op if absent; refuses protected LVs (atlas-image-*)
+	pool.create_thin(lv, obj.disk_gigabytes)
+	run("sudo zstd -d -q -f --sparse -o {} {}", lv.device_path, temp)
+
+
+def _restore_file(obj: BackupObject, temp: str) -> None:
+	"""Write a warm memory-pair file (root:root 0644, like warm-snapshot-vm.py's
+	_stage_durable) into the recreated memory directory."""
+	install_directory(os.path.dirname(obj.source), mode="0755")
+	if obj.compress:
+		run("sudo zstd -d -q -f -o {} {}", obj.source, temp)
+	else:
+		run("sudo cp {} {}", temp, obj.source)
+	run("sudo chown root:root {}", obj.source)
+	run("sudo chmod 0644 {}", obj.source)
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/upload-snapshot-s3.py
+++ b/scripts/upload-snapshot-s3.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Upload a snapshot's on-host artifacts to S3 via controller-presigned PUT URLs.
+# The host holds NO S3 credentials — it streams each object with curl to a
+# short-lived URL the controller signed. Cold snapshots upload their disk LV(s);
+# warm snapshots also upload the frozen memory pair + host signature.
+#
+# Each object is handled ONE AT A TIME: zstd-compress the source (an LV read
+# directly, or a memory file) to a temp file — an S3 PUT needs a known length, so
+# we can't stream unknown-length — sha256 it, curl -T it to the presigned URL,
+# delete the temp. Peak temp space is therefore the largest single COMPRESSED
+# object, not the sum. Idempotent: curl -T overwrites, so a re-run re-uploads.
+#
+# The Task contract is typed at both ends (UploadSnapshotInputs.from_args /
+# UploadSnapshotResult.emit). See spec/29-snapshot-backup.md.
+
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import install_directory, run
+from atlas._task import TaskInputs, TaskResult
+from atlas.lvm import ThinPool
+from atlas.paths import ATLAS_ROOT
+from atlas.snapshot_backup import BackupObject, parse_objects
+
+# Backups favour a fast, well-parallelised compress over the last few percent of
+# ratio: level 3 (zstd's default) with every core.
+ZSTD_LEVEL = 3
+
+
+@dataclass(frozen=True)
+class UploadSnapshotInputs(TaskInputs):
+	"""Upload a snapshot's artifacts to S3 with presigned PUT URLs."""
+
+	command: typing.ClassVar[str] = "upload-snapshot-s3"
+	snapshot_name: str  # names the temp working directory
+	# JSON list; each item is a BackupObject dict plus its presigned `url`.
+	objects_json: str
+
+
+@dataclass(frozen=True)
+class UploadSnapshotResult(TaskResult):
+	# One dict per object: {name, object_name, sha256, compressed_bytes, raw_bytes}.
+	objects: list
+	total_compressed_bytes: int
+
+
+def main() -> None:
+	inputs = UploadSnapshotInputs.from_args()
+	objects = parse_objects(inputs.objects_json)
+	pool = ThinPool()
+
+	work = f"{ATLAS_ROOT}/tmp/s3-upload-{inputs.snapshot_name}"
+	run("sudo rm -rf {}", work)
+	install_directory(work, mode="0700")
+	try:
+		uploaded = [_upload_one(pool, obj, work) for obj in objects]
+	finally:
+		run("sudo rm -rf {}", work)
+
+	total = sum(item["compressed_bytes"] for item in uploaded)
+	UploadSnapshotResult(objects=uploaded, total_compressed_bytes=total).emit()
+	print(
+		f"Uploaded {len(uploaded)} object(s) for snapshot {inputs.snapshot_name} ({total} compressed bytes)."
+	)
+
+
+def _upload_one(pool: ThinPool, obj: BackupObject, work: str) -> dict:
+	"""Compress one artifact to a temp file, sha256 it, PUT it, delete the temp."""
+	temp = f"{work}/{obj.object_name}"
+	raw_bytes = _compress(pool, obj, temp)
+	digest = run("sudo sha256sum {}", temp).split()[0]
+	compressed_bytes = int(run("sudo stat -c %s {}", temp).strip())
+	run("sudo curl --fail --silent --show-error --upload-file {} {}", temp, obj.url)
+	run("sudo rm -f {}", temp)
+	return {
+		"name": obj.name,
+		"object_name": obj.object_name,
+		"sha256": digest,
+		"compressed_bytes": compressed_bytes,
+		"raw_bytes": raw_bytes,
+	}
+
+
+def _compress(pool: ThinPool, obj: BackupObject, temp: str) -> int:
+	"""Write the compressed (or, for the tiny signature JSON, verbatim) artifact to
+	`temp`. Returns the raw source size. zstd reads the LV block device (or file)
+	directly — no dd, no pipe, so the exit code is honestly zstd's own."""
+	source = _activated_source(pool, obj)
+	raw_bytes = int(run("sudo blockdev --getsize64 {}", source).strip()) if obj.block else _file_size(source)
+	if obj.compress:
+		run("sudo zstd -q -f -{} -T0 -o {} {}", ZSTD_LEVEL, temp, source)
+	else:
+		run("sudo cp {} {}", source, temp)
+	return raw_bytes
+
+
+def _activated_source(pool: ThinPool, obj: BackupObject) -> str:
+	"""The readable source path: a plain file as-is, or an activated LV device."""
+	if not obj.block:
+		if not os.path.isfile(obj.source):
+			sys.exit(f"source file missing: {obj.source}")
+		return obj.source
+	lv = pool.from_device(obj.source)
+	if not lv.exists:
+		sys.exit(f"source LV not found: {obj.source} ({lv.name})")
+	return lv.activate().device_path
+
+
+def _file_size(path: str) -> int:
+	return int(run("sudo stat -c %s {}", path).strip())
+
+
+if __name__ == "__main__":
+	main()

--- a/spec/05-virtual-machine-lifecycle.md
+++ b/spec/05-virtual-machine-lifecycle.md
@@ -459,6 +459,10 @@ reaching it — `curl --unix-socket` talks to it from the host as before.
 
 ## Snapshot
 
+A snapshot lives in one thin pool on one host — instant and space-thin, but not
+durable (lose the pool and it is gone). To make one survive its host, back it up
+to S3 and restore it later: [29](./29-snapshot-backup.md).
+
 `Virtual Machine.snapshot(title=None, live=False)`. `title` is optional:
 omitted (or blank), it defaults to `<vm title> — <YYYY-MM-DD HH:mm>`, so a
 caller — the SPA's one-click snapshot, or a direct API call — need not invent a

--- a/spec/23-supply-chain.md
+++ b/spec/23-supply-chain.md
@@ -40,9 +40,11 @@ Installed by [`scripts/bootstrap-server.py`](../scripts/bootstrap-server.py) and
 
 The apt set is: `ca-certificates`, `curl`, `e2fsprogs`, `iproute2`, `jq`,
 `lvm2`, `nftables`, `squashfs-tools`, `thin-provisioning-tools`,
-`wireguard-tools` (plus `unattended-upgrades`). These are stock-archive
+`wireguard-tools`, `zstd` (plus `unattended-upgrades`). These are stock-archive
 packages, not version-pinned — we take what 24.04 ships and let
-`unattended-upgrades` roll the security pocket.
+`unattended-upgrades` roll the security pocket. (`zstd` compresses snapshot
+backups to S3 — [29](./29-snapshot-backup.md); `sync-image` already relied on
+`zstd -d` for kernel decompression, so this only makes the dependency explicit.)
 
 **Why the Firecracker binary isn't checksummed.** `sync-image.py` SHA256-pins
 the kernel and rootfs because they are mutable upstream artefacts re-cut per

--- a/spec/29-snapshot-backup.md
+++ b/spec/29-snapshot-backup.md
@@ -1,0 +1,191 @@
+# Snapshot backup to S3
+
+A `Virtual Machine Snapshot` is an LVM thin snapshot living in **one** thin pool
+on **one** server ([05](./05-virtual-machine-lifecycle.md),
+[07](./07-filesystem-layout.md)). That is instant and space-thin, but it is not
+durable: lose the pool (a wiped disk, a re-imaged host, a reclaimed server) and
+every snapshot on it is gone. This chapter adds an **off-host backup**: push a
+point-in-time snapshot's bytes to **S3**, and pull them back later to rebuild the
+same snapshot's on-host artifacts — so the snapshot survives the host that made
+it.
+
+## Scope (this iteration)
+
+- **Same-VM rollback.** A backup restores onto the snapshot's **own** server and
+  rolls its **own** VM back. Restoring to a *new* VM on *another* server (true
+  cross-host disaster recovery) is a durable independent artifact — a bigger data
+  model — and is deferred (see *Non-goals*).
+- **Both kinds.** A **Cold** snapshot backs up its disk LV(s); a **Warm**
+  snapshot also backs up its frozen memory pair (`vmstate.bin`/`mem.bin`) and the
+  capture-time host signature, so a rehydrated warm golden can still be **cloned**
+  (its sanctioned consumption path — [05](./05-virtual-machine-lifecycle.md),
+  `Virtual Machine Snapshot.clone_to_new_vm`). Warm **in-place resume** onto the
+  same VM is out of scope; warm restore rehydrates for cloning.
+
+## The transport: controller-presigned URLs, host has no credentials
+
+Hosts stay stdlib-only and credential-free (a spec goal —
+[README](./README.md#operating-principles) *Few dependencies*; a host never holds
+S3 keys). The controller already links `boto3` for TLS
+([13](./13-tls.md), [`dns/route53.py`](../atlas/atlas/dns/route53.py)); it reuses
+it here to **presign** short-lived `PUT`/`GET` URLs. The host does the byte
+movement with **`curl`** alone — no `aws` CLI, no boto, no keys on disk:
+
+```
+Controller (boto3):  presign PUT/GET for each object key
+        │  presigned URL (a time-limited bearer token; no static creds)
+        ▼
+Host (curl + zstd; NO dd, NO pipe — zstd reads/writes the block device via -o):
+  upload:   zstd -o tmp /dev/atlas/atlas-snap-<id> ; sha256sum tmp ; curl -T tmp <put-url>
+  restore:  curl -o tmp <get-url> ; sha256sum -c ; zstd -d --sparse -o /dev/atlas/atlas-snap-<id> tmp
+```
+
+This mirrors [`sync-image.py`](../scripts/sync-image.py), which already pulls
+image artifacts with `curl` and verifies a `sha256`. The presigned URLs are
+minted per Task on the controller, passed as Task variables (so they land in the
+`Task.variables_dict` and the rendered command line), and **expire**
+(`S3 Settings.presign_expiry_seconds`, default 3600). They are bearer tokens for
+exactly one object + method for that window; nothing static leaks to the host.
+
+`boto3` is presigned with the default `UNSIGNED-PAYLOAD` signature, so the host's
+`curl` body is not part of the signature — a plain `PUT` with a `Content-Length`
+uploads cleanly. That is also why the host **compresses to a temp file first**:
+an S3 `PUT` needs a known length (AWS rejects `Transfer-Encoding: chunked`), and
+the compressed size is unknown until it is written. Objects are processed **one
+at a time** (compress → `sha256` → upload → delete the temp), so peak temp space
+is the largest single *compressed* object, not the sum.
+
+## Object layout
+
+One snapshot maps to one S3 **key prefix**; each artifact is one object under it:
+
+```
+<S3 Settings.key_prefix>/<snapshot-name>/
+    rootfs.img.zst          # root disk LV  (atlas-snap-<id>),      zstd
+    data.img.zst            # data disk LV  (atlas-datasnap-<id>),  zstd — cold-with-data only
+    vmstate.bin.zst         # Firecracker vmstate,                   zstd — warm only
+    mem.bin.zst             # guest RAM,                             zstd — warm only
+    host-signature.json     # capture-time CPU/kernel/FC,           raw  — warm only
+```
+
+The `.zst` suffix is the restore-side switch: `.zst` objects are piped through
+`zstd -d`; a raw object (the tiny signature JSON) is written verbatim. Disk LVs
+are captured as **raw block images** (`zstd -o` reads the whole block device
+directly — no `dd`, no pipe), so a restore recreates a byte-identical LV
+independent of the pool's thin metadata.
+
+The **manifest** — one JSON row (`s3_objects`) recording each object's `name`,
+`object`, `key`, `sha256` (of the *compressed* bytes), `compressed_bytes`,
+`raw_bytes`, and `disk_gigabytes` (for LVs) — is written on a successful upload.
+Restore reads it, re-presigns a `GET` per object, and hands the host everything
+it needs; the controller never re-derives object names on the restore side.
+
+## Upload
+
+`Virtual Machine Snapshot.upload_to_s3()` (a desk button, whitelisted):
+
+1. Guards: the snapshot is `Available`, its `server` exists, `S3 Settings` is
+   configured. Re-upload is allowed (idempotent — the host `curl -T` overwrites).
+2. Sets `s3_status = "Uploading"` and enqueues `run_upload` **after commit**, then
+   returns — the byte movement is minutes of `dd`/`zstd`/`curl`, far too long for
+   a web request (the same gunicorn-timeout lesson `promote_to_image` learned, and
+   the same background-job shape). A lost/killed job leaves `s3_status =
+   "Uploading"` and no manifest; the operator's retry re-drives it.
+3. The job builds the object plan, presigns a `PUT` per object, and runs the
+   **`upload-snapshot-s3`** Task on the snapshot's server. The host activates each
+   source LV (`-K`, so activation-skipped snapshot LVs come up), `zstd -o`s it to a
+   temp file (reading the block device directly — no `dd`, no pipe), `sha256sum`s
+   it, `curl -T`s it to the presigned URL, deletes the temp, and repeats. It emits
+   the per-object `sha256`/sizes.
+4. On success the controller writes the manifest and sets `s3_status =
+   "Uploaded"`, `s3_bucket`, `s3_key_prefix`, `s3_size_bytes`, `s3_uploaded_at`.
+   On any host failure it sets `s3_status = "Failed"` and re-raises (loud at the
+   boundary — the operator retries the button).
+
+## Restore
+
+`Virtual Machine Snapshot.restore_from_s3()` (a desk button, whitelisted):
+
+1. Guards: `s3_status == "Uploaded"`, the `server` exists. For a **Cold**
+   snapshot whose VM is being rolled back, the VM must be `Stopped` (the same
+   guard `restore_to_vm` → `rebuild` enforces) — checked up front so a running VM
+   fails *before* any download.
+2. Sets `s3_status = "Restoring"` and enqueues `run_restore` after commit; same
+   background-job reasoning as upload.
+3. The job presigns a `GET` per manifest object and runs the
+   **`restore-snapshot-s3`** Task. The host **rehydrates the on-host artifacts**:
+   - Each disk LV is recreated as a fresh thin volume of the recorded
+     `disk_gigabytes` (`ThinPool.create_thin`) at the exact name the row already
+     records (`atlas-snap-<id>`, `atlas-datasnap-<id>`), then `curl | zstd -d |
+     dd` fills it. Idempotent — an existing LV is reactivated and overwritten.
+   - The warm memory pair is rebuilt under `warm_snapshot_directory(<id>)`
+     (`vmstate.bin`, `mem.bin`, `host-signature.json`) with the same ownership
+     `warm-snapshot-vm.py` uses (root-owned, `0644`, so any per-VM uid's jailed
+     Firecracker can map it).
+   - Each downloaded object is verified against its manifest `sha256` **before**
+     decompression (`sha256sum -c`), exactly like `sync-image`.
+4. The snapshot is now fully local again — `rootfs_path`, `data_rootfs_path`, and
+   `memory_directory` already point at what was just rebuilt. The controller sets
+   `s3_status = "Uploaded"` and then:
+   - **Cold** → chains into the existing `restore_to_vm()` (rebuild-in-place), the
+     rollback the operator asked for, and returns that Task.
+   - **Warm** → stops after rehydration and tells the operator to **Clone to new
+     VM** (warm's value is fan-out, not in-place rollback — same asymmetry as
+     `promote_to_image`, which refuses warm).
+
+Rehydration deliberately reuses the *existing* local paths so that after a
+restore, every already-shipped local action (`restore_to_vm`, `clone_to_new_vm`)
+works unchanged — the S3 round trip is invisible to them.
+
+## Data model
+
+- **`S3 Settings`** (a Single, the credential surface the operator fills in —
+  mirrors [`Route53 Settings`](../atlas/atlas/doctype/route53_settings)):
+  `bucket`, `region` (default `us-east-1`), `endpoint_url` (blank for AWS; set for
+  S3-compatible stores — MinIO, DO Spaces), `access_key_id` (Data),
+  `secret_access_key` (Password, read via `secrets.get_secret`), `key_prefix`
+  (default `atlas/snapshots`), `presign_expiry_seconds` (default 3600). A **Test
+  Connection** button (`test_connection`) `head_bucket`s to prove the credentials
+  reach the bucket before any upload — the lightest read that exercises the same
+  permissions, like `Route53Settings.test_connection`.
+- **`Virtual Machine Snapshot`** gains a read-only *S3 Backup* section:
+  `s3_status` (`""` / `Uploading` / `Uploaded` / `Restoring` / `Failed`),
+  `s3_bucket`, `s3_key_prefix`, `s3_size_bytes` (Long Int — the total compressed
+  bytes in S3), `s3_uploaded_at`, and `s3_objects` (the manifest JSON). No new
+  DocType: a backup's lifecycle is tied to its snapshot row (see cleanup).
+
+## Cleanup, integrity, idempotency
+
+- **`on_trash`.** Deleting the snapshot row already `lvremove`s the local LV
+  ([05](./05-virtual-machine-lifecycle.md)); when the row was uploaded it *also*
+  deletes the S3 objects under its prefix, so a deleted snapshot leaves no paid
+  orphan in the bucket. This is **best-effort**: an S3 error is logged, not
+  raised, so a bucket hiccup never wedges a local delete. (The backup's lifecycle
+  follows the row because the scope is same-VM rollback, not an independent
+  archive — an archive that outlives its row is the deferred cross-host model.)
+- **Integrity.** Every object carries a `sha256` of its compressed bytes;
+  restore verifies it before writing — end-to-end, independent of S3's ETag.
+- **Idempotency.** Re-uploading overwrites the objects; re-restoring re-fills the
+  LVs. A failed upload/restore leaves a terminal `Failed`/`Restoring` status and
+  is re-drivable by clicking the button again.
+
+## Dependencies
+
+- **Controller**: `boto3` (already required for TLS, [13](./13-tls.md)).
+- **Host**: `zstd` (compression). `curl`, `lvm2`, `e2fsprogs` are already host
+  deps; `zstd -d` was already relied on by `sync-image` kernel decompression, so
+  this only makes the dependency explicit — `bootstrap-server.py` installs it.
+  See [23-supply-chain.md](./23-supply-chain.md).
+
+## Non-goals (deferred)
+
+- **Cross-host disaster recovery.** Restoring to a brand-new VM on another server
+  needs a backup record that outlives its source VM/server — a standalone
+  `Snapshot Backup` DocType, not fields on the snapshot. Deferred.
+- **Warm in-place resume.** Restoring a warm snapshot straight back onto its own
+  running-state (staging the memory pair with a `READY` marker) is the
+  clone/provision plumbing; warm restore here rehydrates for **Clone to new VM**.
+- **Multipart / incremental.** One object per artifact, whole-image each time — no
+  multipart upload, no changed-block/incremental backup, no server-side dedup.
+- **A GC janitor.** Orphan-object sweeping beyond `on_trash` is out of scope
+  (there is no pool janitor either — [07](./07-filesystem-layout.md)).

--- a/spec/README.md
+++ b/spec/README.md
@@ -159,6 +159,7 @@ keep it the source of truth.
 25. [Private networking (the WireGuard host mesh)](./25-private-networking.md)
 26. [Docker compatibility (`docker run` against microVMs)](./27-docker-compat.md) — *design / proposal*
 28. [Placement — load-aware host selection for the size ladder](./28-placement.md)
+29. [Snapshot backup to S3](./29-snapshot-backup.md) — *push a point-in-time snapshot off-host to S3 and rehydrate it back (same-VM rollback)*
 
 ## First run on a fresh site
 
@@ -269,6 +270,7 @@ operator-facing features add to this list; new tests follow it.
 | Operate a virtual machine      | `Virtual Machine` → **Start / Stop / Restart / Pause / Resume / Terminate** | [05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md) |
 | Manage a VM's disk and size    | `Virtual Machine` → **Snapshot / Rebuild / Resize**; `Virtual Machine Snapshot` → **Restore to VM / Clone to new VM / Delete** | [05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md) |
 | Promote a snapshot to an image | `Virtual Machine Snapshot` → **Promote to image** (or `Image Build` → **Promote to image**): same-server base image new VMs pick via the `image` field | [08-images.md](./08-images.md#two-origins-for-a-base-image-a-url-or-a-snapshot-promote) |
+| Back up a snapshot to S3        | `Virtual Machine Snapshot` → **Upload to S3 / Restore from S3** (off-host durable copy via controller-presigned URLs; restore rehydrates the on-host artifacts and, for a cold snapshot, rolls its own VM back) | [29-snapshot-backup.md](./29-snapshot-backup.md) |
 | Attach a public IPv4 to a VM   | `Reserved IP` → **Attach / Detach** (the inbound-v4 primitive: DNAT in, SNAT out) | [06-networking.md](./06-networking.md#ipv4-ingress-reserved-ip) |
 | Broker a VPN tunnel to a VM    | (user/Central-driven) `request_vpc_access` / `revoke` dials the owner in as a peer on their tenant `/48` via the **customer gateway VM** on the mesh — one shared `wg0`, one client `/128` (supersedes the host-terminated broker) | [25-private-networking.md](./25-private-networking.md#the-customer-gateway--external-dial-in-to-the-mesh), [19-vpn-broker.md](./19-vpn-broker.md) |
 | Issue a TLS cert for a region  | `Root Domain` → **Issue / Renew Certificate**; `TLS Certificate` → **Issue/Renew / Push to Proxies**; `Route53 Settings` / `Lets Encrypt Settings` → **Test Connection** | [13-tls.md](./13-tls.md) |
@@ -467,6 +469,16 @@ reset on the baked `site.local`) on a warm clone, and the cold-boot fallback whe
 the captured host signature is tampered. Heavy (a full bench bake on first run) and so invoked directly, not
 folded into `run_all_smoke`; re-runs reuse the server's Available warm golden.
 It needs the background worker (clone auto-provision).
+
+The **snapshot backup** use case (`snapshot_backup.run_smoke`) covers the S3
+round trip ([29](./29-snapshot-backup.md)): on the shared droplet it provisions a
+Stopped VM, takes a Cold snapshot, uploads it to S3 (`zstd -o` → `sha256sum` →
+`curl -T` a controller-presigned PUT, no host credentials), `lvremove`s the local
+snapshot LV to simulate losing the pool, restores from S3 (recreate the thin LV →
+sha256-verify → `zstd -d --sparse`), rolls the VM back, and asserts it boots off
+the rehydrated disk. It reads an `s3` block from the fixture and skips cleanly
+(MissingConfig) without one; a local MinIO is the zero-cost endpoint. It needs the
+background worker (VM auto-provision).
 
 Every e2e-created droplet is tagged `atlas-e2e`. The harness pre-sweep
 prints droplets older than 30 minutes so the operator can delete them


### PR DESCRIPTION
## What

Adds off-host durability for `Virtual Machine Snapshot`s: upload a point-in-time LVM thin snapshot to **S3** and pull it back to rebuild the same snapshot's on-host artifacts (**same-VM rollback**). A **Cold** snapshot backs up the disk LV(s); a **Warm** snapshot also backs up the frozen memory pair (`vmstate.bin`/`mem.bin`) + host signature so a rehydrated golden can still be **cloned**. Source of truth: `spec/29-snapshot-backup.md`.

## How

- **Hosts stay credential-free.** The controller presigns short-lived S3 `PUT`/`GET` URLs (`boto3`, already a TLS dep); the host moves bytes with `curl` + `zstd` only. `zstd -o` reads/writes the block device directly (no `dd`, no pipe, so the exit code is honestly zstd's), and each object's `sha256` is verified before decompress (mirrors `sync-image`).
- **Background jobs.** `upload_to_s3` / `restore_from_s3` enqueue and return immediately — GBs of `zstd`/`curl` would blow a gunicorn timeout (the `promote_to_image` lesson). Progress via the read-only **S3 Backup** section (`s3_status` + `s3_objects` manifest).
- **New `S3 Settings` single** (bucket / region / endpoint / keys / prefix / expiry) with an idempotent `setup()` contract and a **Test Connection** button (`head_bucket`). Setting `endpoint_url` switches to path-style addressing, so MinIO / DO Spaces work.
- **`on_trash`** best-effort sweeps the snapshot's S3 objects so a deleted backup leaves no paid orphan.
- **Restore rehydrates to the exact LV names the row already records**, so the existing local actions (`restore_to_vm`, `clone_to_new_vm`) keep working unchanged.

## Commits (small, logical)

1. `docs(spec)` — chapter 29 + read-order/use-case entries + ch05/ch23 pointers
2. `feat(scripts)` — the two host verbs + a frappe-free host lib + `zstd` in bootstrap `PACKAGES`
3. `feat(s3)` — the controller `S3Backup` client + the `S3 Settings` single
4. `feat(snapshot)` — `upload_to_s3`/`restore_from_s3` + the S3 Backup fields/buttons + fake_tasks synthesizers
5. `test(e2e)` — the `snapshot_backup.run_smoke` round-trip use case

## Testing

- **Unit / CI:** `test_s3`, the new `TestSnapshotS3Backup` class in `test_virtual_machine_snapshot` (41 in that module), the host-lib `test_snapshot_backup` (part of the 225-test standalone suite), plus `test_scripts_catalog`/`test_scripts_static`, `test_bootstrap`, and `test_fake_tasks` — all green. `compileall scripts/` on py3.14 and pre-commit (ruff / isort / prettier / eslint) clean.
- **Live round trip:** provisioned a VM on a real droplet, took a Cold snapshot, uploaded to a real S3 bucket (~305 MB compressed of a 4 GB disk), `lvremove`d the local snapshot LV to simulate pool loss, restored from S3, rolled the VM back, and confirmed it boots off the rehydrated disk. Teardown swept the bucket (0 orphans).

## Deploy note

Existing Active servers need `sync_scripts` (or a re-bootstrap) to pick up the two new host verbs + `zstd` before upload/restore works on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
