### PR TITLE
fix: Make public IP V6 optional for private VM provisioning

### DIFF
--- a/scripts/lib/atlas/test_entry_ergonomics.py
+++ b/scripts/lib/atlas/test_entry_ergonomics.py
@@ -155,6 +155,25 @@ class TestProvisionResourceArgDefault(unittest.TestCase):
 		self.assertEqual(raised.exception.code, 2)
 		self.assertIn("--cgroup-arg", err.getvalue())
 
+	def test_dark_vm_omits_public_ipv6_and_v4_link(self):
+		# A dark VM (public_networking=0, spec §6) has no public /128 and no proxy-NDP;
+		# an air-gapped VM (egress_nat44=0) has no v4 egress link. Both groups of flags
+		# are optional; the defaults resolve to "" and the controller drops them via
+		# _variables_to_flags.
+		no_v6_v4 = [flag for flag in _PROVISION_REQUIRED if flag not in (
+			"--virtual-machine-ipv6", "2a03::2",
+			"--ipv4-host-cidr", "100.64.0.1/30",
+			"--ipv4-guest-cidr", "100.64.0.2/30",
+			"--ipv4-gateway", "100.64.0.1",
+		)]
+		inputs = self.cls.from_args(no_v6_v4)
+		self.assertEqual(inputs.virtual_machine_ipv6, "")
+		self.assertEqual(inputs.ipv4_host_cidr, "")
+		self.assertEqual(inputs.ipv4_guest_cidr, "")
+		self.assertEqual(inputs.ipv4_gateway, "")
+		# The required fields are still present.
+		self.assertEqual(inputs.virtual_machine_name, "u")
+
 	def test_help_names_each_derived_flag_source_function(self):
 		help_text = self.cls.build_parser().format_help()
 		# Every derived flag names the atlas.networking function that computes it —

--- a/scripts/provision-vm.py
+++ b/scripts/provision-vm.py
@@ -80,18 +80,6 @@ class ProvisionInputs(TaskInputs):
 	# that computes each, so an operator can reproduce them by hand. (See spec/06.)
 	mac_address: str = field(metadata={"help": "derived: atlas.networking.derive_mac(uuid)"})
 	tap_device: str = field(metadata={"help": "derived: atlas.networking.derive_tap(uuid)"})
-	virtual_machine_ipv6: str = field(
-		metadata={"help": "controller-allocated: atlas.networking.allocate_ipv6(server) (DB row-lock scan)"}
-	)
-	ipv4_host_cidr: str = field(
-		metadata={"help": "derived: atlas.networking.derive_ipv4_link(ipv6)[0] (host side of the NAT44 /30)"}
-	)
-	ipv4_guest_cidr: str = field(
-		metadata={"help": "derived: atlas.networking.derive_ipv4_link(ipv6)[1] (guest side of the /30)"}
-	)
-	ipv4_gateway: str = field(
-		metadata={"help": "derived: host side of ipv4_host_cidr without the mask (the guest's v4 gateway)"}
-	)
 	atlas_fc_uid: int = field(metadata={"help": "derived: atlas.networking.derive_uid(uuid) (gid == uid)"})
 	atlas_netns: str = field(metadata={"help": "derived: atlas.networking.derive_netns(uuid)"})
 	host_veth: str = field(
@@ -128,6 +116,39 @@ class ProvisionInputs(TaskInputs):
 		metadata={
 			"help": "resource-limit VALUES (launcher emits `--resource-limit <value>`); "
 			f"omit to default to {DEFAULT_RESOURCE_ARGS}"
+		},
+	)
+	# Optional: the VM's public /128 (empty for a dark VM, public_networking=0). 
+	# The controller drops empty values via _variables_to_flags, so the flag
+	# never reaches the wire — the provision script's argparse default picks "".
+	virtual_machine_ipv6: str = field(
+		default="",
+		metadata={
+			"help": "controller-allocated: atlas.networking.allocate_ipv6(server) "
+			"(DB row-lock scan). Empty for a dark VM (public_networking=0, spec §6)."
+		},
+	)
+	# Optional: the v4 egress link fields (empty for an air-gapped VM, egress_nat44=0).
+	# Same dropping rule as virtual_machine_ipv6.
+	ipv4_host_cidr: str = field(
+		default="",
+		metadata={
+			"help": "derived: atlas.networking.derive_ipv4_link(ipv6)[0] "
+			"(host side of the NAT44 /30). Empty for air-gapped (egress_nat44=0)."
+		},
+	)
+	ipv4_guest_cidr: str = field(
+		default="",
+		metadata={
+			"help": "derived: atlas.networking.derive_ipv4_link(ipv6)[1] "
+			"(guest side of the /30). Empty for air-gapped (egress_nat44=0)."
+		},
+	)
+	ipv4_gateway: str = field(
+		default="",
+		metadata={
+			"help": "derived: host side of ipv4_host_cidr without the mask "
+			"(the guest's v4 gateway). Empty for air-gapped (egress_nat44=0)."
 		},
 	)
 	# One optional source override: a snapshot rootfs path (clone path). Empty
@@ -608,18 +629,26 @@ def _firecracker_config(inputs: "ProvisionInputs") -> str:
 
 
 def _network_env(inputs: "ProvisionInputs") -> str:
-	"""The network.env sidecar vm-network-up.sh reads, byte-shape identical to
-	the shell heredoc."""
+	"""The network.env sidecar vm-network-up reads, byte-shape identical to
+	the shell heredoc.
+
+	A dark VM (public_networking=0, spec §6) has no public /128 — the
+	VIRTUAL_MACHINE_IPV6 line is omitted so vm-network-up.py skips the public
+	routing + NDP + forward block. An air-gapped VM (egress_nat44=0) similarly
+	omits the IPV4_* trio so vm-network-up.py skips the NAT44 block. Mirror of
+	vm-network-down.py's `.get()` + `if value:` pattern."""
 	env = (
 		f"TAP_DEVICE={inputs.tap_device}\n"
-		f"VIRTUAL_MACHINE_IPV6={inputs.virtual_machine_ipv6}\n"
 		f"ATLAS_NETNS={inputs.atlas_netns}\n"
 		f"HOST_VETH={inputs.host_veth}\n"
 		f"NAMESPACE_VETH={inputs.namespace_veth}\n"
-		f"IPV4_HOST_CIDR={inputs.ipv4_host_cidr}\n"
-		f"IPV4_GUEST_CIDR={inputs.ipv4_guest_cidr}\n"
 		f"ATLAS_FC_UID={inputs.atlas_fc_uid}\n"
 	)
+	if inputs.virtual_machine_ipv6:
+		env += f"VIRTUAL_MACHINE_IPV6={inputs.virtual_machine_ipv6}\n"
+	if inputs.ipv4_host_cidr:
+		env += f"IPV4_HOST_CIDR={inputs.ipv4_host_cidr}\n"
+		env += f"IPV4_GUEST_CIDR={inputs.ipv4_guest_cidr}\n"
 	# Only written when the VM has a Reserved IP attached — vm-network-up reads it
 	# with .get() and skips the 1:1-NAT block when absent, so an ordinary VM's env
 	# is unchanged.

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -47,12 +47,12 @@ def main() -> None:
 
 	env = read_network_env(VirtualMachinePaths(uuid).network_env)
 	tap_device = env.require("TAP_DEVICE")
-	virtual_machine_ipv6 = env.require("VIRTUAL_MACHINE_IPV6")
+	virtual_machine_ipv6 = env.get("VIRTUAL_MACHINE_IPV6")
 	atlas_netns = env.require("ATLAS_NETNS")
 	host_veth = env.require("HOST_VETH")
 	namespace_veth = env.require("NAMESPACE_VETH")
-	ipv4_host_cidr = env.require("IPV4_HOST_CIDR")
-	ipv4_guest_cidr = env.require("IPV4_GUEST_CIDR")
+	ipv4_host_cidr = env.get("IPV4_HOST_CIDR")
+	ipv4_guest_cidr = env.get("IPV4_GUEST_CIDR")
 	# Optional: a Reserved IP attached to this VM. Present only for the VMs that
 	# opted into inbound v4 (today, the reverse proxy). Absent for every ordinary
 	# VM, so the 1:1-NAT block below is skipped and nothing changes.
@@ -68,8 +68,9 @@ def main() -> None:
 	# The guest's private v4 as a bare host address. The host routes a /32 to it
 	# (the v4 analog of the VM's /128 v6 route) — a route prefix must be a network
 	# address, so we cannot reuse IPV4_HOST_CIDR (a /30 carrying a host address;
-	# `ip route` rejects "100.64.x.9/30" as an invalid prefix).
-	ipv4_guest_address = ipv4_guest_cidr.split("/", 1)[0]
+	# `ip route` rejects "100.64.x.9/30" as an invalid prefix). Only derivable when
+	# the VM has a NAT44 link (absent for an air-gapped VM, egress_nat44=0).
+	ipv4_guest_address = ipv4_guest_cidr.split("/", 1)[0] if ipv4_guest_cidr else ""
 
 	uplink = default_route_device("-6")
 	# The default-route dev for v4 egress (may differ from the v6 uplink on a
@@ -149,18 +150,20 @@ def main() -> None:
 		atlas_netns,
 		tap_device,
 	)
-	run(
-		"sudo ip netns exec {} ip -6 route replace {} dev {}",
-		atlas_netns,
-		f"{virtual_machine_ipv6}/128",
-		tap_device,
-	)
-	run(
-		"sudo ip netns exec {} ip -4 addr replace {} dev {}",
-		atlas_netns,
-		ipv4_host_cidr,
-		tap_device,
-	)
+	if virtual_machine_ipv6:
+		run(
+			"sudo ip netns exec {} ip -6 route replace {} dev {}",
+			atlas_netns,
+			f"{virtual_machine_ipv6}/128",
+			tap_device,
+		)
+	if ipv4_host_cidr:
+		run(
+			"sudo ip netns exec {} ip -4 addr replace {} dev {}",
+			atlas_netns,
+			ipv4_host_cidr,
+			tap_device,
+		)
 
 	# 5. Bring up both ends of the veth and address it for transit. IPv6 uses
 	#    fe80::2 (host) / fe80::3 (ns); IPv4 uses a link-local /30 (169.254.0.0/30)
@@ -196,33 +199,39 @@ def main() -> None:
 	#    namespace via the veth, and answer NDP for the VM on the uplink so the
 	#    upstream router delivers its v6 packets here. The v4 return path relies on
 	#    the masquerade conntrack, but the explicit /30 route lets the host reach the
-	#    guest's private v4 directly too.
-	run(
-		"sudo ip -6 route replace {} via fe80::3 dev {}",
-		f"{virtual_machine_ipv6}/128",
-		host_veth,
-	)
-	run("sudo ip -6 neigh replace proxy {} dev {}", virtual_machine_ipv6, uplink)
-	run(
-		"sudo ip -4 route replace {} via 169.254.0.2 dev {}",
-		f"{ipv4_guest_address}/32",
-		host_veth,
-	)
+	#    guest's private v4 directly too. A dark VM (public_networking=0) has no
+	#    public /128 and no proxy-NDP; an air-gapped VM (egress_nat44=0) has no v4
+	#    link — both skip their respective blocks.
+	if virtual_machine_ipv6:
+		run(
+			"sudo ip -6 route replace {} via fe80::3 dev {}",
+			f"{virtual_machine_ipv6}/128",
+			host_veth,
+		)
+		run("sudo ip -6 neigh replace proxy {} dev {}", virtual_machine_ipv6, uplink)
+	if ipv4_guest_address:
+		run(
+			"sudo ip -4 route replace {} via 169.254.0.2 dev {}",
+			f"{ipv4_guest_address}/32",
+			host_veth,
+		)
 
 	# 7. Forwarding rules, matching the host-side veth (the tap is no longer in the
 	#    host namespace to match on). The v4 masquerade rule (host postrouting,
 	#    100.64.0.0/16 -> uplink) is created in the nft scaffold above and covers the
-	#    guest's v4 egress once it reaches the host via the veth.
-	run(
-		"sudo nft add rule inet atlas forward ip6 daddr {} oifname {} accept",
-		virtual_machine_ipv6,
-		host_veth,
-	)
-	run(
-		"sudo nft add rule inet atlas forward ip6 saddr {} iifname {} accept",
-		virtual_machine_ipv6,
-		host_veth,
-	)
+	#    guest's v4 egress once it reaches the host via the veth. A dark VM has no
+	#    public v6 forward rules — its only reachability is via the private plane.
+	if virtual_machine_ipv6:
+		run(
+			"sudo nft add rule inet atlas forward ip6 daddr {} oifname {} accept",
+			virtual_machine_ipv6,
+			host_veth,
+		)
+		run(
+			"sudo nft add rule inet atlas forward ip6 saddr {} iifname {} accept",
+			virtual_machine_ipv6,
+			host_veth,
+		)
 
 	# 7a. Private plane (the WireGuard host mesh, design §5). Present only once the
 	#     controller writes PRIVATE_ADDRESS + TENANT_PREFIX into network.env; absent


### PR DESCRIPTION
- Public IPv6 was required before in the provisioning script even if we want to provision private VM.
- FIxed it by making it optional.