### PR TITLE
fix(export): Guard _fail() against deleted row crash (TOCTOU)

### DIFF
--- a/atlas/atlas/export.py
+++ b/atlas/atlas/export.py
@@ -475,7 +475,13 @@ def _detect_lost_task(doc, script: str, timeout_seconds: int) -> None:
 def _fail(name: str, message: str) -> None:
 	"""Mark an export Failed, recording the phase it failed at so retry() resumes there.
 	Best-effort and self-committing (it runs after a rollback)."""
-	doc = frappe.get_doc("Virtual Machine Image Export", name)
+	try:
+		doc = frappe.get_doc("Virtual Machine Image Export", name)
+	except frappe.DoesNotExistError:
+		# The row was deleted between the time we fetched the list of non-terminal
+		# exports and now — nothing to fail. This is not an error (the operator
+		# intentionally removed it), so just return.
+		return
 	doc.db_set({"status": "Failed", "error_message": message[-2000:], "error_at_status": doc.status})
 	# nosemgrep: frappe-manual-commit -- persist the failure so the next tick sees it
 	frappe.db.commit()

--- a/atlas/atlas/migration.py
+++ b/atlas/atlas/migration.py
@@ -1209,7 +1209,13 @@ def _detect_lost_task(doc, script: str, timeout_seconds: int) -> None:
 def _fail(name: str, message: str) -> None:
 	"""Mark a migration Failed, recording the phase it failed at so retry() resumes
 	there. Best-effort and self-committing (it runs after a rollback)."""
-	doc = frappe.get_doc("Virtual Machine Migration", name)
+	try:
+		doc = frappe.get_doc("Virtual Machine Migration", name)
+	except frappe.DoesNotExistError:
+		# The row was deleted between the time we fetched the list of non-terminal
+		# migrations and now — nothing to fail. This is not an error (the operator
+		# intentionally removed it), so just return.
+		return
 	doc.db_set({"status": "Failed", "error_message": message[-2000:], "error_at_status": doc.status})
 	# nosemgrep: frappe-manual-commit -- persist the failure so the next tick sees it
 	frappe.db.commit()


### PR DESCRIPTION
Same bug as BUG-1 in `migration.py` (fixed in 0282b10) but in `export.py`.

`_fail()` at `atlas/atlas/export.py:475` calls `frappe.get_doc("Virtual Machine Image Export", name)` without a `DoesNotExistError` guard. If the row is deleted between the reconcile loop fetching names and processing them, the unhandled exception aborts the entire `for name in names` loop, skipping all other in-flight exports.

**Fix:** Wrap `frappe.get_doc()` in `try/except frappe.DoesNotExistError` and return early, matching the pattern already applied to `migration.py:1209`.

**Reference:** See `llm/bugs-and-flows.md` BUG-1 for the original bug and its fix.
