### PR TITLE
fix(warm): Fail the bake loud when the freshen unit isn't live at capture

### DIFF
--- a/atlas/tests/test_warm_snapshot.py
+++ b/atlas/tests/test_warm_snapshot.py
@@ -215,6 +215,13 @@ class TestGuestWarmTooling(unittest.TestCase):
 		self.assertIn("*pong*", source)  # the stack must be serving in the frozen RAM
 		self.assertIn("rm -f /var/lib/systemd/random-seed", source)  # clone-entropy hygiene
 		self.assertIn("/etc/atlas-vm-uuid", source)  # the adopted-identity marker
+		# The freshen unit MUST be verified enabled + running BEFORE the freeze, so a
+		# golden captured without a live freshen fails the bake loud instead of fanning
+		# out into clones that never adopt their identity (unreachable on their own /128).
+		self.assertIn("systemctl is-enabled --quiet atlas-warm-freshen.service", source)
+		self.assertIn("systemctl is-active --quiet atlas-warm-freshen.service", source)
+		# The check must precede the freeze's final sync (the capture point).
+		self.assertLess(source.index("is-active --quiet atlas-warm-freshen"), source.index("\nsync\n"))
 
 	def test_freshen_pure_helpers(self) -> None:
 		freshen = _load_by_path("freshen_under_test", _BENCH_DIR / "atlas-warm-freshen.py")

--- a/bench/warm.sh
+++ b/bench/warm.sh
@@ -67,6 +67,26 @@ systemctl daemon-reload
 systemctl enable atlas-warm-freshen.service
 systemctl restart atlas-warm-freshen.service
 
+# The freshen unit MUST be installed, enabled and ALIVE at the freeze — it is the
+# one thing that lets a clone adopt its own identity, so a golden captured without
+# it fans out into clones that wake on the golden's address and are unreachable on
+# their own (observed live: a golden whose warm.sh tree was wiped from tmpfs before
+# this ran captured no freshen unit, and every clone was network-dead). The install
+# ran under `set -e`, but assert the end state too so this bake fails LOUD rather
+# than silently freezing a broken golden — the same fail-loud contract as the pre-
+# warm `pong`/`sid` checks below. is-enabled proves the multi-user.target want (so
+# a plain reboot of the clone re-arms it); is-active proves the loop is mid-poll in
+# the RAM the capture is about to freeze.
+if ! systemctl is-enabled --quiet atlas-warm-freshen.service; then
+	echo "warm bake failed: atlas-warm-freshen.service is not enabled after install" >&2
+	exit 1
+fi
+if ! systemctl is-active --quiet atlas-warm-freshen.service; then
+	echo "warm bake failed: atlas-warm-freshen.service is not running after restart:" >&2
+	systemctl status --no-pager atlas-warm-freshen.service >&2 || true
+	exit 1
+fi
+
 # --- 2. Pre-warm. Real requests through the full nginx → gunicorn → MariaDB path
 # against the baked site.local (its vhost is what's frozen; the FQDN rename
 # happens per clone at deploy). The Administrator login + /app GET walks the


### PR DESCRIPTION
## Root cause

A warm golden's entire clone-reachability contract rests on the in-guest identity **freshen unit** (`atlas-warm-freshen`) being *alive, mid-poll*, in the RAM the capture freezes. On resume it reads the clone's new identity from MMDS (169.254.169.254) and reconfigures the guest onto its own IPv6 / MAC / machine-id / SSH host keys. A golden captured **without** a live freshen unit fans out into clones that wake on the golden's frozen identity and are unreachable on their own `/128` — the host gets `No route to host` because NDP for the clone's address never resolves (the guest never brought that address up).

`warm.sh` installed + enabled + restarted the unit but **never verified the end state**. So a silent install failure (e.g. the recipe tree wiped from `/tmp` tmpfs by the pre-capture reboot, before 943d263 re-staged it) froze a broken golden that still reported the bake `Available`. Every clone from it was then network-dead, while `provision-vm` and `vm-tunnel` reported `Success`.

## Fix

Assert `systemctl is-enabled` + `is-active` for the freshen unit right after arming it and **before the freeze** — the same fail-loud contract as the existing pre-warm `pong` / `sid` checks. A nonzero `warm.sh` exit already fails the bake (via `_run_warm_entrypoint`'s `frappe.throw`), so this turns a silently-broken golden into a **failed bake** instead of a fleet of dead clones. Minimal, guest-side, at the exact invariant point warm.sh's own header describes ("must be ALIVE mid-loop at the capture instant").

## Verification

- `bench --site atlas.localhost run-tests --module atlas.tests.test_warm_snapshot` — 25 tests green (13 + 12), including the extended `test_warm_sh_parses_and_arms_the_capture` that pins the new guard before the final `sync`.
- No regressions in the affected area: `test_image_build` (38), `test_bench_routing_guest` (38), `test_virtual_machine_snapshot` (29), `test_image_builder` (44) all green.
- `bash -n bench/warm.sh` clean.
- Root cause confirmed read-only against the live dead VM; no billed cloud resources were created, and diagnostic host artifacts (an LVM inspect snapshot, temporary netns route/neigh) were cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)