### PR TITLE
fix(placement): repair resize tests for the host memory reserve + satisfy pinned ruff

### DIFF
--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -242,9 +242,7 @@ def _share_units(cpu_axis: dict, memory_axis: dict, disk_axis: dict) -> dict | N
 		"memory": (memory_axis, SHARE_UNIT["memory_megabytes"]),
 		"disk": (disk_axis, SHARE_UNIT["disk_gigabytes"]),
 	}
-	measured = {
-		key: (axis, unit) for key, (axis, unit) in priced.items() if axis["effective"] is not None
-	}
+	measured = {key: (axis, unit) for key, (axis, unit) in priced.items() if axis["effective"] is not None}
 	if not measured:
 		return None
 	total = min(int(axis["effective"] // unit) for axis, unit in measured.values())

--- a/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
@@ -346,9 +346,7 @@ class TestVirtualMachine(IntegrationTestCase):
 		# vm.status_changed); single out the auto_provision enqueue and assert it
 		# targets this VM, rather than assuming it is the only enqueue.
 		auto_provision_calls = [
-			call
-			for call in enqueue.call_args_list
-			if call.args and call.args[0].endswith(".auto_provision")
+			call for call in enqueue.call_args_list if call.args and call.args[0].endswith(".auto_provision")
 		]
 		self.assertEqual(len(auto_provision_calls), 1)
 		self.assertEqual(auto_provision_calls[0].kwargs["virtual_machine_name"], vm.name)

--- a/atlas/atlas/doctype/virtual_machine/test_virtual_machine_lifecycle.py
+++ b/atlas/atlas/doctype/virtual_machine/test_virtual_machine_lifecycle.py
@@ -269,7 +269,13 @@ class TestVirtualMachineLifecycle(IntegrationTestCase):
 
 		vm = _vm_with_status("Stopped")
 		task = fake_task(name="task-resize-1")
-		with patch.object(module, "run_task", return_value=task) as mocked:
+		# Bypass the capacity gate: this test pins the resize MECHANICS (fields persist,
+		# resize-vm runs) on the small shared test host; the gate itself is covered by
+		# test_provision_resize_capacity.
+		with (
+			patch.object(module, "run_task", return_value=task) as mocked,
+			patch.object(module, "check_resize_capacity"),
+		):
 			result = vm.resize(vcpus=4, memory_megabytes=4096, disk_gigabytes=20)
 		self.assertEqual(result, "task-resize-1")
 		self.assertEqual(mocked.call_args.kwargs["script"], "resize-vm")
@@ -319,7 +325,12 @@ class TestVirtualMachineLifecycle(IntegrationTestCase):
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
 
 		vm = _vm_with_status("Stopped")  # vcpus=1, cpu_max_cores=1
-		with patch.object(module, "run_task", return_value=fake_task()):
+		# Capacity gate covered separately (test_provision_resize_capacity); this pins
+		# whole-core cap tracking when vcpus grow without an explicit cap.
+		with (
+			patch.object(module, "run_task", return_value=fake_task()),
+			patch.object(module, "check_resize_capacity"),
+		):
 			vm.resize(vcpus=4)
 		vm.reload()
 		self.assertEqual(vm.vcpus, 4)

--- a/atlas/atlas/packing.py
+++ b/atlas/atlas/packing.py
@@ -48,9 +48,7 @@ def _resolve(strategy: str, needs: dict) -> str:
 	return strategy
 
 
-def _evaluate(
-	budgets: dict, used: dict, needs: dict, reserve: float
-) -> tuple[bool, int, float, float]:
+def _evaluate(budgets: dict, used: dict, needs: dict, reserve: float) -> tuple[bool, int, float, float]:
 	"""Feasibility + shape metrics for placing `needs` on one host.
 
 	`budgets`/`used`/`needs` are dicts over `AXES` (a budget of `None` = that axis is

--- a/atlas/atlas/packing_sim.py
+++ b/atlas/atlas/packing_sim.py
@@ -117,7 +117,7 @@ class _Host:
 
 
 class _VM:
-	__slots__ = ("plan", "demand", "host", "alive")
+	__slots__ = ("alive", "demand", "host", "plan")
 
 	def __init__(self, plan: str, demand: dict, host: "_Host") -> None:
 		self.plan = plan
@@ -193,9 +193,7 @@ class _Stats:
 				if self.attempts_by_plan[_LARGEST_PLAN]
 				else 0.0
 			),
-			"in_place_upgrade_rate": (
-				self.in_place_upgrades / upgrade_attempts if upgrade_attempts else 1.0
-			),
+			"in_place_upgrade_rate": (self.in_place_upgrades / upgrade_attempts if upgrade_attempts else 1.0),
 			"forced_migrations": self.forced_migrations,
 			"blocked_resizes": self.blocked_resizes,
 			"mean_utilization": {axis: self._util[axis] / duration for axis in packing.AXES},
@@ -368,9 +366,7 @@ def _format_aggregate(aggregate: dict, seeds: int) -> str:
 			)
 		)
 	widths = [max(len(row[col]) for row in rows) for col in range(len(rows[0]))]
-	table = "\n".join(
-		"  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows
-	)
+	table = "\n".join("  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows)
 	return f"averaged over {seeds} seeds\n{table}"
 
 
@@ -392,9 +388,7 @@ def _format_table(results: dict) -> str:
 			)
 		)
 	widths = [max(len(row[col]) for row in rows) for col in range(len(rows[0]))]
-	return "\n".join(
-		"  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows
-	)
+	return "\n".join("  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)) for row in rows)
 
 
 def _parse_shape(text: str) -> tuple:
@@ -402,22 +396,24 @@ def _parse_shape(text: str) -> tuple:
 	return (cpu, memory, disk)
 
 
-def _build_config(args: argparse.Namespace) -> SimConfig:
-	shapes = tuple(_parse_shape(shape) for shape in args.host_shape) if args.host_shape else (DEFAULT_HOST_SHAPE,)
+def _build_config(ns: argparse.Namespace) -> SimConfig:
+	shapes = tuple(_parse_shape(shape) for shape in ns.host_shape) if ns.host_shape else (DEFAULT_HOST_SHAPE,)
 	return SimConfig(
-		seed=args.seed,
-		duration=args.duration,
-		arrival_rate=args.arrival_rate,
-		host_count=args.host_count,
+		seed=ns.seed,
+		duration=ns.duration,
+		arrival_rate=ns.arrival_rate,
+		host_count=ns.host_count,
 		host_shapes=shapes,
-		mean_lifetime=args.mean_lifetime,
-		upgrade_hazard=args.upgrade_hazard,
-		reserve=args.reserve / 100.0,
+		mean_lifetime=ns.mean_lifetime,
+		upgrade_hazard=ns.upgrade_hazard,
+		reserve=ns.reserve / 100.0,
 	)
 
 
 def main(argv=None) -> None:
-	parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+	parser = argparse.ArgumentParser(
+		description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+	)
 	parser.add_argument("--seed", type=int, default=0)
 	parser.add_argument("--seeds", type=int, default=1, help="average over this many seeds (mean ± sd)")
 	parser.add_argument("--duration", type=float, default=10000.0, help="sim-time units")
@@ -431,7 +427,9 @@ def main(argv=None) -> None:
 		help="host effective budget; repeat for a heterogeneous fleet (cycled)",
 	)
 	parser.add_argument("--mean-lifetime", type=float, default=500.0)
-	parser.add_argument("--upgrade-hazard", type=float, default=0.0, help="resize-up rate per VM per unit time")
+	parser.add_argument(
+		"--upgrade-hazard", type=float, default=0.0, help="resize-up rate per VM per unit time"
+	)
 	parser.add_argument("--reserve", type=float, default=0.0, help="arrival headroom percent")
 	parser.add_argument(
 		"--strategy",
@@ -444,7 +442,9 @@ def main(argv=None) -> None:
 	if args.seeds > 1:
 		print(_format_aggregate(compare_seeds(config, args.seeds, strategies), args.seeds))
 	elif args.strategy:
-		print(_format_table({args.strategy: run(SimConfig(**{**config.__dict__, "strategy": args.strategy}))}))
+		print(
+			_format_table({args.strategy: run(SimConfig(**{**config.__dict__, "strategy": args.strategy}))})
+		)
 	else:
 		print(_format_table(compare(config)))
 

--- a/atlas/tests/test_packing.py
+++ b/atlas/tests/test_packing.py
@@ -35,9 +35,7 @@ class TestStrategyScoring(unittest.TestCase):
 	def test_infeasible_returns_none(self) -> None:
 		# A 512 MB VM can't fit where only 100 MB is free.
 		budgets = {"cpu": 8.0, "memory": 512.0, "disk": 320.0}
-		self.assertIsNone(
-			packing.rank_key(SPREAD, budgets, _used(memory=400.0), _SHARED_1X, 0.0, 0)
-		)
+		self.assertIsNone(packing.rank_key(SPREAD, budgets, _used(memory=400.0), _SHARED_1X, 0.0, 0))
 
 	def test_unmeasured_axis_is_unlimited_and_counted(self) -> None:
 		# A None budget fits anything, but bumps the unmeasured count (first rank
@@ -93,9 +91,7 @@ class TestStrategyScoring(unittest.TestCase):
 		budgets = {"cpu": 8.0, "memory": 1024.0, "disk": 320.0}
 		need = {"cpu": 0.0625, "memory": 768.0, "disk": 10.0}
 		self.assertIsNotNone(packing.rank_key(SPREAD, budgets, _EMPTY, need, 0.0, 0), "raw budget fits")
-		self.assertIsNone(
-			packing.rank_key(SPREAD, budgets, _EMPTY, need, 0.5, 0), "a 50% reserve blocks it"
-		)
+		self.assertIsNone(packing.rank_key(SPREAD, budgets, _EMPTY, need, 0.5, 0), "a 50% reserve blocks it")
 
 
 class TestMetrics(unittest.TestCase):

--- a/atlas/tests/test_placement.py
+++ b/atlas/tests/test_placement.py
@@ -372,9 +372,7 @@ class TestPlacement(IntegrationTestCase):
 		"""A VM pinned to `server` at a given size, in a migratable state. Explicit
 		server + image means apply_user_defaults is a no-op (no placement recursion)."""
 		image = make_image("atlas-placement-image")
-		vm = make_virtual_machine(
-			server, image, memory_megabytes=memory, disk_gigabytes=disk, **overrides
-		)
+		vm = make_virtual_machine(server, image, memory_megabytes=memory, disk_gigabytes=disk, **overrides)
 		vm.db_set("status", status)
 		return vm
 

--- a/atlas/tests/test_provision_resize_capacity.py
+++ b/atlas/tests/test_provision_resize_capacity.py
@@ -23,6 +23,10 @@ class TestProvisionResizeCapacity(IntegrationTestCase):
 	def setUp(self) -> None:
 		_clean_virtual_machines()
 		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		# Isolate the resize add-back arithmetic from the host memory reserve so the
+		# ceilings below are the host's raw totals (the reserve has its own coverage in
+		# test_api_server_capacity) — parallels the overprovision_factor neutralisation.
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
 		self.provider = make_provider("resize-capacity-provider")
 		for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
 			frappe.db.set_value("Server", name, "status", "Draining")
@@ -46,8 +50,12 @@ class TestProvisionResizeCapacity(IntegrationTestCase):
 		return server
 
 	def test_contract_shape(self) -> None:
-		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
-		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		server = self._active_server(
+			vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160
+		)
+		vm = make_virtual_machine(
+			server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40
+		)
 		result = provision.resize_capacity(vm.name)
 		self.assertEqual(set(result), {"available", "unmeasured", "largest_vm"})
 		self.assertEqual(set(result["largest_vm"]), {"vcpus", "memory_megabytes", "disk_gigabytes"})
@@ -55,8 +63,12 @@ class TestProvisionResizeCapacity(IntegrationTestCase):
 	def test_lone_vm_can_grow_to_the_whole_host(self) -> None:
 		# The only VM on the host: its ceiling is the host's full totals (its own footprint
 		# freed and re-reserved), so it can grow to fill the box.
-		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
-		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		server = self._active_server(
+			vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160
+		)
+		vm = make_virtual_machine(
+			server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40
+		)
 		result = provision.resize_capacity(vm.name)
 		self.assertTrue(result["available"])
 		self.assertFalse(result["unmeasured"])
@@ -66,9 +78,15 @@ class TestProvisionResizeCapacity(IntegrationTestCase):
 		# Host 4 / 8192 / 160; VM-A (resizing) 1 / 2048 / 40, neighbour VM-B 1 / 1024 / 20.
 		# VM-A's ceiling adds back only its OWN footprint: cpu 4-2+1=3, mem 8192-3072+2048=7168,
 		# disk 160-60+40=140 — the neighbour's reservation still stands.
-		server = self._active_server(vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160)
-		vm_a = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
-		make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=1024, disk_gigabytes=20)
+		server = self._active_server(
+			vcpus_total=4, memory_megabytes_total=8192, pool_disk_gigabytes_total=160
+		)
+		vm_a = make_virtual_machine(
+			server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40
+		)
+		make_virtual_machine(
+			server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=1024, disk_gigabytes=20
+		)
 		result = provision.resize_capacity(vm_a.name)
 		self.assertEqual(result["largest_vm"], {"vcpus": 3, "memory_megabytes": 7168, "disk_gigabytes": 140})
 
@@ -76,7 +94,9 @@ class TestProvisionResizeCapacity(IntegrationTestCase):
 		# No agent totals and an uncatalogued size → every axis uncatalogued → unlimited.
 		server = self._active_server()
 		server.db_set("size", "Scaleway/EM-B130E-NVME")  # not in the CPU slug dict
-		vm = make_virtual_machine(server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40)
+		vm = make_virtual_machine(
+			server, self.image, vcpus=1, cpu_max_cores=1, memory_megabytes=2048, disk_gigabytes=40
+		)
 		result = provision.resize_capacity(vm.name)
 		self.assertTrue(result["available"])
 		self.assertTrue(result["unmeasured"])

--- a/llm/eval/arbitrary_sim.py
+++ b/llm/eval/arbitrary_sim.py
@@ -76,7 +76,7 @@ class Host:
 
 
 class VM:
-	__slots__ = ("arch", "demand", "host", "alive")
+	__slots__ = ("alive", "arch", "demand", "host")
 
 	def __init__(self, arch, demand, host):
 		self.arch = arch
@@ -189,7 +189,7 @@ def simulate(cfg, workload):
 			vm = payload
 			if not vm.alive:
 				continue
-			base, grow = ARCHETYPES[vm.arch]
+			_base, grow = ARCHETYPES[vm.arch]
 			new = dict(vm.demand)
 			new[grow] = vm.demand[grow] * 1.6
 			delta = {a: new[a] - vm.demand[a] for a in AXES}

--- a/llm/eval/realistic_sim.py
+++ b/llm/eval/realistic_sim.py
@@ -82,7 +82,7 @@ class Host:
 
 
 class VM:
-	__slots__ = ("kind", "demand", "host", "alive", "ladder_i")
+	__slots__ = ("alive", "demand", "host", "kind", "ladder_i")
 
 	def __init__(self, kind, demand, host, ladder_i):
 		self.kind = kind

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ ignore = [
     "UP040", # Use type aliases instead of type annotations
 ]
 typing-modules = ["frappe.types.DF"]
+# The placement/capacity docs use typographic − (minus) and × (times) in math
+# expressions (e.g. "total − reserve", "2 GB × cores"); whitelist just those two
+# confusables so RUF001/002/003 don't flag the intentional notation.
+allowed-confusables = ["−", "×"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Why

`main`'s CI is red on **both** the **Server** test job and the **Frappe Linter** — the load-aware-placement change (#30) merged with failing checks. This follow-up greens it up. (Independent of the snapshot-backup work in #117.)

## What was failing

**Server** (`FAILED (failures=2, errors=2, skipped=1)`) — placement added a **Host Memory Reserve** (`Atlas Settings.host_memory_reserve_megabytes`, default **1024 MB**, subtracted from each host's memory budget) and a **resize capacity gate**, but the pre-existing resize tests still assumed the raw host totals:
- `test_provision_resize_capacity.{test_lone_vm_can_grow_to_the_whole_host, test_shares_host_with_a_neighbour}` — expected 8192 / 7168, got 7168 / 6144 (the 1024 reserve).
- `test_virtual_machine_lifecycle.{test_resize_from_stopped_persists_and_runs_script, test_resize_keeps_whole_core_vm_whole_core}` — `NoResizeCapacityError` resizing a VM to 4 vCPU on the 2-vCPU shared test host.

**Linter** — the placement files merged without the pinned pre-commit ruff (0.14.10): `ruff-format` rewrote several files and `ruff-check` flagged unsorted `__slots__`, an unused unpacked variable, and ambiguous `−` / `×` unicode in the math docstrings/comments.

## The fix

- **Reserve:** neutralise it in `test_provision_resize_capacity`'s `setUp` — parallel to the existing `overprovision_factor` neutralisation, since the reserve has its own coverage in `test_api_server_capacity`.
- **Capacity gate:** bypass it in the two `virtual_machine_lifecycle` resize-**mechanics** tests (they assert that the resize fields persist and `resize-vm` runs, not capacity — they already mock `run_task`).
- **Lint:** apply the formatter, sort the `__slots__`, prefix the unused var, and whitelist the two intentional confusables (`−` minus, `×` times) via `allowed-confusables` so the notation survives without ASCII-flattening it.

## Verification (local, pinned versions)

- The 4 previously-failing tests pass; the reserve's own suite (`test_api_server_capacity`, 27) and its neighbours (`test_packing` 20, `test_placement` 22) stay green.
- `pre-commit run --all-files` fully green; `compileall scripts/` on py3.14 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
