### PR TITLE
Sleepy VMs: idle VMs sleep to free RAM and wake on the first inbound TCP connection

### DIFF
--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -123,9 +123,7 @@ def run_probe(
 		stdout, stderr, exit_code = _run_remote_script(connection, script, variables, timeout_seconds)
 		if exit_code != 0:
 			# Tail, not head: scripts run under `bash -x`, so the real error is at the end.
-			frappe.logger("atlas").warning(
-				f"probe {script} on {server} exited {exit_code}: {stderr[-500:]}"
-			)
+			frappe.logger("atlas").warning(f"probe {script} on {server} exited {exit_code}: {stderr[-500:]}")
 			return ""
 		return stdout
 	except Exception as exception:

--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -89,6 +89,50 @@ def run_task(
 	return task
 
 
+def run_probe(
+	*,
+	script: str,
+	variables: dict,
+	server: str,
+	timeout_seconds: int = 30,
+) -> str:
+	"""Run a read-only polling script on a host WITHOUT recording a Task row.
+
+	The non-persisting sibling of `run_task`, for the per-minute sweeps whose
+	rows nobody reads. `poll-vm-traffic` and `probe-woken-vms` (spec/32 sleepy
+	VMs) each run once per server per minute; as Tasks that is ~2,880 rows per
+	server per day of "polled, nothing happened", drowning the audit log the
+	Task list exists to be. A probe is idempotent, read-only, and interesting
+	only when it fails, so it logs instead of persisting.
+
+	Returns the script's stdout for `parse_result`. Never raises: an SSH error,
+	timeout, or non-zero exit logs a warning and returns "" — a missed poll
+	cycle is at most one extra minute of idle time, and the next tick retries.
+	Callers therefore need no try/except of their own.
+
+	Use `run_task` for anything that changes host state: those rows ARE the
+	audit trail, and their failures must propagate.
+	"""
+	if is_fake_server(server):
+		from atlas.atlas.providers.fake_tasks import fake_stdout
+
+		return fake_stdout(script, variables)
+
+	try:
+		connection = connection_for_server(frappe.get_doc("Server", server))
+		stdout, stderr, exit_code = _run_remote_script(connection, script, variables, timeout_seconds)
+		if exit_code != 0:
+			# Tail, not head: scripts run under `bash -x`, so the real error is at the end.
+			frappe.logger("atlas").warning(
+				f"probe {script} on {server} exited {exit_code}: {stderr[-500:]}"
+			)
+			return ""
+		return stdout
+	except Exception as exception:
+		frappe.logger("atlas").warning(f"probe {script} on {server} failed: {exception}")
+		return ""
+
+
 def execute_task(task_name: str) -> None:
 	"""Background-job entrypoint. Runs an already-inserted Pending Task."""
 	task = frappe.get_doc("Task", task_name)

--- a/atlas/atlas/api/server_capacity.py
+++ b/atlas/atlas/api/server_capacity.py
@@ -168,7 +168,15 @@ def capacity_for_server(server: str) -> dict:
 	memory_total = int(s["memory_megabytes_total"]) if s.get("memory_megabytes_total") else None
 	disk_total = int(s["pool_disk_gigabytes_total"]) if s.get("pool_disk_gigabytes_total") else None
 
-	resident = frappe.get_all(
+	# Sleeping VMs have released their cgroup (RAM freed, vCPUs idle) but their
+	# disk LV is still allocated. Query the two axes separately so placement can
+	# book new VMs on a host whose RAM is freed by sleeping tenants.
+	ram_resident = frappe.get_all(
+		"Virtual Machine",
+		filters={"server": server, "status": ["not in", ("Terminated", "Sleeping")]},
+		fields=list(_VM_COST_FIELDS),
+	)
+	disk_resident = frappe.get_all(
 		"Virtual Machine",
 		filters={"server": server, "status": ["!=", "Terminated"]},
 		fields=list(_VM_COST_FIELDS),
@@ -182,7 +190,11 @@ def capacity_for_server(server: str) -> dict:
 	# cutover): a migrating VM is deliberately charged to BOTH hosts for its brief
 	# life, the safe direction for a capacity gate.
 	incoming = _incoming_migration_vms(server)
-	vms = resident + incoming
+	# Sleeping VMs freed their cgroup (RAM + CPU released) but their disk LV
+	# remains allocated. Use separate VM lists per axis so placement can book
+	# new VMs on a host whose RAM is freed by sleeping tenants.
+	ram_vms = ram_resident + incoming
+	disk_vms = disk_resident + incoming
 	factor = overprovision_factor()
 	# Memory: hard fit, but never packable to the full physical total — the host OS
 	# + per-VM VMM overhead live in the same RAM, so effective = total − reserve
@@ -192,17 +204,17 @@ def capacity_for_server(server: str) -> dict:
 	cpu_axis = _axis(
 		total=vcpus_total,
 		effective=(vcpus_total * factor) if vcpus_total is not None else None,
-		used=sum(float(v.cpu_max_cores or v.vcpus or 0) for v in vms),
+		used=sum(float(v.cpu_max_cores or v.vcpus or 0) for v in ram_vms),
 	)
 	memory_axis = _axis(
 		total=memory_total,
 		effective=memory_effective,  # total − host_memory_reserve, no oversubscription
-		used=sum(int(v.memory_megabytes or 0) for v in vms),
+		used=sum(int(v.memory_megabytes or 0) for v in ram_vms),
 	)
 	disk_axis = _axis(
 		total=disk_total,
 		effective=disk_total,  # no oversubscription
-		used=sum(int(v.disk_gigabytes or 0) + int(v.data_disk_gigabytes or 0) for v in vms),
+		used=sum(int(v.disk_gigabytes or 0) + int(v.data_disk_gigabytes or 0) for v in disk_vms),
 	)
 	share = _share_units(cpu_axis, memory_axis, disk_axis)
 	return {
@@ -216,7 +228,7 @@ def capacity_for_server(server: str) -> dict:
 		"share_units": share["share_units"] if share else None,
 		"stranded": share["stranded"] if share else None,
 		"pool_data_percent": s.get("pool_data_percent"),  # advisory alert signal
-		"virtual_machine_count": len(resident),
+		"virtual_machine_count": len(ram_resident),
 		# VMs migrating in but not yet cut over — counted in `used` above, surfaced
 		# separately so the operator can see why a host reads fuller than its resident
 		# VM list.

--- a/atlas/atlas/dns/test_powerdns.py
+++ b/atlas/atlas/dns/test_powerdns.py
@@ -33,14 +33,18 @@ class TestPowerDNSDnsProvider(IntegrationTestCase):
 		self.assertTrue(path.endswith("/.atlas/certbot/blr1.frappe.dev/powerdns.ini"))
 
 	def test_credential_env_carries_powerdns_settings(self) -> None:
-		env = _provider(api_url="https://pdns.example.test/", api_key="shh", server_id="primary").credential_env()
+		env = _provider(
+			api_url="https://pdns.example.test/", api_key="shh", server_id="primary"
+		).credential_env()
 		self.assertEqual(env["POWERDNS_API_URL"], "https://pdns.example.test")
 		self.assertEqual(env["POWERDNS_API_KEY"], "shh")
 		self.assertEqual(env["POWERDNS_SERVER_ID"], "primary")
 
 	def test_authenticate_reads_server_endpoint(self) -> None:
 		provider = _provider(server_id="primary")
-		with patch.object(provider, "_request", return_value={"id": "primary", "version": "4.9.0"}) as request:
+		with patch.object(
+			provider, "_request", return_value={"id": "primary", "version": "4.9.0"}
+		) as request:
 			result = provider.authenticate()
 		self.assertTrue(result.ok)
 		self.assertEqual(result.account_label, "primary (4.9.0)")
@@ -76,9 +80,10 @@ class TestPowerDNSDnsProvider(IntegrationTestCase):
 
 	def test_upsert_wildcard_skips_empty_family(self) -> None:
 		provider = _provider()
-		with patch.object(provider, "_zone_id", return_value="x.frappe.dev."), patch.object(
-			provider, "_request", return_value={}
-		) as request:
+		with (
+			patch.object(provider, "_zone_id", return_value="x.frappe.dev."),
+			patch.object(provider, "_request", return_value={}) as request,
+		):
 			records = provider.upsert_wildcard(
 				"atlas1.x.frappe.dev", WildcardTargets(ipv4=["1.2.3.4"], ipv6=[])
 			)

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -959,7 +959,8 @@ def sync_scripts_to_all() -> dict[str, int]:
 	for name in names:
 		server = frappe.get_doc("Server", name)
 		if not server.ipv4_address:
-			frappe.throw(f"Server {name} has no ipv4_address; cannot sync scripts")
+			print(f"Skipping {name}: no ipv4_address")
+			continue
 		jobs.append((name, connection_for_server(server), server._script_uploads()))
 
 	if not jobs:
@@ -969,12 +970,16 @@ def sync_scripts_to_all() -> dict[str, int]:
 
 	def _push(job) -> tuple[str, int]:
 		name, connection, uploads = job
-		with frappe_thread_context(site):
-			print(f"Syncing durable scripts to {name} ({connection.host})")
-			upload_files(connection, uploads)
-			reinstall_atlas_venv_package(connection, name)
-			print(f"Done syncing durable scripts to {name} ({connection.host})")
-		return name, len(uploads)
+		try:
+			with frappe_thread_context(site):
+				print(f"Syncing durable scripts to {name} ({connection.host})")
+				upload_files(connection, uploads)
+				reinstall_atlas_venv_package(connection, name)
+				print(f"Done syncing durable scripts to {name} ({connection.host})")
+			return name, len(uploads)
+		except Exception as exc:
+			print(f"Failed to sync {name} ({connection.host}): {exc}")
+			return name, 0
 
 	from concurrent.futures import ThreadPoolExecutor
 

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -968,7 +968,7 @@ def sync_scripts_to_all() -> dict[str, int]:
 	for name in names:
 		server = frappe.get_doc("Server", name)
 		if not server.ipv4_address:
-			print(f"Skipping {name}: no ipv4_address")
+			frappe.logger("atlas").warning(f"sync-scripts skipping {name}: no ipv4_address")
 			continue
 		jobs.append((name, connection_for_server(server), server._script_uploads()))
 
@@ -987,7 +987,7 @@ def sync_scripts_to_all() -> dict[str, int]:
 				print(f"Done syncing durable scripts to {name} ({connection.host})")
 			return name, len(uploads)
 		except Exception as exc:
-			print(f"Failed to sync {name} ({connection.host}): {exc}")
+			frappe.logger("atlas").warning(f"sync-scripts failed for {name} ({connection.host}): {exc}")
 			return name, 0
 
 	from concurrent.futures import ThreadPoolExecutor

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -74,6 +74,12 @@ class Server(Document):
 		("install.sh", "/var/lib/atlas/bin/install.sh"),
 		("vm-network-up.py", "/var/lib/atlas/bin/vm-network-up.py"),
 		("vm-network-down.py", "/var/lib/atlas/bin/vm-network-down.py"),
+		# atlas-wake-trap.py is the always-on daemon that wakes a Sleeping VM on its
+		# first inbound TCP SYN (spec/32). Shipped durably like the systemd hooks
+		# (it imports the same durable atlas package); it is not a Task verb — the
+		# scripts_catalog SYSTEMD_HOOKS set excludes it from the host run-task gate.
+		("atlas-wake-trap.py", "/var/lib/atlas/bin/atlas-wake-trap.py"),
+		("systemd/atlas-wake-trap.service", "/etc/systemd/system/atlas-wake-trap.service"),
 		# vm-disk-up.py re-activates the VM's thin-snapshot disk LV and refreshes
 		# its in-jail block node at every unit start — the disk analogue of
 		# vm-network-up.py, so an enabled VM self-heals its disk after a reboot.

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -105,6 +105,15 @@ class Server(Document):
 		atlas_settings = frappe.get_single("Atlas Settings")
 		atlas_settings._ensure_ancp_operator_keypair()
 		atlas_settings._ensure_ancp_wg_derivation_secret()
+		# ignore_mandatory: this save is incidental — we are only persisting the two
+		# lazily-generated ANCP secrets, not asking the operator to have finished
+		# configuring Atlas Settings. Without it, a Single with an empty `region`
+		# (any site that has not been through setup(), including every fresh test
+		# site) makes EVERY Server insert die with "Value missing for Atlas
+		# Settings: Region" — an error naming a field the caller never touched.
+		# The operator's required fields are still enforced when they save the
+		# Single themselves.
+		atlas_settings.flags.ignore_mandatory = True
 		atlas_settings.save(ignore_permissions=True)
 		self._validate_immutability()
 		self._denormalize_mesh_identity()

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.js
@@ -1,6 +1,7 @@
 const PRIMARY_BY_STATUS = {
 	Failed: { label: "Provision", method: "provision" },
 	Stopped: { label: "Start", method: "start" },
+	Sleeping: { label: "Start", method: "start" },
 	Running: { label: "Stop", method: "stop" },
 	Paused: { label: "Resume", method: "resume" },
 };

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.json
@@ -59,7 +59,12 @@
   "last_started",
   "column_break_activity",
   "last_stopped",
-  "has_memory_snapshot"
+  "has_memory_snapshot",
+  "section_break_sleep",
+  "sleep_on_idle",
+  "idle_timeout_seconds",
+  "column_break_sleep",
+  "last_traffic_at"
  ],
  "fields": [
   {
@@ -106,7 +111,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nRunning\nPaused\nStopped\nFailed\nTerminated",
+   "options": "Pending\nRunning\nPaused\nStopped\nSleeping\nFailed\nTerminated",
    "read_only": 1,
    "reqd": 1
   },
@@ -428,6 +433,38 @@
    "fieldname": "has_memory_snapshot",
    "fieldtype": "Check",
    "label": "Has Memory Snapshot",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_sleep",
+   "fieldtype": "Section Break",
+   "label": "Sleep Settings"
+  },
+  {
+   "default": "0",
+   "description": "When set, the scheduler will automatically put this VM to sleep after idle_timeout_seconds of no network activity (measured by nftables byte counters). A sleeping VM frees its host RAM without losing state — the next Start resumes it in milliseconds via a memory snapshot.",
+   "fieldname": "sleep_on_idle",
+   "fieldtype": "Check",
+   "label": "Sleep on Idle"
+  },
+  {
+   "default": "300",
+   "depends_on": "sleep_on_idle",
+   "description": "Seconds of no network activity before the VM is put to sleep. Minimum 120 (validated on save). The scheduler polls every minute, so actual idle time is between idle_timeout_seconds and idle_timeout_seconds + 60 seconds.",
+   "fieldname": "idle_timeout_seconds",
+   "fieldtype": "Int",
+   "label": "Idle Timeout (seconds)"
+  },
+  {
+   "fieldname": "column_break_sleep",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Last time the per-minute traffic poll detected network activity on this VM. The scheduler compares this to idle_timeout_seconds to decide when to sleep it.",
+   "fieldname": "last_traffic_at",
+   "fieldtype": "Datetime",
+   "label": "Last Traffic At",
    "read_only": 1
   },
   {

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -620,9 +620,7 @@ class VirtualMachine(Document):
 		# frm.call / REST send `live` as a JSON/stringy value; normalize to bool.
 		live = live in (True, 1, "1", "true", "True", "yes")
 		if self.status == "Sleeping":
-			frappe.throw(
-				_("Cannot snapshot a Sleeping VM — wake it first, stop it, then snapshot")
-			)
+			frappe.throw(_("Cannot snapshot a Sleeping VM — wake it first, stop it, then snapshot"))
 		if live:
 			if self.status not in ("Running", "Paused"):
 				frappe.throw(

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -1426,10 +1426,19 @@ def sleep_idle_vms() -> None:
 		elapsed = (frappe.utils.now_datetime() - vm_data.last_traffic_at).total_seconds()
 		if elapsed < (vm_data.idle_timeout_seconds or 300):
 			continue
-		# Re-read status under a transaction so a concurrent poll doesn't race us.
-		current_status = frappe.db.get_value("Virtual Machine", vm_data.name, "status")
-		if current_status != "Running":
+		# Re-read BOTH fields the decision rests on, not just status: the batch read
+		# above is a snapshot, and poll_vm_traffic can stamp last_traffic_at between
+		# it and here. Acting on the stale timestamp would sleep a VM that just went
+		# active — self-correcting (the next SYN wakes it) but a real interruption.
+		current = frappe.db.get_value(
+			"Virtual Machine", vm_data.name, ["status", "last_traffic_at"], as_dict=True
+		)
+		if current.status != "Running":
 			continue
+		if not current.last_traffic_at or (
+			frappe.utils.now_datetime() - current.last_traffic_at
+		).total_seconds() < (vm_data.idle_timeout_seconds or 300):
+			continue  # traffic arrived since the batch read
 		try:
 			vm = frappe.get_doc("Virtual Machine", vm_data.name)
 			vm.sleep()

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -271,6 +271,9 @@ class VirtualMachine(Document):
 		)
 		self.status = "Running"
 		self.last_started = frappe.utils.now_datetime()
+		# Seed the idle clock (spec/32) so a freshly provisioned sleep_on_idle VM is
+		# measured from now, not from a null that only the first traffic poll fills.
+		self.last_traffic_at = self.last_started
 		self.save()
 		# The VM's private /128 is locally owned by this host; atlas-networkd's
 		# periodic scan (spec/31 §11) detects it via the local-ownership cache
@@ -386,6 +389,11 @@ class VirtualMachine(Document):
 		self.status = "Running"
 		self.has_memory_snapshot = 0
 		self.last_started = frappe.utils.now_datetime()
+		# Treat the start itself as activity (spec/32). Without this a sleep_on_idle
+		# VM carries the last_traffic_at it had before it stopped — already older
+		# than idle_timeout_seconds — and the next sleep_idle_vms tick puts it
+		# straight back to sleep, within a minute of the operator starting it.
+		self.last_traffic_at = self.last_started
 		self.save()
 		return task.name
 
@@ -522,6 +530,11 @@ class VirtualMachine(Document):
 		self.status = "Running"
 		self.has_memory_snapshot = 0
 		self.last_started = frappe.utils.now_datetime()
+		# The wake is itself the activity (spec/32) — same reason as start(), and
+		# more acute here: this VM slept *because* last_traffic_at was stale, so
+		# leaving it would guarantee the next idle sweep re-sleeps it. _adopt_wake
+		# stamps the same field for the host-initiated (packet-triggered) wake.
+		self.last_traffic_at = self.last_started
 		self.save()
 		return task.name
 

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -73,12 +73,14 @@ class VirtualMachine(Document):
 		data_disk_mount_point: DF.Data | None
 		disk_gigabytes: DF.Int
 		has_memory_snapshot: DF.Check
+		idle_timeout_seconds: DF.Int
 		image: DF.Link
 		ipv6_address: DF.Data | None
 		is_gateway: DF.Check
 		is_proxy: DF.Check
 		last_started: DF.Datetime | None
 		last_stopped: DF.Datetime | None
+		last_traffic_at: DF.Datetime | None
 		mac_address: DF.Data | None
 		memory_megabytes: DF.Int
 		memory_snapshot_on_stop: DF.Check
@@ -86,8 +88,9 @@ class VirtualMachine(Document):
 		server: DF.Link
 		pilot_credential_id: DF.Data | None
 		size_preset: DF.Literal["Custom", "Shared 1x", "Shared 2x", "Shared 4x", "Shared 8x", "Dedicated 1x"]
+		sleep_on_idle: DF.Check
 		ssh_public_key: DF.LongText
-		status: DF.Literal["Pending", "Running", "Paused", "Stopped", "Failed", "Terminated"]
+		status: DF.Literal["Pending", "Running", "Paused", "Stopped", "Sleeping", "Failed", "Terminated"]
 		stop_protection: DF.Check
 		tap_device: DF.Data | None
 		tenant: DF.Link | None
@@ -236,6 +239,8 @@ class VirtualMachine(Document):
 		# Role exclusivity holds for every save, not just insert — a later db-flip of
 		# is_gateway on a live proxy (or vice versa) is caught here too.
 		self.validate_infra_role()
+		if self.sleep_on_idle and (not self.idle_timeout_seconds or self.idle_timeout_seconds < 120):
+			frappe.throw(_("idle_timeout_seconds must be at least 120 when sleep_on_idle is enabled"))
 		if self.is_new():
 			return
 		original = self.get_doc_before_save()
@@ -362,7 +367,12 @@ class VirtualMachine(Document):
 		instead of cold-booting; the start Task is the same either way — the
 		launcher and the unit's vm-restore.py hook decide from the on-host marker.
 		The snapshot is consumed by the start (restored or not), so the flag
-		clears here unconditionally."""
+		clears here unconditionally.
+
+		A Sleeping VM is woken instead of started — Desk's Start button works for
+		both states transparently."""
+		if self.status == "Sleeping":
+			return self.wake()
 		if self.status != "Stopped":
 			frappe.throw(f"Cannot start from {self.status}")
 		self._guard_no_active_migration()
@@ -407,6 +417,10 @@ class VirtualMachine(Document):
 		(spec/24 §0.5.2). It only applies to the plain (non-snapshot) stop."""
 		# A Paused VM's unit is still active (vCPUs frozen, not shut down), so
 		# `systemctl stop` is the correct full shutdown from either state.
+		# A Sleeping VM's unit is already stopped — wake it first to get it
+		# Running, then call stop() normally.
+		if self.status == "Sleeping":
+			frappe.throw(_("VM is sleeping — wake it first, then stop"))
 		if self.status not in ("Running", "Paused"):
 			frappe.throw(f"Cannot stop from {self.status}")
 		self._guard_no_active_migration()
@@ -447,6 +461,67 @@ class VirtualMachine(Document):
 		self.status = "Stopped"
 		self.has_memory_snapshot = 1 if snapshotted else 0
 		self.last_stopped = frappe.utils.now_datetime()
+		self.save()
+		return task.name
+
+	@frappe.whitelist()
+	def sleep(self) -> str:
+		"""Put a Running VM to sleep: memory snapshot on the host + SLEEPING marker
+		file that suppresses systemd auto-start on host reboot. The VM's cgroup is
+		released, freeing its RAM on the host — that is the whole point.
+
+		Falls back to a plain stop if the snapshot fails (launcher too old, not
+		enough disk, etc.) — the VM always ends up Sleeping; only the next wake's
+		speed differs. sleep_on_idle must be enabled on the VM."""
+		if not self.sleep_on_idle:
+			frappe.throw(_("Enable sleep_on_idle before putting this VM to sleep"))
+		if self.status != "Running":
+			frappe.throw(f"Cannot sleep from {self.status}")
+		self._guard_no_active_migration()
+		if self.stop_protection:
+			frappe.throw(_("Disable stop protection before sleeping this VM"))
+		task = run_task(
+			server=self.server,
+			script="sleep-vm",
+			variables={
+				"VIRTUAL_MACHINE_NAME": self.name,
+				"ATLAS_FC_UID": str(derive_uid(self.name)),
+			},
+			virtual_machine=self.name,
+			timeout_seconds=120,
+		)
+		snapshotted = bool(parse_result(task.stdout)["memory_snapshot"])
+		self.status = "Sleeping"
+		self.has_memory_snapshot = 1 if snapshotted else 0
+		self.last_stopped = frappe.utils.now_datetime()
+		self.save()
+		return task.name
+
+	@frappe.whitelist()
+	def wake(self) -> str:
+		"""Wake a Sleeping VM. Removes the SLEEPING marker on the host so systemd
+		will auto-start it on the next host reboot, then starts the unit. If a
+		memory snapshot is present (has_memory_snapshot), the guest resumes in
+		milliseconds; otherwise it cold-boots."""
+		if self.status != "Sleeping":
+			frappe.throw(f"Cannot wake from {self.status}")
+		# FOR UPDATE holds the row lock for this transaction, preventing two
+		# concurrent wake() calls (e.g. two proxy wake-ups) from both dispatching
+		# a start Task and racing each other.
+		frappe.db.sql("SELECT name FROM `tabVirtual Machine` WHERE name = %s FOR UPDATE", self.name)
+		current_status = frappe.db.get_value("Virtual Machine", self.name, "status")
+		if current_status != "Sleeping":
+			return ""  # Another caller already woke it
+		task = run_task(
+			server=self.server,
+			script="wake-vm",
+			variables={"VIRTUAL_MACHINE_NAME": self.name},
+			virtual_machine=self.name,
+			timeout_seconds=30,
+		)
+		self.status = "Running"
+		self.has_memory_snapshot = 0
+		self.last_started = frappe.utils.now_datetime()
 		self.save()
 		return task.name
 
@@ -531,6 +606,10 @@ class VirtualMachine(Document):
 		  guaranteed-clean image."""
 		# frm.call / REST send `live` as a JSON/stringy value; normalize to bool.
 		live = live in (True, 1, "1", "true", "True", "yes")
+		if self.status == "Sleeping":
+			frappe.throw(
+				_("Cannot snapshot a Sleeping VM — wake it first, stop it, then snapshot")
+			)
 		if live:
 			if self.status not in ("Running", "Paused"):
 				frappe.throw(
@@ -1281,3 +1360,66 @@ def auto_provision(virtual_machine_name: str) -> None:
 	if virtual_machine.status != "Pending":
 		return
 	virtual_machine.provision()
+
+
+def poll_vm_traffic() -> None:
+	"""Scheduled job (*/1 * * * *): for each server with sleep_on_idle Running VMs,
+	dispatch a poll-vm-traffic Task and stamp last_traffic_at on active VMs."""
+	import json
+
+	vms = frappe.get_all(
+		"Virtual Machine",
+		filters={"status": "Running", "sleep_on_idle": 1},
+		fields=["name", "server", "ipv6_address"],
+	)
+	if not vms:
+		return
+
+	by_server: dict = {}
+	for vm in vms:
+		by_server.setdefault(vm.server, []).append(vm)
+
+	now = frappe.utils.now_datetime()
+	for server, server_vms in by_server.items():
+		vms_json = json.dumps([{"name": vm.name, "ipv6_address": vm.ipv6_address} for vm in server_vms])
+		try:
+			task = run_task(
+				server=server,
+				script="poll-vm-traffic",
+				variables={"VMS_JSON": vms_json},
+				virtual_machine=None,
+				timeout_seconds=30,
+			)
+			counters = parse_result(task.stdout).get("counters", {})
+			for vm_name, counter in counters.items():
+				if counter.get("active"):
+					frappe.db.set_value("Virtual Machine", vm_name, "last_traffic_at", now)
+		except Exception:
+			pass  # Per-server failures don't abort other servers
+
+
+def sleep_idle_vms() -> None:
+	"""Scheduled job (*/1 * * * *): find Running sleep_on_idle VMs whose
+	last_traffic_at is older than their idle_timeout_seconds and put them to sleep.
+	The per-minute poll (poll_vm_traffic) keeps last_traffic_at fresh; this sweeper
+	acts on the staleness."""
+	vms = frappe.get_all(
+		"Virtual Machine",
+		filters={"status": "Running", "sleep_on_idle": 1},
+		fields=["name", "last_traffic_at", "idle_timeout_seconds"],
+	)
+	for vm_data in vms:
+		if not vm_data.last_traffic_at:
+			continue
+		elapsed = (frappe.utils.now_datetime() - vm_data.last_traffic_at).total_seconds()
+		if elapsed < (vm_data.idle_timeout_seconds or 300):
+			continue
+		# Re-read status under a transaction so a concurrent poll doesn't race us.
+		current_status = frappe.db.get_value("Virtual Machine", vm_data.name, "status")
+		if current_status != "Running":
+			continue
+		try:
+			vm = frappe.get_doc("Virtual Machine", vm_data.name)
+			vm.sleep()
+		except Exception:
+			pass  # Failures are recorded in the Task row; don't abort the sweep

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -20,7 +20,7 @@ from atlas.atlas.networking import (
 	resource_limit_args,
 )
 from atlas.atlas.placement import apply_user_defaults, check_resize_capacity
-from atlas.atlas.ssh import run_task
+from atlas.atlas.ssh import run_probe, run_task
 from atlas.atlas.task_results import parse_result
 
 # Never change after insert — identity and the key the rootfs was built with.
@@ -1395,20 +1395,21 @@ def poll_vm_traffic() -> None:
 	now = frappe.utils.now_datetime()
 	for server, server_vms in by_server.items():
 		vms_json = json.dumps([{"name": vm.name, "ipv6_address": vm.ipv6_address} for vm in server_vms])
-		try:
-			task = run_task(
-				server=server,
-				script="poll-vm-traffic",
-				variables={"VMS_JSON": vms_json},
-				virtual_machine=None,
-				timeout_seconds=30,
-			)
-			counters = parse_result(task.stdout).get("counters", {})
-			for vm_name, counter in counters.items():
-				if counter.get("active"):
-					frappe.db.set_value("Virtual Machine", vm_name, "last_traffic_at", now)
-		except Exception:
-			pass  # Per-server failures don't abort other servers
+		# run_probe, not run_task: a read-only poll on every server every minute
+		# would bury the Task log in rows nobody reads. It logs its own failures
+		# and returns "" instead of raising, so one bad server can't abort the rest.
+		stdout = run_probe(
+			server=server,
+			script="poll-vm-traffic",
+			variables={"VMS_JSON": vms_json},
+			timeout_seconds=30,
+		)
+		if not stdout:
+			continue
+		counters = parse_result(stdout).get("counters", {})
+		for vm_name, counter in counters.items():
+			if counter.get("active"):
+				frappe.db.set_value("Virtual Machine", vm_name, "last_traffic_at", now)
 
 
 def sleep_idle_vms() -> None:
@@ -1466,20 +1467,20 @@ def reconcile_sleeping_vms() -> None:
 
 	now = frappe.utils.now_datetime()
 	for server, names in by_server.items():
-		try:
-			task = run_task(
-				server=server,
-				script="probe-woken-vms",
-				variables={"VMS_JSON": json.dumps(names)},
-				virtual_machine=None,
-				timeout_seconds=30,
-			)
-			woken = parse_result(task.stdout).get("woken", {})
-			for name, is_woken in woken.items():
-				if is_woken:
-					_adopt_wake(name, now)
-		except Exception:
-			pass  # Per-server failures don't abort other servers
+		# run_probe, not run_task — see poll_vm_traffic: read-only, once a minute
+		# per server with any sleeping VM, and its rows would be pure noise.
+		stdout = run_probe(
+			server=server,
+			script="probe-woken-vms",
+			variables={"VMS_JSON": json.dumps(names)},
+			timeout_seconds=30,
+		)
+		if not stdout:
+			continue
+		woken = parse_result(stdout).get("woken", {})
+		for name, is_woken in woken.items():
+			if is_woken:
+				_adopt_wake(name, now)
 
 
 def _adopt_wake(name: str, now) -> None:

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -1423,3 +1423,68 @@ def sleep_idle_vms() -> None:
 			vm.sleep()
 		except Exception:
 			pass  # Failures are recorded in the Task row; don't abort the sweep
+
+
+def reconcile_sleeping_vms() -> None:
+	"""Scheduled job (*/1 * * * *, BEFORE sleep_idle_vms): flip a Sleeping VM to
+	Running once the host has woken it on its own — the DB catch-up for a
+	packet-triggered wake (spec/32 sleepy VMs).
+
+	atlas-wake-trap.py on the host wakes a Sleeping VM the moment it receives an
+	inbound TCP SYN (removing the `sleeping` marker + starting the unit), but the
+	host cannot reach into Atlas's DB. This probes each server's sleeping VMs for the
+	marker's absence and mirrors that back into the status, so the DB drifts by at
+	most one minute while the guest is reachable throughout. Ordered before
+	sleep_idle_vms so a same-tick idle sweep sees the fresh last_traffic_at and does
+	not immediately re-sleep a just-woken VM."""
+	import json
+
+	vms = frappe.get_all(
+		"Virtual Machine",
+		filters={"status": "Sleeping"},
+		fields=["name", "server"],
+	)
+	if not vms:
+		return
+
+	by_server: dict = {}
+	for vm in vms:
+		by_server.setdefault(vm.server, []).append(vm.name)
+
+	now = frappe.utils.now_datetime()
+	for server, names in by_server.items():
+		try:
+			task = run_task(
+				server=server,
+				script="probe-woken-vms",
+				variables={"VMS_JSON": json.dumps(names)},
+				virtual_machine=None,
+				timeout_seconds=30,
+			)
+			woken = parse_result(task.stdout).get("woken", {})
+			for name, is_woken in woken.items():
+				if is_woken:
+					_adopt_wake(name, now)
+		except Exception:
+			pass  # Per-server failures don't abort other servers
+
+
+def _adopt_wake(name: str, now) -> None:
+	"""Record a host-initiated wake in the DB, race-safe against an operator wake().
+	Takes the same row lock wake() uses and re-reads status inside it, so whichever
+	of the two commits first flips Sleeping->Running and the other no-ops. Sets the
+	same fields wake() does: last_started + last_traffic_at (so sleep_idle_vms won't
+	immediately re-sleep it) and clears has_memory_snapshot (the wake consumed it)."""
+	frappe.db.sql("SELECT name FROM `tabVirtual Machine` WHERE name = %s FOR UPDATE", name)
+	if frappe.db.get_value("Virtual Machine", name, "status") != "Sleeping":
+		return  # operator wake() (or a previous tick) already adopted it
+	frappe.db.set_value(
+		"Virtual Machine",
+		name,
+		{
+			"status": "Running",
+			"last_started": now,
+			"last_traffic_at": now,
+			"has_memory_snapshot": 0,
+		},
+	)

--- a/atlas/atlas/migration.py
+++ b/atlas/atlas/migration.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import ipaddress
 
 import frappe
+from frappe import _
 
 from atlas.atlas.networking import (
 	address_is_free_on_server,
@@ -227,7 +228,7 @@ def preflight_checks(vm, target_server: str, release_reserved_ip: bool) -> None:
 		# A sleeping VM's RAM lives in an on-host memory snapshot that is not
 		# transportable between hosts (spec/32, and the non-goal in ch.24), so
 		# there is nothing to migrate until it is resumed or discarded.
-		frappe.throw("Cannot migrate a sleeping VM — wake or stop it first")
+		frappe.throw(_("Cannot migrate a sleeping VM — wake or stop it first"))
 	if vm.status not in ("Stopped", "Running", "Paused"):
 		frappe.throw(f"Cannot migrate from {vm.status}")
 	if vm.server == target_server:

--- a/atlas/atlas/migration.py
+++ b/atlas/atlas/migration.py
@@ -223,6 +223,11 @@ def preflight_checks(vm, target_server: str, release_reserved_ip: bool) -> None:
 
 	if active_migration_for(vm.name):
 		frappe.throw("This VM already has an in-flight migration")
+	if vm.status == "Sleeping":
+		# A sleeping VM's RAM lives in an on-host memory snapshot that is not
+		# transportable between hosts (spec/32, and the non-goal in ch.24), so
+		# there is nothing to migrate until it is resumed or discarded.
+		frappe.throw("Cannot migrate a sleeping VM — wake or stop it first")
 	if vm.status not in ("Stopped", "Running", "Paused"):
 		frappe.throw(f"Cannot migrate from {vm.status}")
 	if vm.server == target_server:

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -186,6 +186,20 @@ def _snapshot_stop_result(_variables: dict) -> dict:
 	return {"memory_snapshot": True, "reason": "", "memory_snapshot_bytes": 536_870_912}
 
 
+def _sleep_vm_result(_variables: dict) -> dict:
+	return {"memory_snapshot": True, "reason": "", "memory_snapshot_bytes": 536_870_912}
+
+
+def _poll_vm_traffic_result(variables: dict) -> dict:
+	import json
+
+	try:
+		vms = json.loads(variables.get("VMS_JSON") or "[]")
+	except (json.JSONDecodeError, TypeError):
+		vms = []
+	return {"counters": {vm["name"]: {"active": False} for vm in vms}}
+
+
 def _warm_snapshot_result(variables: dict) -> dict:
 	return {
 		"size_bytes": _fake_disk_bytes(variables),
@@ -250,6 +264,8 @@ _RESULT_BUILDERS = {
 	"server-facts": _server_facts_result,
 	"snapshot-vm": _snapshot_result,
 	"snapshot-stop-vm": _snapshot_stop_result,
+	"sleep-vm": _sleep_vm_result,
+	"poll-vm-traffic": _poll_vm_traffic_result,
 	"warm-snapshot-vm": _warm_snapshot_result,
 	"upload-snapshot-s3": _upload_snapshot_s3_result,
 	"restore-snapshot-s3": _restore_snapshot_s3_result,

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -163,6 +163,15 @@ def _fake_stdout(script: str, variables: dict) -> str:
 	return RESULT_MARKER + json.dumps(builder(variables)) + "\n"
 
 
+def fake_stdout(script: str, variables: dict) -> str:
+	"""The synthesized stdout for a script, with no Task row involved.
+
+	`run_probe` (the non-persisting poller path) needs only the output a Fake
+	host would have produced — there is no row to finalize. Keeps the fake's
+	result synthesis in one place, shared with the Task-recording path."""
+	return _fake_stdout(script, variables)
+
+
 def _bootstrap_result(_variables: dict) -> dict:
 	return {
 		"firecracker_version": "v1.16.0",

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -200,6 +200,19 @@ def _poll_vm_traffic_result(variables: dict) -> dict:
 	return {"counters": {vm["name"]: {"active": False} for vm in vms}}
 
 
+def _probe_woken_vms_result(variables: dict) -> dict:
+	# A Fake host has no wake trap, so it reports nothing woken — a fake sleeping VM
+	# stays Sleeping until a test wakes it explicitly (vm.wake()). VMS_JSON is a flat
+	# list of uuids here (not the {name, ipv6} dicts poll-vm-traffic takes).
+	import json
+
+	try:
+		uuids = json.loads(variables.get("VMS_JSON") or "[]")
+	except (json.JSONDecodeError, TypeError):
+		uuids = []
+	return {"woken": {uuid: False for uuid in uuids}}
+
+
 def _warm_snapshot_result(variables: dict) -> dict:
 	return {
 		"size_bytes": _fake_disk_bytes(variables),
@@ -266,6 +279,7 @@ _RESULT_BUILDERS = {
 	"snapshot-stop-vm": _snapshot_stop_result,
 	"sleep-vm": _sleep_vm_result,
 	"poll-vm-traffic": _poll_vm_traffic_result,
+	"probe-woken-vms": _probe_woken_vms_result,
 	"warm-snapshot-vm": _warm_snapshot_result,
 	"upload-snapshot-s3": _upload_snapshot_s3_result,
 	"restore-snapshot-s3": _restore_snapshot_s3_result,

--- a/atlas/atlas/providers/worker.py
+++ b/atlas/atlas/providers/worker.py
@@ -269,7 +269,10 @@ def _probe_networkd_liveness(server_name: str) -> tuple[bool, str]:
 					conflict_note = f", conflict_count={conflicts}"
 		except Exception:
 			pass
-		return False, f"systemctl is-active/is-enabled -> {active_state or ['<none>']} (exit {exit_code}){conflict_note}"
+		return (
+			False,
+			f"systemctl is-active/is-enabled -> {active_state or ['<none>']} (exit {exit_code}){conflict_note}",
+		)
 
 
 def check_networkd_liveness() -> list[str]:

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -111,16 +111,18 @@ def _search_paths() -> list[Path]:
 _TASK_SUFFIXES: frozenset[str] = frozenset({".py", ".sh"})
 
 
-# Systemd-invoked hooks live in scripts/ but are NOT Task-runnable: they take a
-# positional VM uuid (passed by the unit's ExecStartPre/ExecStopPost as `%i`),
-# not the --flag CLI contract a Task uses, and they import the durable package.
-# Excluded from the catalog (by verb) so the runner never executes them as a Task.
+# Systemd-invoked scripts live in scripts/ but are NOT Task-runnable: the per-VM
+# hooks take a positional VM uuid (passed by the unit's ExecStartPre/ExecStopPost as
+# `%i`), and atlas-wake-trap is an always-on daemon (no args) — neither speaks the
+# --flag CLI contract a Task uses, and all import the durable package. Excluded from
+# the catalog (by verb) so the runner never executes them as a Task.
 SYSTEMD_HOOKS: frozenset[str] = frozenset(
 	{
 		"vm-disk-up",
 		"vm-network-up",
 		"vm-network-down",
 		"vm-restore",
+		"atlas-wake-trap",
 	}
 )
 

--- a/atlas/atlas/ssh.py
+++ b/atlas/atlas/ssh.py
@@ -9,6 +9,7 @@ from atlas.atlas._ssh.runner import (
 	connection_for_guest,
 	connection_for_server,
 	execute_task,
+	run_probe,
 	run_task,
 )
 from atlas.atlas._ssh.transport import (
@@ -32,6 +33,7 @@ __all__ = [
 	"connection_for_server",
 	"execute_task",
 	"forget_host",
+	"run_probe",
 	"run_ssh",
 	"run_task",
 	"ssh_key_file",

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -243,6 +243,8 @@ scheduler_events = {
 	"cron": {
 		"*/1 * * * *": [
 			"atlas.atlas.central_report.retry_pending",
+			"atlas.atlas.doctype.virtual_machine.virtual_machine.poll_vm_traffic",
+			"atlas.atlas.doctype.virtual_machine.virtual_machine.sleep_idle_vms",
 		],
 		"*/10 * * * *": [
 			"atlas.atlas.providers.worker.reconcile_pending_servers",

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -244,6 +244,9 @@ scheduler_events = {
 		"*/1 * * * *": [
 			"atlas.atlas.central_report.retry_pending",
 			"atlas.atlas.doctype.virtual_machine.virtual_machine.poll_vm_traffic",
+			# BEFORE sleep_idle_vms: adopt any host-initiated (packet-triggered) wake so
+			# a just-woken VM is Running with fresh last_traffic_at before the idle sweep.
+			"atlas.atlas.doctype.virtual_machine.virtual_machine.reconcile_sleeping_vms",
 			"atlas.atlas.doctype.virtual_machine.virtual_machine.sleep_idle_vms",
 		],
 		"*/10 * * * *": [

--- a/atlas/public/js/setup_wizard.js
+++ b/atlas/public/js/setup_wizard.js
@@ -307,7 +307,8 @@ function atlas_setup_slides() {
 					label: __("PowerDNS API URL"),
 					fieldtype: "Data",
 					depends_on: "eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
-					mandatory_depends_on: "eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
+					mandatory_depends_on:
+						"eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
 					description: __("Base URL without /api/v1."),
 				},
 				{
@@ -315,7 +316,8 @@ function atlas_setup_slides() {
 					label: __("PowerDNS API Key"),
 					fieldtype: "Password",
 					depends_on: "eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
-					mandatory_depends_on: "eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
+					mandatory_depends_on:
+						"eval:doc.setup_tls && doc.dns_provider_type=='PowerDNS'",
 				},
 				{
 					fieldname: "powerdns_server_id",
@@ -365,10 +367,13 @@ function atlas_provider_slide_onload(slide) {
 	// the first/declared option visually but leaves the doc value empty, so a field a
 	// user never touches would post blank and fail its `mandatory_depends_on` — make
 	// "what you see selected" == "what gets posted".
-	["provider_type", "do_region", "dns_provider_type", "powerdns_server_id"].forEach((fieldname) => {
-		const field = slide.get_field(fieldname);
-		if (field?.df.default && !slide.get_value(fieldname)) field.set_input(field.df.default);
-	});
+	["provider_type", "do_region", "dns_provider_type", "powerdns_server_id"].forEach(
+		(fieldname) => {
+			const field = slide.get_field(fieldname);
+			if (field?.df.default && !slide.get_value(fieldname))
+				field.set_input(field.df.default);
+		}
+	);
 	slide.form.refresh();
 
 	slide

--- a/atlas/setup.py
+++ b/atlas/setup.py
@@ -146,7 +146,9 @@ def setup_tls_layer(tls: dict) -> None:
 		acme_directory_url=tls.get("acme_directory_url")
 		or "https://acme-staging-v02.api.letsencrypt.org/directory",
 	)
-	frappe.db.set_single_value("Atlas Settings", "dns_provider_type", dns_provider_type, update_modified=False)
+	frappe.db.set_single_value(
+		"Atlas Settings", "dns_provider_type", dns_provider_type, update_modified=False
+	)
 	frappe.db.set_single_value("Atlas Settings", "tls_provider_type", "Let's Encrypt", update_modified=False)
 	if not frappe.db.exists("Root Domain", tls["domain"]):
 		frappe.get_doc(

--- a/atlas/tests/e2e/__init__.py
+++ b/atlas/tests/e2e/__init__.py
@@ -32,6 +32,7 @@ from atlas.tests.e2e.use_cases import (
 	reserved_ip_inbound,
 	run_task,
 	server_provisioning,
+	sleepy_vms,
 	ssh_primitive,
 	virtual_machine_lifecycle,
 	virtual_machine_provisioning,
@@ -72,6 +73,7 @@ def run_all() -> None:
 		("run-task", run_task.run),
 		("desk-buttons", desk_buttons.run),
 		("reserved-ip-inbound", reserved_ip_inbound.run),
+		("sleepy-vms", sleepy_vms.run),
 		# ("proxy-vm", proxy_vm.run),  # TODO: broken — re-enable when fixed
 		("server-provisioning (validation)", server_provisioning.run_against_shared),
 		("ssh-primitive (transport+bootstrap)", ssh_primitive.run_against_shared),
@@ -167,6 +169,7 @@ def run_all_smoke() -> None:
 		("run-task", run_task.run_smoke),
 		("desk-buttons", desk_buttons.run_smoke),
 		("reserved-ip-inbound", reserved_ip_inbound.run_smoke),
+		("sleepy-vms", sleepy_vms.run_smoke),
 		# ("proxy-vm", proxy_vm.run_smoke),  # TODO: broken — re-enable when fixed
 		("server-provisioning", server_provisioning.run_smoke),
 		("ssh-primitive", ssh_primitive.run_smoke),

--- a/atlas/tests/e2e/scripts/phase-is-parked.sh
+++ b/atlas/tests/e2e/scripts/phase-is-parked.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Sleepy-VM e2e: assert a Sleeping VM is PARKED — i.e. the host still has the
+# minimum reachability needed to trap an inbound TCP SYN, with no running guest
+# (spec/32-sleepy-vms.md).
+#
+# phase7-is-sleeping.sh already covers the "VM is off" half (unit inactive,
+# SLEEPING marker present). This covers the half that makes wake-on-TCP possible
+# at all, and which is otherwise invisible until a connection silently fails:
+#
+#   1. the named counter `wake_<uuid-no-dashes>` exists in table inet atlas —
+#      it is the flat surface atlas-wake-trap polls;
+#   2. a rule in the `forward` chain references it, matching a bare SYN and
+#      DROPping (not rejecting, so the client retransmits into the woken guest);
+#   3. the VM's /128 routes out the shared atlas-park0 dummy, which is what makes
+#      an inbound packet FORWARDED (so it reaches the rule) instead of being
+#      input-delivered and consumed by the host;
+#   4. atlas-wake-trap.service is actually running — the trap is inert without it.
+#
+# Inputs:
+#   VIRTUAL_MACHINE_NAME  - the VM UUID.
+#   VIRTUAL_MACHINE_IPV6  - its public /128.
+
+set -euo pipefail
+
+: "${VIRTUAL_MACHINE_NAME:?}"
+: "${VIRTUAL_MACHINE_IPV6:?}"
+
+counter="wake_${VIRTUAL_MACHINE_NAME//-/}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# The park happens in sleep-vm.py right after the unit stops, so give it a moment
+# rather than racing the tail of the sleep Task.
+for _ in $(seq 1 30); do
+    if sudo nft list counter inet atlas "${counter}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+sudo nft list counter inet atlas "${counter}" >/dev/null 2>&1 \
+    || fail "named counter ${counter} missing — nothing for atlas-wake-trap to poll"
+
+chain="$(sudo nft list chain inet atlas forward)"
+printf '%s\n' "${chain}" | grep -q "${counter}" \
+    || fail "no forward rule references ${counter} — an inbound SYN would not be counted"
+
+rule="$(printf '%s\n' "${chain}" | grep "${counter}")"
+printf '%s\n' "${rule}" | grep -q 'tcp flags syn' \
+    || fail "wake rule is not SYN-only (ICMP/UDP would wake the VM): ${rule}"
+printf '%s\n' "${rule}" | grep -q 'drop' \
+    || fail "wake rule does not drop — the client would not retransmit: ${rule}"
+
+route="$(ip -6 route show "${VIRTUAL_MACHINE_IPV6}/128" || true)"
+printf '%s\n' "${route}" | grep -q 'atlas-park0' \
+    || fail "/128 does not route out atlas-park0 (got '${route}') — inbound packets would not be forwarded"
+
+systemctl is-active --quiet atlas-wake-trap.service \
+    || fail "atlas-wake-trap.service is not active — the trap would never fire"
+
+echo "OK parked ${VIRTUAL_MACHINE_NAME}"

--- a/atlas/tests/e2e/scripts/phase-is-unparked.sh
+++ b/atlas/tests/e2e/scripts/phase-is-unparked.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Sleepy-VM e2e: assert a woken VM is UNPARKED — every artefact phase-is-parked
+# asserted is gone (spec/32-sleepy-vms.md).
+#
+# vm-network-up.py calls unpark() as its FIRST step, before rebuilding the real
+# netns, so the client's retransmitted SYN reaches the resumed guest rather than
+# hitting the trap again. If the rule or the off-link route survived the wake,
+# the VM would be up but its traffic would still be dropped or blackholed out the
+# dummy — which looks exactly like "the VM is broken" and is why this is asserted
+# rather than assumed.
+#
+# A leftover counter also matters on its own: atlas-wake-trap skips a non-zero
+# counter whose marker is gone, so the VM would not be re-woken, but the stale
+# object would accumulate on the host for every sleep/wake cycle.
+#
+# Inputs:
+#   VIRTUAL_MACHINE_NAME  - the VM UUID.
+#   VIRTUAL_MACHINE_IPV6  - its public /128.
+
+set -euo pipefail
+
+: "${VIRTUAL_MACHINE_NAME:?}"
+: "${VIRTUAL_MACHINE_IPV6:?}"
+
+counter="wake_${VIRTUAL_MACHINE_NAME//-/}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# The unpark is the first thing the starting unit does; allow for the Task
+# returning slightly ahead of ExecStartPre completing.
+for _ in $(seq 1 30); do
+    if ! sudo nft list counter inet atlas "${counter}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+! sudo nft list counter inet atlas "${counter}" >/dev/null 2>&1 \
+    || fail "named counter ${counter} survived the wake"
+
+! sudo nft list chain inet atlas forward | grep -q "${counter}" \
+    || fail "forward chain still has a wake rule for ${counter} — live traffic would be dropped"
+
+route="$(ip -6 route show "${VIRTUAL_MACHINE_IPV6}/128" || true)"
+! printf '%s\n' "${route}" | grep -q 'atlas-park0' \
+    || fail "/128 still routes out atlas-park0 (got '${route}') — the guest is unreachable"
+
+echo "OK unparked ${VIRTUAL_MACHINE_NAME}"

--- a/atlas/tests/e2e/scripts/phase-wake-ping.sh
+++ b/atlas/tests/e2e/scripts/phase-wake-ping.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Sleepy-VM e2e (stimulus, not an assertion): ICMP the target /128 from an
+# off-host vantage. The caller asserts afterwards that the VM is STILL sleeping.
+#
+# The wake rule matches `tcp flags syn`, which implies TCP, so ICMP falls through
+# the forward chain's policy accept, is forwarded out atlas-park0, and is
+# discarded — no wake. That is the "TCP only" contract (spec/32), and it is worth
+# probing because the failure mode is silent and expensive: any stray ping (a
+# monitoring sweep, a neighbour discovery) would otherwise resurrect every
+# sleeping VM on the host and quietly undo the whole feature.
+#
+# Runs on a DIFFERENT host than the one holding the VM: a packet from the VM's
+# own host would be locally delivered and never traverse `inet atlas forward`.
+#
+# Always exits 0 — the absence of a wake is what the caller checks.
+#
+# Inputs:
+#   TARGET_IPV6 - the sleeping VM's /128.
+
+set -euo pipefail
+
+: "${TARGET_IPV6:?}"
+
+ping -6 -c 3 -W 2 "${TARGET_IPV6}" >/dev/null 2>&1 || true
+echo "OK pinged ${TARGET_IPV6} (expecting NO wake)"

--- a/atlas/tests/e2e/scripts/phase-wake-tcp.sh
+++ b/atlas/tests/e2e/scripts/phase-wake-tcp.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Sleepy-VM e2e: open a TCP connection to a SLEEPING VM's /128 from an off-host
+# vantage and assert it eventually answers — the wake-on-first-inbound-TCP path
+# end to end (spec/32), and the only part of the feature a tenant ever sees.
+#
+# What is being proved: the first SYN is DROPped by the park rule (so this first
+# connect attempt fails by design), the named counter goes non-zero,
+# atlas-wake-trap notices within ~1s and starts the unit, vm-network-up unparks
+# and vm-restore resumes the guest from its memory snapshot, and the client's
+# retransmit — or one of our retries — lands on the live guest.
+#
+# Runs on a DIFFERENT host than the one holding the VM. A packet originating on
+# the VM's own host would be input-delivered locally and never traverse
+# `inet atlas forward`, so the trap would never fire and this would prove nothing.
+#
+# Inputs:
+#   TARGET_IPV6    - the sleeping VM's /128.
+#   TARGET_PORT    - port to dial (22; sshd is up in the guest once resumed).
+#   TIMEOUT_SECONDS- how long to keep retrying before failing.
+
+set -euo pipefail
+
+: "${TARGET_IPV6:?}"
+TARGET_PORT="${TARGET_PORT:-22}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-150}"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+attempt=0
+
+while [ "$SECONDS" -lt "$deadline" ]; do
+    attempt=$((attempt + 1))
+    # -w bounds each attempt so a DROPped SYN cannot hang until the kernel gives
+    # up; -z is connect-only (no payload), which is exactly one SYN handshake.
+    if timeout 10 nc -6 -z -w 5 "${TARGET_IPV6}" "${TARGET_PORT}" 2>/dev/null; then
+        echo "OK woke ${TARGET_IPV6}:${TARGET_PORT} after ${attempt} attempt(s), ${SECONDS}s"
+        exit 0
+    fi
+    sleep 3
+done
+
+echo "FAIL: ${TARGET_IPV6}:${TARGET_PORT} never answered in ${TIMEOUT_SECONDS}s (${attempt} attempts) — the SYN trap did not wake the VM" >&2
+exit 1

--- a/atlas/tests/e2e/scripts/phase7-is-sleeping.sh
+++ b/atlas/tests/e2e/scripts/phase7-is-sleeping.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Phase 7 e2e: assert the VM is sleeping — unit inactive and SLEEPING marker present.
+
+set -euo pipefail
+
+: "${VIRTUAL_MACHINE_NAME:?}"
+
+SLEEPING_MARKER="/var/lib/atlas/virtual-machines/${VIRTUAL_MACHINE_NAME}/sleeping"
+
+for _ in $(seq 1 30); do
+    if ! systemctl is-active --quiet "firecracker-vm@${VIRTUAL_MACHINE_NAME}.service" \
+            && sudo test -f "${SLEEPING_MARKER}"; then
+        exit 0
+    fi
+    sleep 1
+done
+
+if systemctl is-active --quiet "firecracker-vm@${VIRTUAL_MACHINE_NAME}.service"; then
+    echo "VM unit is still active" >&2
+elif ! sudo test -f "${SLEEPING_MARKER}"; then
+    echo "SLEEPING marker missing at ${SLEEPING_MARKER}" >&2
+fi
+exit 1

--- a/atlas/tests/e2e/use_cases/sleepy_vms.py
+++ b/atlas/tests/e2e/use_cases/sleepy_vms.py
@@ -81,11 +81,19 @@ def run_with_vantage(vantage_name: str, reuse: bool = True, keep: bool = True) -
 
 
 def _find_vantage(server_name: str) -> str | None:
-	"""Another Active, SSH-reachable host to originate the inbound SYN from."""
+	"""Another Active, SSH-reachable, REAL host to originate the inbound SYN from.
+
+	Fake-provider Servers are excluded and the exclusion is load-bearing: a Task
+	on a Fake host is synthesized in-process and never touches SSH, so a probe
+	"succeeds" with canned output having dialed nothing. Picking one made the
+	whole scenario pass vacuously — ICMP "didn't wake" the VM because no ping was
+	ever sent, and TCP "woke" it without a packet leaving the controller.
+	"""
+	from atlas.atlas.providers.fake_tasks import is_fake_server
 	from atlas.tests.e2e._shared import server_is_reachable
 
 	for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
-		if name == server_name:
+		if name == server_name or is_fake_server(name):
 			continue
 		if server_is_reachable(name, timeout_seconds=5):
 			return name
@@ -186,13 +194,16 @@ def _check_wake_on_inbound_tcp(server_name: str, vantage_name: str) -> None:
 
 		# Sanity: the vantage must reach the guest while it is UP, or every
 		# assertion below would pass or fail for reasons that have nothing to do
-		# with the trap.
+		# with the trap. This doubles as the wait for the guest to finish booting
+		# — sleeping a VM whose Firecracker API socket is not yet listening makes
+		# the memory snapshot fail ("API socket missing"), and the VM then wakes by
+		# cold boot instead of resume, which is not what this scenario is testing.
 		assert_probe(
 			vantage_name,
 			"phase-wake-tcp",
-			timeout_seconds=90,
+			timeout_seconds=180,
 			TARGET_IPV6=address,
-			TIMEOUT_SECONDS="60",
+			TIMEOUT_SECONDS="150",
 		)
 
 		# --- 1. Sleep, and assert the trap is armed ---
@@ -223,7 +234,9 @@ def _check_wake_on_inbound_tcp(server_name: str, vantage_name: str) -> None:
 			TARGET_IPV6=address,
 			TIMEOUT_SECONDS="150",
 		)
-		assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+		assert_probe(
+			server_name, "phase5-is-active", timeout_seconds=90, VIRTUAL_MACHINE_NAME=vm.name
+		)
 		assert_probe(
 			server_name,
 			"phase-is-unparked",

--- a/atlas/tests/e2e/use_cases/sleepy_vms.py
+++ b/atlas/tests/e2e/use_cases/sleepy_vms.py
@@ -1,0 +1,110 @@
+"""Use case: Sleepy VMs — idle VMs put to sleep, resumed on wake.
+
+Exercises:
+1. Auto-provision (insert -> Running)
+2. vm.sleep() — memory snapshot + SLEEPING marker on host; status -> Sleeping
+3. vm.start() from Sleeping delegates to wake() — status -> Running
+4. Repeat stop/sleep to verify idempotency
+5. Manual vm.wake() from Sleeping — status -> Running
+
+Host facts checked:
+- After sleep: sleeping marker file present, systemd unit inactive
+- After wake: sleeping marker file absent, systemd unit active, VM SSH-reachable
+"""
+
+import time
+
+import frappe
+
+from atlas.tests.e2e._shared import (
+	assert_probe,
+	ensure_image_on_server,
+	ephemeral_public_key,
+	expect_validation_error,
+	phase,
+	wait_for_vm_running,
+)
+
+
+def run(reuse: bool = True, keep: bool = True) -> None:
+	with phase("sleepy-vms", reuse=reuse, keep=keep) as server:
+		image_doc = ensure_image_on_server(server.name)
+		public_key = ephemeral_public_key()
+
+		vm = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine",
+				"title": "sleepy-vm",
+				"server": server.name,
+				"image": image_doc.name,
+				"vcpus": 1,
+				"memory_megabytes": 512,
+				"disk_gigabytes": 4,
+				"ssh_public_key": public_key,
+				"sleep_on_idle": 1,
+				"idle_timeout_seconds": 120,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		_check_sleep_wake(server.name, vm)
+
+
+run_smoke = run
+
+
+def _check_sleep_wake(server_name: str, vm) -> None:
+	# --- 1. Auto-provision -> Running ---
+	wait_for_vm_running(vm.name, timeout_seconds=120)
+	vm.reload()
+	assert vm.status == "Running", vm.status
+	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+
+	# --- 2. Sleep ---
+	vm.sleep()
+	vm.reload()
+	assert vm.status == "Sleeping", f"expected Sleeping, got {vm.status}"
+	assert vm.has_memory_snapshot, "sleep() should have captured a memory snapshot"
+	assert vm.last_stopped, "last_stopped should be set after sleep()"
+
+	# Host facts: sleeping marker present, unit inactive
+	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+
+	# --- 3. Guards while sleeping ---
+	with expect_validation_error("sleeping"):
+		vm.stop()
+	with expect_validation_error("sleeping"):
+		vm.snapshot()
+
+	# --- 4. start() from Sleeping delegates to wake() ---
+	time.sleep(1)
+	vm.start()  # must call wake() internally
+	vm.reload()
+	assert vm.status == "Running", f"expected Running after start-from-Sleeping, got {vm.status}"
+	assert not vm.has_memory_snapshot, "wake should clear has_memory_snapshot"
+	assert vm.last_started, "last_started should be set"
+
+	# Host facts: sleeping marker gone, unit active
+	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+
+	# --- 5. Sleep again, then explicit wake() ---
+	vm.sleep()
+	vm.reload()
+	assert vm.status == "Sleeping", vm.status
+
+	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+
+	time.sleep(1)
+	vm.wake()
+	vm.reload()
+	assert vm.status == "Running", f"expected Running after wake(), got {vm.status}"
+	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+
+	# --- 6. wake() from non-Sleeping throws ---
+	with expect_validation_error("Cannot wake"):
+		vm.wake()
+
+	# --- 7. Terminate ---
+	vm.terminate()
+	vm.reload()
+	assert vm.status == "Terminated", vm.status

--- a/atlas/tests/e2e/use_cases/sleepy_vms.py
+++ b/atlas/tests/e2e/use_cases/sleepy_vms.py
@@ -6,12 +6,18 @@ Exercises:
 3. vm.start() from Sleeping delegates to wake() — status -> Running
 4. Repeat stop/sleep to verify idempotency
 5. Manual vm.wake() from Sleeping — status -> Running
+6. Wake on the first inbound TCP SYN — the whole point of the feature, and the
+   only part a tenant ever sees. Covered end to end: parked while asleep, ICMP
+   does NOT wake, a TCP connect DOES, unparked afterwards, and the DB catches up.
 
 Host facts checked:
-- After sleep: sleeping marker file present, systemd unit inactive
-- After wake: sleeping marker file absent, systemd unit active, VM SSH-reachable
+- After sleep: sleeping marker file present, systemd unit inactive, /128 parked
+  (named counter + SYN-drop rule + off-link route out atlas-park0)
+- After wake: sleeping marker absent, unit active, VM SSH-reachable, unparked
 """
 
+import socket
+import subprocess
 import time
 
 import frappe
@@ -48,6 +54,7 @@ def run(reuse: bool = True, keep: bool = True) -> None:
 		frappe.db.commit()
 
 		_check_sleep_wake(server.name, vm)
+		_check_wake_on_inbound_tcp(server.name)
 
 
 run_smoke = run
@@ -108,3 +115,107 @@ def _check_sleep_wake(server_name: str, vm) -> None:
 	vm.terminate()
 	vm.reload()
 	assert vm.status == "Terminated", vm.status
+
+
+def _tcp_connect(address: str, port: int, timeout: float) -> bool:
+	"""One TCP connect attempt to the VM's public /128."""
+	try:
+		with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+			sock.settimeout(timeout)
+			sock.connect((address, port))
+		return True
+	except OSError:
+		return False
+
+
+def _check_wake_on_inbound_tcp(server_name: str) -> None:
+	"""The tenant-visible path: a sleeping VM wakes on the first inbound SYN.
+
+	Runs on a FRESH VM because _check_sleep_wake terminates its own.
+	"""
+	image_doc = ensure_image_on_server(server_name)
+	vm = frappe.get_doc(
+		{
+			"doctype": "Virtual Machine",
+			"title": "sleepy-vm-syn",
+			"server": server_name,
+			"image": image_doc.name,
+			"vcpus": 1,
+			"memory_megabytes": 512,
+			"disk_gigabytes": 4,
+			"ssh_public_key": ephemeral_public_key(),
+			"sleep_on_idle": 1,
+			"idle_timeout_seconds": 120,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	wait_for_vm_running(vm.name, timeout_seconds=180)
+	vm.reload()
+	address = vm.ipv6_address
+	assert address, "VM has no public /128 to dial"
+
+	# The controller must actually be able to reach the guest, or every assertion
+	# below would "pass" for the wrong reason.
+	assert _tcp_connect(address, 22, timeout=30), (
+		f"guest {address}:22 unreachable while Running — "
+		"this host/controller pair cannot exercise the SYN trap"
+	)
+
+	# --- 1. Sleep, and assert the trap is armed ---
+	vm.sleep()
+	vm.reload()
+	assert vm.status == "Sleeping", vm.status
+	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+	assert_probe(
+		server_name,
+		"phase-is-parked",
+		timeout_seconds=60,
+		VIRTUAL_MACHINE_NAME=vm.name,
+		VIRTUAL_MACHINE_IPV6=address,
+	)
+
+	# --- 2. ICMP must NOT wake it (the rule matches `tcp flags`, so ping falls
+	#        through, is forwarded out the dummy, and is discarded) ---
+	subprocess.run(
+		["ping6", "-c", "3", "-W", "2", address],
+		capture_output=True,
+		check=False,
+	)
+	time.sleep(5)
+	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+	vm.reload()
+	assert vm.status == "Sleeping", f"ICMP woke the VM; the trap is not TCP-only ({vm.status})"
+
+	# --- 3. A TCP SYN DOES wake it. The first SYN is dropped by design, so the
+	#        connect fails and the kernel retransmits (~1s) into the resumed
+	#        guest; retry until the guest answers. ---
+	deadline = time.monotonic() + 120
+	connected = False
+	while time.monotonic() < deadline:
+		if _tcp_connect(address, 22, timeout=5):
+			connected = True
+			break
+		time.sleep(2)
+	assert connected, f"{address}:22 never answered after the SYN trap should have woken it"
+
+	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+	assert_probe(
+		server_name,
+		"phase-is-unparked",
+		timeout_seconds=60,
+		VIRTUAL_MACHINE_NAME=vm.name,
+		VIRTUAL_MACHINE_IPV6=address,
+	)
+
+	# --- 4. The DB catches up. The host woke the VM on its own; Atlas learns
+	#        about it from the per-minute reconcile, not from a Task. ---
+	from atlas.atlas.doctype.virtual_machine.virtual_machine import reconcile_sleeping_vms
+
+	reconcile_sleeping_vms()
+	vm.reload()
+	assert vm.status == "Running", f"reconcile did not adopt the host wake ({vm.status})"
+	assert not vm.has_memory_snapshot, "the wake consumed the memory snapshot"
+	assert vm.last_traffic_at, "adopting the wake must reset the idle clock"
+
+	vm.terminate()

--- a/atlas/tests/e2e/use_cases/sleepy_vms.py
+++ b/atlas/tests/e2e/use_cases/sleepy_vms.py
@@ -16,12 +16,13 @@ Host facts checked:
 - After wake: sleeping marker absent, unit active, VM SSH-reachable, unparked
 """
 
-import socket
-import subprocess
 import time
 
 import frappe
 
+from atlas.atlas.doctype.virtual_machine.virtual_machine import (
+	reconcile_sleeping_vms,
+)
 from atlas.tests.e2e._shared import (
 	assert_probe,
 	ensure_image_on_server,
@@ -54,10 +55,41 @@ def run(reuse: bool = True, keep: bool = True) -> None:
 		frappe.db.commit()
 
 		_check_sleep_wake(server.name, vm)
-		_check_wake_on_inbound_tcp(server.name)
+
+		# The SYN trap needs an off-host vantage (see _check_wake_on_inbound_tcp).
+		# Without a second reachable host the scenario cannot be exercised
+		# honestly, so say so loudly and skip it rather than pass vacuously.
+		vantage = _find_vantage(server.name)
+		if vantage:
+			_check_wake_on_inbound_tcp(server.name, vantage)
+		else:
+			print(
+				"sleepy-vms: SKIPPED wake-on-inbound-TCP — no second Active, "
+				"SSH-reachable host to dial from. Run the two-host e2e, or use "
+				"run_with_vantage(<server-name>)."
+			)
 
 
 run_smoke = run
+
+
+def run_with_vantage(vantage_name: str, reuse: bool = True, keep: bool = True) -> None:
+	"""Run only the wake-on-inbound-TCP scenario, dialing from `vantage_name`."""
+	with phase("sleepy-vms-syn", reuse=reuse, keep=keep) as server:
+		assert vantage_name != server.name, "the vantage must not be the VM's own host"
+		_check_wake_on_inbound_tcp(server.name, vantage_name)
+
+
+def _find_vantage(server_name: str) -> str | None:
+	"""Another Active, SSH-reachable host to originate the inbound SYN from."""
+	from atlas.tests.e2e._shared import server_is_reachable
+
+	for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
+		if name == server_name:
+			continue
+		if server_is_reachable(name, timeout_seconds=5):
+			return name
+	return None
 
 
 def _check_sleep_wake(server_name: str, vm) -> None:
@@ -117,21 +149,17 @@ def _check_sleep_wake(server_name: str, vm) -> None:
 	assert vm.status == "Terminated", vm.status
 
 
-def _tcp_connect(address: str, port: int, timeout: float) -> bool:
-	"""One TCP connect attempt to the VM's public /128."""
-	try:
-		with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
-			sock.settimeout(timeout)
-			sock.connect((address, port))
-		return True
-	except OSError:
-		return False
+def _check_wake_on_inbound_tcp(server_name: str, vantage_name: str) -> None:
+	"""The tenant-visible path: a sleeping VM wakes on the first inbound TCP SYN.
 
+	Both stimuli are driven from `vantage_name`, a DIFFERENT host, because a packet
+	originating on the VM's own host is input-delivered locally and never traverses
+	`inet atlas forward` — the trap would never fire and the probe would prove
+	nothing. The controller is not a usable vantage either: a laptop has no v6
+	route to a guest (the same reason the migration use case probes from the
+	target host).
 
-def _check_wake_on_inbound_tcp(server_name: str) -> None:
-	"""The tenant-visible path: a sleeping VM wakes on the first inbound SYN.
-
-	Runs on a FRESH VM because _check_sleep_wake terminates its own.
+	Runs on a fresh VM — _check_sleep_wake terminates its own.
 	"""
 	image_doc = ensure_image_on_server(server_name)
 	vm = frappe.get_doc(
@@ -150,72 +178,68 @@ def _check_wake_on_inbound_tcp(server_name: str) -> None:
 	).insert(ignore_permissions=True)
 	frappe.db.commit()
 
-	wait_for_vm_running(vm.name, timeout_seconds=180)
-	vm.reload()
-	address = vm.ipv6_address
-	assert address, "VM has no public /128 to dial"
+	try:
+		wait_for_vm_running(vm.name, timeout_seconds=180)
+		vm.reload()
+		address = vm.ipv6_address
+		assert address, "VM has no public /128 to dial"
 
-	# The controller must actually be able to reach the guest, or every assertion
-	# below would "pass" for the wrong reason.
-	assert _tcp_connect(address, 22, timeout=30), (
-		f"guest {address}:22 unreachable while Running — "
-		"this host/controller pair cannot exercise the SYN trap"
-	)
+		# Sanity: the vantage must reach the guest while it is UP, or every
+		# assertion below would pass or fail for reasons that have nothing to do
+		# with the trap.
+		assert_probe(
+			vantage_name,
+			"phase-wake-tcp",
+			timeout_seconds=90,
+			TARGET_IPV6=address,
+			TIMEOUT_SECONDS="60",
+		)
 
-	# --- 1. Sleep, and assert the trap is armed ---
-	vm.sleep()
-	vm.reload()
-	assert vm.status == "Sleeping", vm.status
-	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
-	assert_probe(
-		server_name,
-		"phase-is-parked",
-		timeout_seconds=60,
-		VIRTUAL_MACHINE_NAME=vm.name,
-		VIRTUAL_MACHINE_IPV6=address,
-	)
+		# --- 1. Sleep, and assert the trap is armed ---
+		vm.sleep()
+		vm.reload()
+		assert vm.status == "Sleeping", vm.status
+		assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+		assert_probe(
+			server_name,
+			"phase-is-parked",
+			timeout_seconds=60,
+			VIRTUAL_MACHINE_NAME=vm.name,
+			VIRTUAL_MACHINE_IPV6=address,
+		)
 
-	# --- 2. ICMP must NOT wake it (the rule matches `tcp flags`, so ping falls
-	#        through, is forwarded out the dummy, and is discarded) ---
-	subprocess.run(
-		["ping6", "-c", "3", "-W", "2", address],
-		capture_output=True,
-		check=False,
-	)
-	time.sleep(5)
-	assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
-	vm.reload()
-	assert vm.status == "Sleeping", f"ICMP woke the VM; the trap is not TCP-only ({vm.status})"
+		# --- 2. ICMP must NOT wake it (the rule matches `tcp flags`) ---
+		assert_probe(vantage_name, "phase-wake-ping", timeout_seconds=60, TARGET_IPV6=address)
+		time.sleep(5)
+		assert_probe(server_name, "phase7-is-sleeping", VIRTUAL_MACHINE_NAME=vm.name)
+		vm.reload()
+		assert vm.status == "Sleeping", f"ICMP woke the VM; the trap is not TCP-only ({vm.status})"
 
-	# --- 3. A TCP SYN DOES wake it. The first SYN is dropped by design, so the
-	#        connect fails and the kernel retransmits (~1s) into the resumed
-	#        guest; retry until the guest answers. ---
-	deadline = time.monotonic() + 120
-	connected = False
-	while time.monotonic() < deadline:
-		if _tcp_connect(address, 22, timeout=5):
-			connected = True
-			break
-		time.sleep(2)
-	assert connected, f"{address}:22 never answered after the SYN trap should have woken it"
+		# --- 3. A TCP SYN DOES wake it ---
+		assert_probe(
+			vantage_name,
+			"phase-wake-tcp",
+			timeout_seconds=200,
+			TARGET_IPV6=address,
+			TIMEOUT_SECONDS="150",
+		)
+		assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
+		assert_probe(
+			server_name,
+			"phase-is-unparked",
+			timeout_seconds=60,
+			VIRTUAL_MACHINE_NAME=vm.name,
+			VIRTUAL_MACHINE_IPV6=address,
+		)
 
-	assert_probe(server_name, "phase5-is-active", VIRTUAL_MACHINE_NAME=vm.name)
-	assert_probe(
-		server_name,
-		"phase-is-unparked",
-		timeout_seconds=60,
-		VIRTUAL_MACHINE_NAME=vm.name,
-		VIRTUAL_MACHINE_IPV6=address,
-	)
-
-	# --- 4. The DB catches up. The host woke the VM on its own; Atlas learns
-	#        about it from the per-minute reconcile, not from a Task. ---
-	from atlas.atlas.doctype.virtual_machine.virtual_machine import reconcile_sleeping_vms
-
-	reconcile_sleeping_vms()
-	vm.reload()
-	assert vm.status == "Running", f"reconcile did not adopt the host wake ({vm.status})"
-	assert not vm.has_memory_snapshot, "the wake consumed the memory snapshot"
-	assert vm.last_traffic_at, "adopting the wake must reset the idle clock"
-
-	vm.terminate()
+		# --- 4. The DB catches up. The host woke the VM on its own; Atlas learns
+		#        it from the per-minute reconcile, not from a Task. ---
+		reconcile_sleeping_vms()
+		vm.reload()
+		assert vm.status == "Running", f"reconcile did not adopt the host wake ({vm.status})"
+		assert not vm.has_memory_snapshot, "the wake consumed the memory snapshot"
+		assert vm.last_traffic_at, "adopting the wake must reset the idle clock"
+	finally:
+		vm.reload()
+		if vm.status != "Terminated":
+			vm.terminate()

--- a/atlas/tests/e2e/use_cases/sleepy_vms.py
+++ b/atlas/tests/e2e/use_cases/sleepy_vms.py
@@ -234,9 +234,7 @@ def _check_wake_on_inbound_tcp(server_name: str, vantage_name: str) -> None:
 			TARGET_IPV6=address,
 			TIMEOUT_SECONDS="150",
 		)
-		assert_probe(
-			server_name, "phase5-is-active", timeout_seconds=90, VIRTUAL_MACHINE_NAME=vm.name
-		)
+		assert_probe(server_name, "phase5-is-active", timeout_seconds=90, VIRTUAL_MACHINE_NAME=vm.name)
 		assert_probe(
 			server_name,
 			"phase-is-unparked",

--- a/atlas/tests/e2e/use_cases/tls_issuance.py
+++ b/atlas/tests/e2e/use_cases/tls_issuance.py
@@ -223,7 +223,9 @@ def _seed_dns_provider_settings(config: dict) -> None:
 	if config["dns_provider_type"] == "PowerDNS":
 		powerdns = config["powerdns"]
 		frappe.db.set_single_value("PowerDNS Settings", "api_url", powerdns["api_url"], update_modified=False)
-		frappe.db.set_single_value("PowerDNS Settings", "server_id", powerdns["server_id"], update_modified=False)
+		frappe.db.set_single_value(
+			"PowerDNS Settings", "server_id", powerdns["server_id"], update_modified=False
+		)
 		frappe.utils.password.set_encrypted_password(
 			"PowerDNS Settings", "PowerDNS Settings", powerdns["api_key"], "api_key"
 		)

--- a/atlas/tests/test_setup.py
+++ b/atlas/tests/test_setup.py
@@ -228,11 +228,11 @@ class TestSetupContract(IntegrationTestCase):
 
 	def test_tls_block_seeds_powerdns_le_and_root_domain(self) -> None:
 		setup.run(_do_config(tls=_POWERDNS_TLS_BLOCK))
-		self.assertEqual(frappe.db.get_single_value("PowerDNS Settings", "api_url"), "https://pdns.example.test")
-		self.assertEqual(frappe.db.get_single_value("PowerDNS Settings", "server_id"), "primary")
 		self.assertEqual(
-			get_secret("PowerDNS Settings", "PowerDNS Settings", "api_key"), "powerdns-secret"
+			frappe.db.get_single_value("PowerDNS Settings", "api_url"), "https://pdns.example.test"
 		)
+		self.assertEqual(frappe.db.get_single_value("PowerDNS Settings", "server_id"), "primary")
+		self.assertEqual(get_secret("PowerDNS Settings", "PowerDNS Settings", "api_key"), "powerdns-secret")
 		self.assertEqual(frappe.db.get_single_value("Atlas Settings", "dns_provider_type"), "PowerDNS")
 		self.assertEqual(frappe.db.get_single_value("Atlas Settings", "tls_provider_type"), "Let's Encrypt")
 		self.assertTrue(frappe.db.exists("Root Domain", "blr1.frappe.dev"))

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -496,3 +496,32 @@ class TestIdleClockSeeding(IntegrationTestCase):
 			vm_mod.sleep_idle_vms()
 		vm.reload()
 		self.assertEqual(vm.status, "Running", "a just-woken VM must survive the next idle sweep")
+
+
+class TestServerInsertWithoutSetup(IntegrationTestCase):
+	"""A Server must be insertable before Atlas Settings is fully configured.
+
+	Server.validate() saves the Atlas Settings Single to persist two lazily
+	generated ANCP secrets. That save used to enforce the Single's own mandatory
+	fields, so on any site that had not been through setup() — every fresh test
+	site — inserting a Server died with "Value missing for Atlas Settings:
+	Region", naming a field the caller never touched. It accounted for the bulk
+	of the suite's failures in CI.
+	"""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		self.provider = make_provider("sleepy-nosetup-provider")
+
+	def test_insert_succeeds_with_no_region_configured(self) -> None:
+		frappe.db.set_single_value("Atlas Settings", "region", "", update_modified=False)
+		server = make_server(
+			self.provider,
+			"sleepy-nosetup-server",
+			ipv4_address="10.0.95.1",
+			ipv6_address="2001:db8:95::1",
+			ipv6_prefix="2001:db8:95::/64",
+			ipv6_virtual_machine_range="2001:db8:95::/124",
+			status="Active",
+		)
+		self.assertIsNotNone(server.name)

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -13,7 +13,8 @@ Exercises:
 - fake_tasks: sleep-vm, poll-vm-traffic and probe-woken-vms result builders
 
 The host-side wake trap itself (park/unpark, the atlas-wake-trap daemon) is
-covered by scripts/lib/atlas/test_park.py and atlas/tests/test_wake_trap.py.
+covered by scripts/lib/atlas/test_{park,wake_trap}.py — bare unittest, since the
+Frappe app shares the `atlas` name with the scripts package they import.
 """
 
 import json

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -215,7 +215,7 @@ class TestSleepyVmsFakeTasks(IntegrationTestCase):
 
 	def setUp(self) -> None:
 		_clean_virtual_machines()
-		from atlas.atlas.providers.fake_tasks import _sleep_vm_result, _poll_vm_traffic_result
+		from atlas.atlas.providers.fake_tasks import _poll_vm_traffic_result, _sleep_vm_result
 
 		self._sleep_vm_result = _sleep_vm_result
 		self._poll_vm_traffic_result = _poll_vm_traffic_result

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -324,3 +324,103 @@ class TestReconcileSleepingVms(IntegrationTestCase):
 		with patch.object(vm_mod, "run_task") as mocked:
 			vm_mod.reconcile_sleeping_vms()
 		mocked.assert_not_called()
+
+
+class TestIdleClockSeeding(IntegrationTestCase):
+	"""last_traffic_at is stamped at provision/start/wake (spec/32).
+
+	Every transition into Running must reset the idle clock. A VM that slept did
+	so *because* last_traffic_at was older than idle_timeout_seconds, so waking it
+	without re-stamping leaves the field stale and the very next sleep_idle_vms
+	tick — within a minute — puts it straight back to sleep.
+	"""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		self.provider = make_provider("sleepy-clock-provider")
+		self.server = make_server(
+			self.provider,
+			"sleepy-clock-server",
+			ipv4_address="10.0.96.1",
+			ipv6_address="2001:db8:96::1",
+			ipv6_prefix="2001:db8:96::/64",
+			ipv6_virtual_machine_range="2001:db8:96::/124",
+			status="Active",
+		)
+		self.image = make_image("sleepy-clock-image")
+
+	def _stale_vm(self, status: str) -> frappe.model.document.Document:
+		"""A sleep_on_idle VM whose idle clock is already well past its timeout."""
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
+		)
+		vm.db_set("status", status)
+		vm.db_set("last_traffic_at", frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1))
+		vm.reload()
+		return vm
+
+	def _fake_task(self):
+		"""A Task stub whose stdout parses as a real sleep-vm result.
+
+		It must: sleep() does `parse_result(task.stdout)["memory_snapshot"]`, and
+		sleep_idle_vms swallows exceptions — so an unparseable stdout would make a
+		re-sleep look like a pass in test_woken_vm_is_not_immediately_re_slept.
+		"""
+		from types import SimpleNamespace
+
+		return SimpleNamespace(name="t", stdout='ATLAS_RESULT={"memory_snapshot": true}\n')
+
+	def test_wake_refreshes_the_idle_clock(self) -> None:
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._stale_vm("Sleeping")
+		before = vm.last_traffic_at
+		with patch.object(vm_mod, "run_task", return_value=self._fake_task()):
+			vm.wake()
+		vm.reload()
+		self.assertEqual(vm.status, "Running")
+		self.assertGreater(vm.last_traffic_at, before, "wake() must reset the idle clock")
+
+	def test_start_refreshes_the_idle_clock(self) -> None:
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._stale_vm("Stopped")
+		before = vm.last_traffic_at
+		with patch.object(vm_mod, "run_task", return_value=self._fake_task()):
+			vm.start()
+		vm.reload()
+		self.assertEqual(vm.status, "Running")
+		self.assertGreater(vm.last_traffic_at, before, "start() must reset the idle clock")
+
+	def test_provision_seeds_the_idle_clock(self) -> None:
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
+		)
+		vm.db_set("status", "Pending")
+		vm.db_set("last_traffic_at", None)
+		vm.reload()
+		with patch.object(vm_mod, "run_task", return_value=self._fake_task()):
+			vm.provision()
+		vm.reload()
+		self.assertIsNotNone(vm.last_traffic_at, "a fresh VM must start with a seeded idle clock")
+
+	def test_woken_vm_is_not_immediately_re_slept(self) -> None:
+		"""The regression this guards: wake() then the very next idle sweep."""
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._stale_vm("Sleeping")
+		with patch.object(vm_mod, "run_task", return_value=self._fake_task()):
+			vm.wake()
+			vm_mod.sleep_idle_vms()
+		vm.reload()
+		self.assertEqual(vm.status, "Running", "a just-woken VM must survive the next idle sweep")

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -190,6 +190,16 @@ class TestSleepyVmsLifecycle(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			vm.sleep()
 
+	def test_migration_rejects_a_sleeping_vm_by_name(self) -> None:
+		"""spec/32: the memory snapshot is not transportable, so migration from
+		Sleeping is refused — and says which action unblocks it."""
+		from atlas.atlas.migration import preflight_checks
+
+		vm = self._make_sleeping_vm()
+		with self.assertRaises(frappe.ValidationError) as caught:
+			preflight_checks(vm, self.server.name, release_reserved_ip=False)
+		self.assertIn("wake or stop", str(caught.exception).lower())
+
 	def test_wake_from_non_sleeping_throws(self) -> None:
 		vm = make_virtual_machine(
 			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -75,9 +75,7 @@ class TestSleepyVmsCapacity(IntegrationTestCase):
 
 	def test_running_and_sleeping_vms_mixed(self) -> None:
 		make_virtual_machine(self.server, self.image, memory_megabytes=512, disk_gigabytes=10)
-		sleeping = make_virtual_machine(
-			self.server, self.image, memory_megabytes=1024, disk_gigabytes=20
-		)
+		sleeping = make_virtual_machine(self.server, self.image, memory_megabytes=1024, disk_gigabytes=20)
 		sleeping.db_set("status", "Sleeping")
 		result = server_capacity.capacity_for_server(self.server.name)
 		self.assertEqual(result["memory"]["used"], 512, "only running VM's RAM counted")
@@ -85,13 +83,9 @@ class TestSleepyVmsCapacity(IntegrationTestCase):
 		self.assertEqual(result["virtual_machine_count"], 1, "only running VM in resident count")
 
 	def test_terminated_and_sleeping_vm_disk_exclusion(self) -> None:
-		terminated = make_virtual_machine(
-			self.server, self.image, memory_megabytes=512, disk_gigabytes=50
-		)
+		terminated = make_virtual_machine(self.server, self.image, memory_megabytes=512, disk_gigabytes=50)
 		terminated.db_set("status", "Terminated")
-		sleeping = make_virtual_machine(
-			self.server, self.image, memory_megabytes=512, disk_gigabytes=10
-		)
+		sleeping = make_virtual_machine(self.server, self.image, memory_megabytes=512, disk_gigabytes=10)
 		sleeping.db_set("status", "Sleeping")
 		result = server_capacity.capacity_for_server(self.server.name)
 		self.assertEqual(result["disk"]["used"], 10, "only sleeping VM disk counted; terminated excluded")
@@ -116,33 +110,27 @@ class TestSleepyVmsLifecycle(IntegrationTestCase):
 		self.image = make_image("sleepy-lc-image")
 
 	def _make_sleeping_vm(self, **overrides) -> frappe.model.document.Document:
-		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120, **overrides)
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120, **overrides
+		)
 		vm.db_set("status", "Sleeping")
 		vm.reload()
 		return vm
 
 	def test_validate_rejects_timeout_below_120(self) -> None:
 		with self.assertRaises(frappe.ValidationError):
-			make_virtual_machine(
-				self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=60
-			)
+			make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=60)
 
 	def test_validate_rejects_zero_timeout_with_sleep_on_idle(self) -> None:
 		with self.assertRaises(frappe.ValidationError):
-			make_virtual_machine(
-				self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=0
-			)
+			make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=0)
 
 	def test_validate_allows_120_seconds(self) -> None:
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120)
 		self.assertIsNotNone(vm.name)
 
 	def test_validate_allows_no_timeout_when_sleep_on_idle_off(self) -> None:
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=0, idle_timeout_seconds=0
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=0, idle_timeout_seconds=0)
 		self.assertIsNotNone(vm.name)
 
 	def test_stop_from_sleeping_throws(self) -> None:
@@ -182,9 +170,7 @@ class TestSleepyVmsLifecycle(IntegrationTestCase):
 			vm.sleep()
 
 	def test_sleep_from_non_running_throws(self) -> None:
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300)
 		vm.db_set("status", "Stopped")
 		vm.reload()
 		with self.assertRaises(frappe.ValidationError):
@@ -201,9 +187,7 @@ class TestSleepyVmsLifecycle(IntegrationTestCase):
 		self.assertIn("wake or stop", str(caught.exception).lower())
 
 	def test_wake_from_non_sleeping_throws(self) -> None:
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300)
 		vm.db_set("status", "Running")
 		vm.reload()
 		with self.assertRaises(frappe.ValidationError):
@@ -363,12 +347,8 @@ class TestReconcileSleepingVms(IntegrationTestCase):
 		with patch.object(vm_mod, "run_probe", return_value=stdout) as mocked:
 			vm_mod.poll_vm_traffic()
 
-		self.assertGreater(
-			frappe.db.get_value("Virtual Machine", active.name, "last_traffic_at"), stale
-		)
-		self.assertEqual(
-			frappe.db.get_value("Virtual Machine", idle.name, "last_traffic_at"), stale
-		)
+		self.assertGreater(frappe.db.get_value("Virtual Machine", active.name, "last_traffic_at"), stale)
+		self.assertEqual(frappe.db.get_value("Virtual Machine", idle.name, "last_traffic_at"), stale)
 		_, kwargs = mocked.call_args
 		self.assertEqual(kwargs.get("script"), "poll-vm-traffic")
 		self.assertNotIn("virtual_machine", kwargs, "run_probe is server-scoped")
@@ -418,9 +398,7 @@ class TestIdleClockSeeding(IntegrationTestCase):
 
 	def _stale_vm(self, status: str) -> frappe.model.document.Document:
 		"""A sleep_on_idle VM whose idle clock is already well past its timeout."""
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120)
 		vm.db_set("status", status)
 		vm.db_set("last_traffic_at", frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1))
 		vm.reload()
@@ -468,9 +446,7 @@ class TestIdleClockSeeding(IntegrationTestCase):
 
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
 
-		vm = make_virtual_machine(
-			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
-		)
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120)
 		vm.db_set("status", "Pending")
 		vm.db_set("last_traffic_at", None)
 		vm.reload()

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -1,0 +1,225 @@
+"""Unit tests for the Sleepy VMs feature.
+
+Exercises:
+- sleep_on_idle validate constraint (idle_timeout_seconds >= 120)
+- start() from Sleeping delegates to wake()
+- stop() from Sleeping throws
+- snapshot() from Sleeping throws
+- Capacity accounting: Sleeping excluded from RAM/CPU axes, included in disk
+- poll_vm_traffic() and sleep_idle_vms() scheduler functions
+- fake_tasks: sleep-vm and poll-vm-traffic result builders
+"""
+
+import json
+
+import frappe
+import frappe.model.document
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas.api import server_capacity
+from atlas.tests.fixtures import make_image, make_provider, make_server, make_virtual_machine
+
+
+def _clean_virtual_machines() -> None:
+	for name in frappe.get_all("Virtual Machine", pluck="name"):
+		frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+
+class TestSleepyVmsCapacity(IntegrationTestCase):
+	"""Sleeping VMs are excluded from RAM/CPU axes but still charged for disk."""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		frappe.db.set_single_value("Atlas Settings", "host_memory_reserve_megabytes", 0)
+		frappe.db.set_single_value("Atlas Settings", "overprovision_factor", 1)
+		self.provider = make_provider("sleepy-cap-provider")
+		self.server = make_server(
+			self.provider,
+			"sleepy-cap-server",
+			ipv4_address="10.0.99.1",
+			ipv6_address="2001:db8:99::1",
+			ipv6_prefix="2001:db8:99::/64",
+			ipv6_virtual_machine_range="2001:db8:99::/124",
+			status="Active",
+		)
+		self.server.db_set("memory_megabytes_total", 4096)
+		self.server.db_set("pool_disk_gigabytes_total", 100)
+		self.image = make_image("sleepy-cap-image")
+
+	def test_sleeping_vm_excluded_from_memory_used(self) -> None:
+		vm = make_virtual_machine(self.server, self.image, memory_megabytes=512, disk_gigabytes=10)
+		vm.db_set("status", "Sleeping")
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["memory"]["used"], 0, "sleeping VM's RAM should not count")
+
+	def test_sleeping_vm_excluded_from_cpu_used(self) -> None:
+		vm = make_virtual_machine(self.server, self.image, vcpus=2, memory_megabytes=512, disk_gigabytes=5)
+		vm.db_set("status", "Sleeping")
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["cpu"]["used"], 0, "sleeping VM's CPU should not count")
+
+	def test_sleeping_vm_still_charged_for_disk(self) -> None:
+		vm = make_virtual_machine(
+			self.server, self.image, memory_megabytes=512, disk_gigabytes=10, data_disk_gigabytes=5
+		)
+		vm.db_set("status", "Sleeping")
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["disk"]["used"], 15, "sleeping VM's disk is still allocated")
+
+	def test_running_and_sleeping_vms_mixed(self) -> None:
+		make_virtual_machine(self.server, self.image, memory_megabytes=512, disk_gigabytes=10)
+		sleeping = make_virtual_machine(
+			self.server, self.image, memory_megabytes=1024, disk_gigabytes=20
+		)
+		sleeping.db_set("status", "Sleeping")
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["memory"]["used"], 512, "only running VM's RAM counted")
+		self.assertEqual(result["disk"]["used"], 30, "both VMs' disk counted")
+		self.assertEqual(result["virtual_machine_count"], 1, "only running VM in resident count")
+
+	def test_terminated_and_sleeping_vm_disk_exclusion(self) -> None:
+		terminated = make_virtual_machine(
+			self.server, self.image, memory_megabytes=512, disk_gigabytes=50
+		)
+		terminated.db_set("status", "Terminated")
+		sleeping = make_virtual_machine(
+			self.server, self.image, memory_megabytes=512, disk_gigabytes=10
+		)
+		sleeping.db_set("status", "Sleeping")
+		result = server_capacity.capacity_for_server(self.server.name)
+		self.assertEqual(result["disk"]["used"], 10, "only sleeping VM disk counted; terminated excluded")
+		self.assertEqual(result["memory"]["used"], 0, "neither terminated nor sleeping count for RAM")
+
+
+class TestSleepyVmsLifecycle(IntegrationTestCase):
+	"""VM controller guards for the Sleeping status."""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		self.provider = make_provider("sleepy-lc-provider")
+		self.server = make_server(
+			self.provider,
+			"sleepy-lc-server",
+			ipv4_address="10.0.98.1",
+			ipv6_address="2001:db8:98::1",
+			ipv6_prefix="2001:db8:98::/64",
+			ipv6_virtual_machine_range="2001:db8:98::/124",
+			status="Active",
+		)
+		self.image = make_image("sleepy-lc-image")
+
+	def _make_sleeping_vm(self, **overrides) -> frappe.model.document.Document:
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120, **overrides)
+		vm.db_set("status", "Sleeping")
+		vm.reload()
+		return vm
+
+	def test_validate_rejects_timeout_below_120(self) -> None:
+		with self.assertRaises(frappe.ValidationError):
+			make_virtual_machine(
+				self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=60
+			)
+
+	def test_validate_rejects_zero_timeout_with_sleep_on_idle(self) -> None:
+		with self.assertRaises(frappe.ValidationError):
+			make_virtual_machine(
+				self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=0
+			)
+
+	def test_validate_allows_120_seconds(self) -> None:
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120
+		)
+		self.assertIsNotNone(vm.name)
+
+	def test_validate_allows_no_timeout_when_sleep_on_idle_off(self) -> None:
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=0, idle_timeout_seconds=0
+		)
+		self.assertIsNotNone(vm.name)
+
+	def test_stop_from_sleeping_throws(self) -> None:
+		vm = self._make_sleeping_vm()
+		with self.assertRaises(frappe.ValidationError):
+			vm.stop()
+
+	def test_snapshot_from_sleeping_throws(self) -> None:
+		vm = self._make_sleeping_vm()
+		with self.assertRaises(frappe.ValidationError):
+			vm.snapshot()
+
+	def test_snapshot_live_from_sleeping_throws(self) -> None:
+		vm = self._make_sleeping_vm()
+		with self.assertRaises(frappe.ValidationError):
+			vm.snapshot(live=True)
+
+	def test_start_from_sleeping_calls_wake(self) -> None:
+		"""start() from Sleeping must delegate to wake(), not throw."""
+		vm = self._make_sleeping_vm()
+		wake_calls = []
+
+		def _capture_wake():
+			wake_calls.append(True)
+			return "fake-task"
+
+		vm.wake = _capture_wake
+		result = vm.start()
+		self.assertEqual(result, "fake-task")
+		self.assertEqual(len(wake_calls), 1, "start() must delegate to wake() from Sleeping")
+
+	def test_sleep_requires_sleep_on_idle(self) -> None:
+		vm = make_virtual_machine(self.server, self.image, sleep_on_idle=0, idle_timeout_seconds=0)
+		vm.db_set("status", "Running")
+		vm.reload()
+		with self.assertRaises(frappe.ValidationError):
+			vm.sleep()
+
+	def test_sleep_from_non_running_throws(self) -> None:
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300
+		)
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with self.assertRaises(frappe.ValidationError):
+			vm.sleep()
+
+	def test_wake_from_non_sleeping_throws(self) -> None:
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=300
+		)
+		vm.db_set("status", "Running")
+		vm.reload()
+		with self.assertRaises(frappe.ValidationError):
+			vm.wake()
+
+
+class TestSleepyVmsFakeTasks(IntegrationTestCase):
+	"""sleep-vm and poll-vm-traffic use the Fake task seam correctly."""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		from atlas.atlas.providers.fake_tasks import _sleep_vm_result, _poll_vm_traffic_result
+
+		self._sleep_vm_result = _sleep_vm_result
+		self._poll_vm_traffic_result = _poll_vm_traffic_result
+
+	def test_sleep_vm_result_has_memory_snapshot_true(self) -> None:
+		result = self._sleep_vm_result({})
+		self.assertTrue(result["memory_snapshot"])
+		self.assertIn("memory_snapshot_bytes", result)
+		self.assertIn("reason", result)
+
+	def test_poll_vm_traffic_result_has_active_false_per_vm(self) -> None:
+		vms = [{"name": "vm-1"}, {"name": "vm-2"}]
+		result = self._poll_vm_traffic_result({"VMS_JSON": json.dumps(vms)})
+		self.assertIn("counters", result)
+		self.assertFalse(result["counters"]["vm-1"]["active"])
+		self.assertFalse(result["counters"]["vm-2"]["active"])
+
+	def test_poll_vm_traffic_result_empty_vms_json(self) -> None:
+		result = self._poll_vm_traffic_result({})
+		self.assertEqual(result["counters"], {})
+
+	def test_poll_vm_traffic_result_bad_json_returns_empty(self) -> None:
+		result = self._poll_vm_traffic_result({"VMS_JSON": "not-json"})
+		self.assertEqual(result["counters"], {})

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -1,13 +1,19 @@
-"""Unit tests for the Sleepy VMs feature.
+"""Unit tests for the Sleepy VMs feature (spec/32).
 
 Exercises:
 - sleep_on_idle validate constraint (idle_timeout_seconds >= 120)
 - start() from Sleeping delegates to wake()
-- stop() from Sleeping throws
-- snapshot() from Sleeping throws
+- stop() / snapshot() from Sleeping throw
 - Capacity accounting: Sleeping excluded from RAM/CPU axes, included in disk
-- poll_vm_traffic() and sleep_idle_vms() scheduler functions
-- fake_tasks: sleep-vm and poll-vm-traffic result builders
+- poll_vm_traffic() and sleep_idle_vms() scheduler functions, over the
+  non-persisting run_probe path (no Task rows for the per-minute sweeps)
+- reconcile_sleeping_vms() / _adopt_wake(): adopting a host-initiated
+  (packet-triggered) wake into the DB, race-safe against an operator wake()
+- The idle clock is reset on every transition into Running (provision/start/wake)
+- fake_tasks: sleep-vm, poll-vm-traffic and probe-woken-vms result builders
+
+The host-side wake trap itself (park/unpark, the atlas-wake-trap daemon) is
+covered by scripts/lib/atlas/test_park.py and atlas/tests/test_wake_trap.py.
 """
 
 import json
@@ -287,41 +293,91 @@ class TestReconcileSleepingVms(IntegrationTestCase):
 		self.assertEqual(vm.status, "Running")
 
 	def test_reconcile_adopts_woken_vm(self) -> None:
-		from types import SimpleNamespace
 		from unittest.mock import patch
 
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
 
 		vm = self._sleeping_vm()
-		task = SimpleNamespace(name="t", stdout=self._probe_stdout({vm.name: True}))
-		with patch.object(vm_mod, "run_task", return_value=task) as mocked:
+		stdout = self._probe_stdout({vm.name: True})
+		with patch.object(vm_mod, "run_probe", return_value=stdout) as mocked:
 			vm_mod.reconcile_sleeping_vms()
 		vm.reload()
 		self.assertEqual(vm.status, "Running")
-		# Server-scoped probe: no VM FK, the probe-woken-vms verb.
+		# Server-scoped probe on the non-persisting path: the probe-woken-vms verb,
+		# via run_probe so the per-minute sweep records no Task row.
 		_, kwargs = mocked.call_args
-		self.assertIsNone(kwargs.get("virtual_machine"))
 		self.assertEqual(kwargs.get("script"), "probe-woken-vms")
+		self.assertNotIn("virtual_machine", kwargs, "run_probe is server-scoped")
 
 	def test_reconcile_leaves_unwoken_vm_sleeping(self) -> None:
-		from types import SimpleNamespace
 		from unittest.mock import patch
 
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
 
 		vm = self._sleeping_vm()
-		task = SimpleNamespace(name="t", stdout=self._probe_stdout({vm.name: False}))
-		with patch.object(vm_mod, "run_task", return_value=task):
+		stdout = self._probe_stdout({vm.name: False})
+		with patch.object(vm_mod, "run_probe", return_value=stdout):
 			vm_mod.reconcile_sleeping_vms()
 		vm.reload()
 		self.assertEqual(vm.status, "Sleeping")
+
+	def test_reconcile_tolerates_a_failed_probe(self) -> None:
+		"""run_probe returns "" on failure rather than raising; the VM stays put."""
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		with patch.object(vm_mod, "run_probe", return_value=""):
+			vm_mod.reconcile_sleeping_vms()
+		vm.reload()
+		self.assertEqual(vm.status, "Sleeping")
+
+	def test_poll_vm_traffic_stamps_active_vms(self) -> None:
+		"""An active VM gets a fresh last_traffic_at; an idle one is left alone."""
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		active = self._sleeping_vm()
+		idle = self._sleeping_vm()
+		for vm in (active, idle):
+			vm.db_set("status", "Running")
+			vm.db_set("last_traffic_at", frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1))
+		stale = frappe.db.get_value("Virtual Machine", idle.name, "last_traffic_at")
+
+		stdout = "ATLAS_RESULT=" + json.dumps(
+			{"counters": {active.name: {"active": True}, idle.name: {"active": False}}}
+		)
+		with patch.object(vm_mod, "run_probe", return_value=stdout) as mocked:
+			vm_mod.poll_vm_traffic()
+
+		self.assertGreater(
+			frappe.db.get_value("Virtual Machine", active.name, "last_traffic_at"), stale
+		)
+		self.assertEqual(
+			frappe.db.get_value("Virtual Machine", idle.name, "last_traffic_at"), stale
+		)
+		_, kwargs = mocked.call_args
+		self.assertEqual(kwargs.get("script"), "poll-vm-traffic")
+		self.assertNotIn("virtual_machine", kwargs, "run_probe is server-scoped")
+
+	def test_poll_vm_traffic_tolerates_a_failed_probe(self) -> None:
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		vm.db_set("status", "Running")
+		with patch.object(vm_mod, "run_probe", return_value=""):
+			vm_mod.poll_vm_traffic()  # must not raise
 
 	def test_reconcile_no_sleeping_vms_skips_ssh(self) -> None:
 		from unittest.mock import patch
 
 		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
 
-		with patch.object(vm_mod, "run_task") as mocked:
+		with patch.object(vm_mod, "run_probe") as mocked:
 			vm_mod.reconcile_sleeping_vms()
 		mocked.assert_not_called()
 

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -223,3 +223,104 @@ class TestSleepyVmsFakeTasks(IntegrationTestCase):
 	def test_poll_vm_traffic_result_bad_json_returns_empty(self) -> None:
 		result = self._poll_vm_traffic_result({"VMS_JSON": "not-json"})
 		self.assertEqual(result["counters"], {})
+
+	def test_probe_woken_vms_result_reports_none_woken(self) -> None:
+		from atlas.atlas.providers.fake_tasks import _probe_woken_vms_result
+
+		result = _probe_woken_vms_result({"VMS_JSON": json.dumps(["u1", "u2"])})
+		self.assertEqual(result["woken"], {"u1": False, "u2": False})
+
+	def test_probe_woken_vms_result_bad_json_returns_empty(self) -> None:
+		from atlas.atlas.providers.fake_tasks import _probe_woken_vms_result
+
+		self.assertEqual(_probe_woken_vms_result({"VMS_JSON": "not-json"}), {"woken": {}})
+
+
+class TestReconcileSleepingVms(IntegrationTestCase):
+	"""reconcile_sleeping_vms() adopts a host-initiated (packet-triggered) wake into
+	the Frappe status, race-safe against an operator wake()."""
+
+	def setUp(self) -> None:
+		_clean_virtual_machines()
+		self.provider = make_provider("sleepy-rec-provider")
+		self.server = make_server(
+			self.provider,
+			"sleepy-rec-server",
+			ipv4_address="10.0.97.1",
+			ipv6_address="2001:db8:97::1",
+			ipv6_prefix="2001:db8:97::/64",
+			ipv6_virtual_machine_range="2001:db8:97::/124",
+			status="Active",
+		)
+		self.image = make_image("sleepy-rec-image")
+
+	def _sleeping_vm(self, **overrides) -> frappe.model.document.Document:
+		vm = make_virtual_machine(
+			self.server, self.image, sleep_on_idle=1, idle_timeout_seconds=120, **overrides
+		)
+		vm.db_set("status", "Sleeping")
+		vm.reload()
+		return vm
+
+	def _probe_stdout(self, woken: dict) -> str:
+		return "ATLAS_RESULT=" + json.dumps({"woken": woken}) + "\n"
+
+	def test_adopt_wake_flips_sleeping_to_running(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		vm.db_set("has_memory_snapshot", 1)
+		vm_mod._adopt_wake(vm.name, frappe.utils.now_datetime())
+		vm.reload()
+		self.assertEqual(vm.status, "Running")
+		self.assertEqual(vm.has_memory_snapshot, 0, "the wake consumed the snapshot")
+		self.assertIsNotNone(vm.last_started)
+		self.assertIsNotNone(vm.last_traffic_at, "fresh so sleep_idle_vms won't re-sleep it")
+
+	def test_adopt_wake_noop_when_operator_wake_won_the_race(self) -> None:
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		vm.db_set("status", "Running")  # operator wake() already flipped it
+		vm_mod._adopt_wake(vm.name, frappe.utils.now_datetime())  # must not throw
+		vm.reload()
+		self.assertEqual(vm.status, "Running")
+
+	def test_reconcile_adopts_woken_vm(self) -> None:
+		from types import SimpleNamespace
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		task = SimpleNamespace(name="t", stdout=self._probe_stdout({vm.name: True}))
+		with patch.object(vm_mod, "run_task", return_value=task) as mocked:
+			vm_mod.reconcile_sleeping_vms()
+		vm.reload()
+		self.assertEqual(vm.status, "Running")
+		# Server-scoped probe: no VM FK, the probe-woken-vms verb.
+		_, kwargs = mocked.call_args
+		self.assertIsNone(kwargs.get("virtual_machine"))
+		self.assertEqual(kwargs.get("script"), "probe-woken-vms")
+
+	def test_reconcile_leaves_unwoken_vm_sleeping(self) -> None:
+		from types import SimpleNamespace
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._sleeping_vm()
+		task = SimpleNamespace(name="t", stdout=self._probe_stdout({vm.name: False}))
+		with patch.object(vm_mod, "run_task", return_value=task):
+			vm_mod.reconcile_sleeping_vms()
+		vm.reload()
+		self.assertEqual(vm.status, "Sleeping")
+
+	def test_reconcile_no_sleeping_vms_skips_ssh(self) -> None:
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		with patch.object(vm_mod, "run_task") as mocked:
+			vm_mod.reconcile_sleeping_vms()
+		mocked.assert_not_called()

--- a/atlas/tests/test_sleepy_vms.py
+++ b/atlas/tests/test_sleepy_vms.py
@@ -455,6 +455,35 @@ class TestIdleClockSeeding(IntegrationTestCase):
 		vm.reload()
 		self.assertIsNotNone(vm.last_traffic_at, "a fresh VM must start with a seeded idle clock")
 
+	def test_traffic_arriving_mid_sweep_cancels_the_sleep(self) -> None:
+		"""sleep_idle_vms batch-reads, then decides. A poll that stamps
+		last_traffic_at in between must cancel the sleep, not be ignored."""
+		from unittest.mock import patch
+
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as vm_mod
+
+		vm = self._stale_vm("Running")
+
+		original_get_value = frappe.db.get_value
+		fired = []
+
+		def _became_active(*args, **kwargs):
+			# Stand in for poll_vm_traffic landing between the batch read and the
+			# per-VM decision. Fires once, on the sweep's re-read.
+			if not fired:
+				fired.append(True)
+				frappe.db.set_value(
+					"Virtual Machine", vm.name, "last_traffic_at", frappe.utils.now_datetime()
+				)
+			return original_get_value(*args, **kwargs)
+
+		with patch.object(frappe.db, "get_value", side_effect=_became_active):
+			with patch.object(vm_mod, "run_task", return_value=self._fake_task()) as task:
+				vm_mod.sleep_idle_vms()
+		task.assert_not_called()
+		vm.reload()
+		self.assertEqual(vm.status, "Running", "an active VM must not be slept")
+
 	def test_woken_vm_is_not_immediately_re_slept(self) -> None:
 		"""The regression this guards: wake() then the very next idle sweep."""
 		from unittest.mock import patch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,11 @@ ignore = [
 ]
 typing-modules = ["frappe.types.DF"]
 # The placement/capacity docs use typographic − (minus) and × (times) in math
-# expressions (e.g. "total − reserve", "2 GB × cores"); whitelist just those two
-# confusables so RUF001/002/003 don't flag the intentional notation.
-allowed-confusables = ["−", "×"]
+# expressions (e.g. "total − reserve", "2 GB × cores"), and the ANCP notes use ∪
+# (set union) for key-set composition (e.g. "seeds ∪ persisted-membership-keys");
+# whitelist just those confusables so RUF001/002/003 don't flag the intentional
+# notation.
+allowed-confusables = ["−", "×", "∪"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/atlas-wake-trap.py
+++ b/scripts/atlas-wake-trap.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Always-on host daemon: wake a Sleeping VM when it receives an inbound TCP SYN
+# (spec/32-sleepy-vms.md). The wake side of the "parked" reachability atlas.park
+# installs on sleep — see that module for the network mechanics.
+#
+# A sleeping VM's /128 is parked: proxy-NDP keeps the host answering for it, an
+# off-link route sends inbound packets through `inet atlas forward`, and one rule
+# there counts + DROPs a connection-opening TCP SYN into a named counter
+# `wake_<uuid>`. This daemon polls those named counters ~once a second; the first
+# SYN to a still-sleeping VM makes its counter non-zero, and we do the local wake —
+# exactly wake-vm.py's two steps (remove the marker, start the unit). The started
+# unit's vm-network-up.py unparks (removing the rule + counter + route) and
+# vm-restore.py resumes from the snapshot, so the client's retransmitted SYN
+# reaches the live guest.
+#
+# Why a counter poll and not NFQUEUE/NFLOG: it needs no new host dependency (it
+# reuses `nft -j` from the stdlib, like poll-vm-traffic.py). The SYN is dropped and
+# the client retransmits, so we only have to DETECT the SYN within ~1s, not deliver
+# it. The read is untraced (trace=False) so a per-second poll never floods the
+# journal; the rare wake action is traced.
+#
+# systemd-invoked (atlas-wake-trap.service), NOT a Task: it takes no arguments and
+# runs forever. It imports the DURABLE atlas package under /var/lib/atlas/bin
+# (placed by bootstrap), like the other systemd hooks.
+
+import json
+import os
+import sys
+import time
+
+# The durable package lives next to this script under /var/lib/atlas/bin.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from atlas._run import run
+from atlas.park import ensure_park_device, park, uuid_for_counter
+from atlas.paths import VIRTUAL_MACHINES_DIRECTORY, VirtualMachinePaths
+
+# ~1s: an interactive SSH SYN retransmits after its initial RTO (~1s on Linux), so
+# detecting within a second lets the retransmit land on the just-woken guest.
+POLL_SECONDS = 1.0
+
+
+def main() -> None:
+	# A sleeping VM's unit is suppressed on reboot (ConditionPathNotExists), so
+	# vm-network-up never runs and the park state is gone — rebuild it from the
+	# on-disk markers before the poll loop, DB-free, like atlas-pool.service
+	# re-asserts the pool.
+	_resweep_parked_vms()
+	while True:
+		try:
+			_tick()
+		except Exception as error:  # a bad tick must never kill the daemon
+			print(f"atlas-wake-trap: tick error: {error}", file=sys.stderr, flush=True)
+		time.sleep(POLL_SECONDS)
+
+
+def _tick() -> None:
+	for uuid, packets in _wake_counters().items():
+		if packets <= 0:
+			continue
+		paths = VirtualMachinePaths(uuid)
+		if not os.path.exists(paths.sleeping_marker):
+			# Already woken (an operator Start, or a previous tick): vm-network-up
+			# removes the counter as it rebuilds the real path, so a lingering count
+			# here is stale. The marker is the authority that the VM is still asleep.
+			continue
+		try:
+			_wake(paths)
+		except Exception as error:  # one VM's failed wake must not skip the others
+			print(f"atlas-wake-trap: wake {uuid} failed: {error}", file=sys.stderr, flush=True)
+
+
+def _wake(paths: VirtualMachinePaths) -> None:
+	"""The local wake — exactly wake-vm.py's two steps. Remove the marker FIRST so a
+	reboot between the steps leaves nothing suppressing the unit; `systemctl start`
+	then runs vm-network-up (which unparks) and vm-restore (fast resume). Both steps
+	are idempotent, so a concurrent operator wake() or a second tick is harmless."""
+	print(f"atlas-wake-trap: waking {paths.uuid} (inbound TCP SYN)", flush=True)
+	run("sudo rm -f {}", paths.sleeping_marker)
+	run("sudo systemctl start {}", paths.systemd_unit)
+
+
+def _wake_counters() -> dict[str, int]:
+	"""Map VM uuid -> packet count for every `wake_<hex>` named counter in the atlas
+	table. Untraced (trace=False) — this runs every second. Tolerates a missing
+	table / malformed JSON (returns {})."""
+	output = run("sudo nft -j list counters table inet atlas", check=False, quiet=True, trace=False)
+	counters: dict[str, int] = {}
+	try:
+		data = json.loads(output)
+	except (json.JSONDecodeError, ValueError, TypeError):
+		return counters
+	for item in data.get("nftables", []):
+		counter = item.get("counter") if isinstance(item, dict) else None
+		if not counter:
+			continue
+		uuid = uuid_for_counter(str(counter.get("name", "")))
+		if uuid is not None:
+			counters[uuid] = int(counter.get("packets", 0))
+	return counters
+
+
+def _resweep_parked_vms() -> None:
+	"""Re-establish park state for every VM still marked sleeping (and the shared
+	atlas-park0 device) at daemon boot. Best-effort per VM: one failure must not
+	stop the others or the poll loop."""
+	try:
+		ensure_park_device()
+	except Exception as error:
+		print(f"atlas-wake-trap: ensure atlas-park0 failed: {error}", file=sys.stderr, flush=True)
+	for uuid in _sleeping_uuids():
+		try:
+			park(uuid)
+		except Exception as error:
+			print(f"atlas-wake-trap: re-park {uuid} failed: {error}", file=sys.stderr, flush=True)
+
+
+def _sleeping_uuids() -> list[str]:
+	"""Every VM directory that still carries a `sleeping` marker — the DB-free set
+	of parked VMs to re-assert after a reboot."""
+	try:
+		entries = os.listdir(VIRTUAL_MACHINES_DIRECTORY)
+	except OSError:
+		return []
+	return [uuid for uuid in entries if os.path.exists(VirtualMachinePaths(uuid).sleeping_marker)]
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -398,6 +398,17 @@ def main() -> None:
 			"{ type filter hook forward priority filter; policy accept; }",
 		)
 
+	# 9-park. The shared always-up dummy every SLEEPING VM's /128 routes out (spec/32
+	#     sleepy VMs). Parking a sleeping VM keeps its /128 reachable and routes it
+	#     off-link out this device so an inbound TCP SYN is FORWARDED (hits the forward
+	#     hook, where atlas.park's wake rule traps it) with no running guest. A dummy
+	#     never carries real traffic — it only gives the parked route a valid, always-up
+	#     next hop. atlas.park.ensure_park_device() re-creates it after a reboot; kept by
+	#     reset-server (bootstrap floor, like the nft scaffold). Idempotent.
+	if not run_ok("ip link show atlas-park0"):
+		run("sudo ip link add atlas-park0 type dummy")
+	run("sudo ip link set atlas-park0 up")
+
 	# 9-imds. Drop guest traffic to the cloud metadata endpoint (169.254.169.254).
 	#     prod-host-setup.md "Filtering Guest Egress Network Traffic": a guest must
 	#     not reach the HOST's IMDS, which on DigitalOcean serves the droplet's own
@@ -533,6 +544,15 @@ def main() -> None:
 	run("sudo systemctl daemon-reload")
 	run("sudo systemctl enable atlas-networkd.service", check=False, quiet=True)
 	run("sudo systemctl start atlas-networkd.service", check=False, quiet=True)
+
+	# 11d. Wake-on-TCP trap for sleeping VMs (spec/32). The always-on daemon polls the
+	#      per-VM nft `wake_<uuid>` counters atlas.park installs and wakes a Sleeping VM
+	#      on its first inbound TCP SYN. Enable AND start it now — unlike the pool/mesh
+	#      oneshots there is no per-boot re-assert to defer to; it must be running so a
+	#      VM slept later this session auto-wakes. Its startup sweep re-parks any already
+	#      sleeping VM, so an enable+start after a reboot self-heals. `--now` is
+	#      best-effort: a start failure must not fail an otherwise-good bootstrap.
+	run("sudo systemctl enable --now atlas-wake-trap.service", check=False, quiet=True)
 
 	# 12. Record state for Atlas to pick up. Single JSON file is the canonical
 	#     source of truth. The bytes still land in /var/lib/atlas/bootstrap.json;

--- a/scripts/issue-cert.py
+++ b/scripts/issue-cert.py
@@ -66,7 +66,7 @@ def _write_powerdns_credentials(domain: str) -> None:
 		handle.write(f"dns_pdns_endpoint = {api_url}\n")
 		handle.write(f"dns_pdns_api_key = {api_key}\n")
 		handle.write(f"dns_pdns_server_id = {server_id}\n")
-		handle.write(f"dns_pdns_disable_notify = false\n")
+		handle.write("dns_pdns_disable_notify = false\n")
 	os.chmod(path, 0o600)
 
 

--- a/scripts/lib/atlas/_run.py
+++ b/scripts/lib/atlas/_run.py
@@ -83,7 +83,7 @@ class CommandError(RuntimeError):
 		super().__init__(f"command failed (exit {returncode}): {shlex.join(argv)}\n{output}")
 
 
-def run(command: str, *params: object, check: bool = True, quiet: bool = False) -> str:
+def run(command: str, *params: object, check: bool = True, quiet: bool = False, trace: bool = True) -> str:
 	"""Run one command, echo it (the `set -x` trace), return its stdout.
 
 	- `command` reads like a shell line; interpolated values go through `{}`
@@ -102,11 +102,15 @@ def run(command: str, *params: object, check: bool = True, quiet: bool = False) 
 	- The `+ <command>` line goes to stderr so it interleaves with `bash -x`
 	  tracing already in the Task log and never pollutes stdout that a caller
 	  parses (e.g. blockdev --getsize64).
+	- `trace=False` suppresses that `+ <command>` line — for an always-on daemon
+	  that polls the same read-only command every second (atlas-wake-trap.py), where
+	  a per-second trace would flood the journal for no diagnostic value.
 	"""
 	argv = _render(command, params)
-	start = _trace(argv)
+	start = _trace(argv) if trace else 0.0
 	result = subprocess.run(argv, capture_output=True, text=True, check=False)
-	_traced(argv, start)
+	if trace:
+		_traced(argv, start)
 	if result.stderr and not quiet:
 		sys.stderr.write(result.stderr)
 		sys.stderr.flush()

--- a/scripts/lib/atlas/networkd/daemon.py
+++ b/scripts/lib/atlas/networkd/daemon.py
@@ -277,9 +277,7 @@ class Daemon:
 			return
 		current: dict[str, frozenset[str]] = {}
 		for ip in ownership.conflicts:
-			current[ip] = frozenset(
-				origin for origin, adv in self.state.ownership.items() if ip in adv.owned
-			)
+			current[ip] = frozenset(origin for origin, adv in self.state.ownership.items() if ip in adv.owned)
 		# The H2 mesh collisions carry their own contending-peer origins; union
 		# them in (a /128 could in principle be both an owned conflict and a mesh
 		# collision — merge the origin sets so neither source is lost).
@@ -310,8 +308,7 @@ class Daemon:
 			doc = {
 				"conflict_count": len(current),
 				"conflicts": [
-					{"private_ip": ip, "origins": sorted(origins)}
-					for ip, origins in sorted(current.items())
+					{"private_ip": ip, "origins": sorted(origins)} for ip, origins in sorted(current.items())
 				],
 				"metrics": counter.snapshot() if counter is not None else {},
 			}

--- a/scripts/lib/atlas/networkd/loop.py
+++ b/scripts/lib/atlas/networkd/loop.py
@@ -150,7 +150,7 @@ class Loop:
 		nothing in the guard itself can mask a shutdown signal."""
 		try:
 			fn(*args)
-		except Exception as exc:  # noqa: BLE001 — deliberate broad catch; see docstring
+		except Exception as exc:
 			counter = getattr(self.daemon, "metrics", None)
 			if counter is not None:
 				counter.incr("loop_step_error")

--- a/scripts/lib/atlas/park.py
+++ b/scripts/lib/atlas/park.py
@@ -1,0 +1,165 @@
+"""Host-side "parked" reachability for a Sleeping VM (spec/32-sleepy-vms.md).
+
+When a VM sleeps, its unit stops and vm-network-down.py tears down ALL of its
+host networking — the proxy-NDP entry, the /128 route, the netns/veth/tap, and
+the per-VM forward rules — so the VM's public IPv6 is completely unrouted. That
+frees the RAM (the whole point of sleep) but also means an inbound TCP connection
+can never reach the host to trigger a wake.
+
+Park restores the MINIMUM reachability needed to TRAP the first inbound TCP SYN,
+with no running guest:
+
+  - proxy-NDP for the /128 on the uplink, so the upstream router keeps delivering
+    the VM's packets to this host (exactly as vm-network-up would);
+  - a /128 route out a shared, always-up dummy interface (atlas-park0), so an
+    inbound packet is FORWARDED (traverses `inet atlas forward`) instead of being
+    input-delivered and consumed by the host — the same off-link trick the
+    reserved-IP DNAT relies on ("must NOT be a local address … leaving it off-link
+    is what lets the packet be forwarded", reserved_ip_nat.py);
+  - one forward rule matching a connection-opening TCP SYN to the /128, with a
+    named counter, that DROPs it:
+
+        ip6 daddr <vm> tcp flags syn / fin,syn,rst,ack counter name wake_<hex> drop
+
+    `tcp flags syn / fin,syn,rst,ack` is nft's mask/value form — it matches only a
+    packet with SYN set and FIN/RST/ACK clear (a genuine new-connection SYN, not a
+    SYN-ACK, not a mid-stream segment). `tcp flags` implies TCP, so ICMP (ping) and
+    UDP never match: they fall through to the chain's `policy accept`, are forwarded
+    out the dummy, and are silently discarded WITHOUT waking (the "TCP only"
+    contract). The SYN is DROPped, not rejected, so the client's TCP stack
+    retransmits after its RTO (~1s) — by then atlas-wake-trap.py has started the
+    unit and the real path is live, so the retransmit reaches the resumed guest.
+
+atlas-wake-trap.py (the always-on host daemon) polls the named counters and, on
+the first packet for a still-sleeping VM, does the local wake (remove the marker,
+start the unit). The started unit's vm-network-up.py calls unpark() FIRST, so the
+rule + counter + dummy route are gone before the real forwarding path comes up.
+
+A NAMED counter, not the anonymous `counter` the forward accept rules use: only
+named counters appear in `nft list counters`, the flat, cheap surface the daemon
+polls (no whole-chain parse). The name is `wake_<uuid-no-dashes>` — nft
+identifiers forbid `-`, and the hex is a pure function of the UUID, so the
+uuid<->counter map needs no stored state.
+
+Pure argv/string construction except park() / unpark() / ensure_park_device(),
+which touch the host; the builders are unit-testable with bare `python3 -m
+unittest`, like firewall.py / reserved_ip_nat.py.
+"""
+
+from __future__ import annotations
+
+from atlas._run import _substitute, run, run_ok
+from atlas.network_env import default_route_device, read_network_env_optional
+from atlas.paths import VirtualMachinePaths
+
+FORWARD = "forward"
+# The shared, always-up dummy interface every sleeping VM's /128 routes out, so an
+# inbound packet is forwarded (hits the forward hook) with no running guest. Created
+# at bootstrap and re-asserted by ensure_park_device(); kept across a reset.
+PARK_DEVICE = "atlas-park0"
+_COUNTER_PREFIX = "wake_"
+
+
+def counter_name(uuid: str) -> str:
+	"""The named nft counter for a VM's parked SYN trap. nft identifiers forbid
+	'-', so use the UUID hex; it is a pure function of the UUID (no stored map)."""
+	return _COUNTER_PREFIX + uuid.replace("-", "")
+
+
+def uuid_for_counter(name: str) -> str | None:
+	"""Inverse of counter_name for the daemon: recover the dashed UUID from a
+	`wake_<32hex>` counter name, or None when the name is not ours / malformed."""
+	if not name.startswith(_COUNTER_PREFIX):
+		return None
+	hex_digits = name[len(_COUNTER_PREFIX) :]
+	if len(hex_digits) != 32 or any(character not in "0123456789abcdef" for character in hex_digits):
+		return None
+	return (
+		f"{hex_digits[0:8]}-{hex_digits[8:12]}-{hex_digits[12:16]}-"
+		f"{hex_digits[16:20]}-{hex_digits[20:32]}"
+	)
+
+
+def counter_command(uuid: str) -> str:
+	"""`nft add counter` for the VM's named SYN-trap counter (a table-scope object
+	the daemon reads via `nft list counters`)."""
+	return f"add counter inet atlas {counter_name(uuid)}"
+
+
+def wake_rule_command(virtual_machine_ipv6: str, uuid: str) -> str:
+	"""The forward rule: count + DROP a connection-opening TCP SYN to the VM's /128.
+	`tcp flags syn / fin,syn,rst,ack` matches only a bare SYN (SYN set; FIN/RST/ACK
+	clear), so ICMP/UDP and SYN-ACK do not match. drop (not reject) so the client
+	retransmits into the woken VM. The counter name is a fixed hex identifier (not
+	data), so it stays literal; only the VM's /128 goes through a quoted `{}` hole."""
+	return _substitute(
+		f"add rule inet atlas {FORWARD} ip6 daddr {{}} "
+		f"tcp flags syn / fin,syn,rst,ack "
+		f"counter name {counter_name(uuid)} drop",
+		(virtual_machine_ipv6,),
+	)
+
+
+def ensure_park_device() -> None:
+	"""Create the shared always-up atlas-park0 dummy if missing, and bring it up.
+	Created at bootstrap; re-created here so a post-reboot re-park (atlas-wake-trap's
+	startup sweep, before any VM unit rebuilds anything) still has a device to route
+	the parked /128 out of. Idempotent."""
+	if not run_ok("ip link show {}", PARK_DEVICE):
+		run("sudo ip link add {} type dummy", PARK_DEVICE)
+	run("sudo ip link set {} up", PARK_DEVICE)
+
+
+def park(uuid: str) -> None:
+	"""Install parked reachability + the TCP-SYN wake trap for a Sleeping VM.
+	Idempotent and self-healing — called at sleep (after the unit stops) and at
+	atlas-wake-trap boot re-sweep. Reads the VM's /128 from network.env; a VM with
+	no network.env (never provisioned / already terminated) is a no-op."""
+	env = read_network_env_optional(VirtualMachinePaths(uuid).network_env)
+	virtual_machine_ipv6 = env.get("VIRTUAL_MACHINE_IPV6")
+	if not virtual_machine_ipv6:
+		return
+
+	ensure_park_device()
+
+	# Keep answering NDP for the /128 so the upstream router still delivers here,
+	# and route it off-link out the dummy so an inbound packet is forwarded (hits
+	# the forward hook) rather than consumed by the host. Both are `replace` —
+	# idempotent, and a re-park after reboot rebuilds them from scratch.
+	uplink = default_route_device("-6", tolerate_missing=True)
+	if uplink:
+		run("sudo ip -6 neigh replace proxy {} dev {}", virtual_machine_ipv6, uplink)
+	run("sudo ip -6 route replace {} dev {}", f"{virtual_machine_ipv6}/128", PARK_DEVICE)
+
+	# The named counter must exist before the rule references it. Guard both adds on
+	# the live ruleset (substring / list-counter checks) so a re-park is a no-op and
+	# never duplicates the rule (which would split the count across two entries).
+	if not run_ok("sudo nft list counter inet atlas {}", counter_name(uuid)):
+		run("sudo nft " + counter_command(uuid))
+	forward = run("sudo nft list chain inet atlas {}", FORWARD, check=False)
+	if counter_name(uuid) not in forward:
+		run("sudo nft " + wake_rule_command(virtual_machine_ipv6, uuid))
+
+
+def unpark(uuid: str) -> None:
+	"""Remove a VM's parked state: the SYN-trap rule, its named counter, and the
+	off-link /128 route out atlas-park0. Called at the top of vm-network-up.py
+	(BEFORE the real netns is rebuilt, so the retransmitted SYN reaches the guest)
+	and by vm-network-down.py (so a terminate cleans park artifacts even though the
+	already-stopped unit's ExecStopPost will not re-run). Best-effort and idempotent:
+	a VM that was never parked (an ordinary start) is a no-op. proxy-NDP is NOT
+	touched here — vm-network-up re-`replace`s it, vm-network-down deletes it."""
+	name = counter_name(uuid)
+	# Delete the rule(s) BEFORE the counter — nft refuses to drop a counter a rule
+	# still references. The counter name is unique per VM, so it is an exact
+	# discriminator for the handle scrape (the pattern from vm-network-down.py).
+	listing = run("sudo nft -a list chain inet atlas {}", FORWARD, check=False)
+	for line in listing.splitlines():
+		if name in line and "handle" in line:
+			run("sudo nft delete rule inet atlas {} handle {}", FORWARD, line.split()[-1], check=False)
+	run("sudo nft delete counter inet atlas {}", name, check=False)
+
+	env = read_network_env_optional(VirtualMachinePaths(uuid).network_env)
+	virtual_machine_ipv6 = env.get("VIRTUAL_MACHINE_IPV6")
+	if virtual_machine_ipv6:
+		run("sudo ip -6 route del {} dev {}", f"{virtual_machine_ipv6}/128", PARK_DEVICE, check=False)

--- a/scripts/lib/atlas/park.py
+++ b/scripts/lib/atlas/park.py
@@ -107,6 +107,26 @@ def ensure_park_device() -> None:
 	run("sudo ip link set {} up", PARK_DEVICE)
 
 
+def ensure_forward_chain() -> None:
+	"""Recreate the `inet atlas` table and its `forward` chain if absent.
+
+	nftables is not persisted across a host reboot; today the first VM unit to
+	start rebuilds the scaffold in vm-network-up.py. A host whose VMs are ALL
+	sleeping starts no unit at all — every one of them is suppressed by its
+	`sleeping` marker — so nothing rebuilds it, and atlas-wake-trap's boot
+	re-sweep would then fail to add its counters and rules. The VMs would stay
+	parked-in-name-only and could never be woken by traffic, which is exactly the
+	case the re-sweep exists to cover. Same clause as vm-network-up's scaffold."""
+	if not run_ok("sudo nft list table inet atlas"):
+		run("sudo nft add table inet atlas")
+	if not run_ok("sudo nft list chain inet atlas {}", FORWARD):
+		run(
+			"sudo nft add chain inet atlas {} {}",
+			FORWARD,
+			"{ type filter hook forward priority filter; policy accept; }",
+		)
+
+
 def park(uuid: str) -> None:
 	"""Install parked reachability + the TCP-SYN wake trap for a Sleeping VM.
 	Idempotent and self-healing — called at sleep (after the unit stops) and at
@@ -118,6 +138,7 @@ def park(uuid: str) -> None:
 		return
 
 	ensure_park_device()
+	ensure_forward_chain()
 
 	# Keep answering NDP for the /128 so the upstream router still delivers here,
 	# and route it off-link out the dummy so an inbound packet is forwarded (hits

--- a/scripts/lib/atlas/park.py
+++ b/scripts/lib/atlas/park.py
@@ -74,10 +74,7 @@ def uuid_for_counter(name: str) -> str | None:
 	hex_digits = name[len(_COUNTER_PREFIX) :]
 	if len(hex_digits) != 32 or any(character not in "0123456789abcdef" for character in hex_digits):
 		return None
-	return (
-		f"{hex_digits[0:8]}-{hex_digits[8:12]}-{hex_digits[12:16]}-"
-		f"{hex_digits[16:20]}-{hex_digits[20:32]}"
-	)
+	return f"{hex_digits[0:8]}-{hex_digits[8:12]}-{hex_digits[12:16]}-{hex_digits[16:20]}-{hex_digits[20:32]}"
 
 
 def counter_command(uuid: str) -> str:

--- a/scripts/lib/atlas/paths.py
+++ b/scripts/lib/atlas/paths.py
@@ -197,6 +197,22 @@ class VirtualMachinePaths:
 		return "firecracker.socket"
 
 	@property
+	def sleeping_marker(self) -> str:
+		"""Present while the VM is sleeping: suppresses systemd auto-start on host
+		reboot (ConditionPathNotExists in the unit) and is the authority for the
+		Sleeping status. Written by sleep-vm.py after stop; removed by wake-vm.py
+		before start. Lives outside the jail so terminate's rm -rf sweeps it with
+		the VM directory."""
+		return f"{self.directory}/sleeping"
+
+	@property
+	def traffic_counter_file(self) -> str:
+		"""Last-seen nftables byte total for this VM, written by poll-vm-traffic.py.
+		Stores JSON {"bytes": N} so per-minute polls compute deltas on the host and
+		return only active:bool to the controller."""
+		return f"{self.directory}/traffic-counter.json"
+
+	@property
 	def systemd_unit(self) -> str:
 		"""The per-VM systemd instance name."""
 		return f"firecracker-vm@{self.uuid}.service"

--- a/scripts/lib/atlas/test_certs.py
+++ b/scripts/lib/atlas/test_certs.py
@@ -76,7 +76,9 @@ class TestCertbotArgv(unittest.TestCase):
 class TestCertPaths(unittest.TestCase):
 	def test_powerdns_credentials_path_is_absolute(self):
 		self.assertTrue(os.path.isabs(certs.powerdns_credentials_path(DOMAIN)))
-		self.assertTrue(certs.powerdns_credentials_path(DOMAIN).endswith(os.path.join(DOMAIN, "powerdns.ini")))
+		self.assertTrue(
+			certs.powerdns_credentials_path(DOMAIN).endswith(os.path.join(DOMAIN, "powerdns.ini"))
+		)
 
 	def test_pem_paths_live_under_the_domain_live_dir(self):
 		self.assertTrue(certs.fullchain_path(DOMAIN).endswith(os.path.join("live", DOMAIN, "fullchain.pem")))

--- a/scripts/lib/atlas/test_networkd_daemon.py
+++ b/scripts/lib/atlas/test_networkd_daemon.py
@@ -484,7 +484,7 @@ class TestDaemonConflictObservability(unittest.TestCase):
 
 	def test_owned_conflict_start_and_end_surface(self):
 		with tempfile.TemporaryDirectory() as tmp:
-			daemon, tracker, clock, adv = self._daemon_with_tracker(tmp)
+			daemon, _tracker, clock, adv = self._daemon_with_tracker(tmp)
 			# Two origins both own fdaa::9 → owned §7.3 conflict.
 			daemon.state.membership["h1"] = _member("h1", "K1", "fdaa:0:0:1::1")
 			daemon.state.membership["h2"] = _member("h2", "K2", "fdaa:0:0:2::1")
@@ -522,7 +522,7 @@ class TestDaemonConflictObservability(unittest.TestCase):
 		# owned conflict (empty ownership table), so this proves the render-level
 		# source is threaded out and surfaced too.
 		with tempfile.TemporaryDirectory() as tmp:
-			daemon, tracker, clock, _adv = self._daemon_with_tracker(tmp)
+			daemon, _tracker, _clock, _adv = self._daemon_with_tracker(tmp)
 			daemon.state.membership["h1"] = _member("h1", "K1", "fdaa:0:0:5::1")
 			daemon.state.membership["h2"] = _member("h2", "K2", "fdaa:0:0:5::1")  # same mesh
 			daemon.last_applied_config = "STALE\n"
@@ -539,7 +539,7 @@ class TestDaemonConflictObservability(unittest.TestCase):
 		# A status_path that can't be written (parent is a file) → best-effort:
 		# the apply still runs, a counter is bumped, no exception escapes.
 		with tempfile.TemporaryDirectory() as tmp:
-			daemon, tracker, clock, adv = self._daemon_with_tracker(tmp)
+			daemon, _tracker, _clock, adv = self._daemon_with_tracker(tmp)
 			blocker = Path(tmp) / "afile"
 			blocker.write_text("x")
 			daemon.config = daemon.config.with_overrides(status_path=str(blocker / "status.json"))
@@ -557,7 +557,7 @@ class TestDaemonConflictObservability(unittest.TestCase):
 		# observe path must run BEFORE the drift short-circuit so the END still
 		# fires + status.json refreshes.
 		with tempfile.TemporaryDirectory() as tmp:
-			daemon, tracker, clock, adv = self._daemon_with_tracker(tmp)
+			daemon, _tracker, clock, adv = self._daemon_with_tracker(tmp)
 			daemon.state.ownership["h1"] = adv("h1", 1, ("fdaa::9",))
 			daemon.state.ownership["h2"] = adv("h2", 1, ("fdaa::9",))
 			daemon.state.membership["h1"] = _member("h1", "K1", "fdaa:0:0:1::1")

--- a/scripts/lib/atlas/test_networkd_loop_hardening.py
+++ b/scripts/lib/atlas/test_networkd_loop_hardening.py
@@ -22,7 +22,6 @@ from atlas.networkd.ratelimit import SourceRateLimiter
 from atlas.networkd.transport import UdpTransport
 from atlas.networkd.wire import Message
 
-
 # --- SourceRateLimiter (M2 per-source gate) ----------------------------------
 
 

--- a/scripts/lib/atlas/test_networkd_render.py
+++ b/scripts/lib/atlas/test_networkd_render.py
@@ -231,9 +231,7 @@ class TestMeshAddressOverlap(unittest.TestCase):
 		# Direct unit of the invariant hook: two peers carrying the same /128
 		# trips the assertion (defends a future folding bug).
 		with self.assertRaises(AssertionError):
-			_assert_no_input_overlap(
-				{"h1": ["fdaa::7/128"], "h2": ["fdaa::7/128"]}, OwnershipTable()
-			)
+			_assert_no_input_overlap({"h1": ["fdaa::7/128"], "h2": ["fdaa::7/128"]}, OwnershipTable())
 
 
 if __name__ == "__main__":

--- a/scripts/lib/atlas/test_park.py
+++ b/scripts/lib/atlas/test_park.py
@@ -158,8 +158,7 @@ class TestUnpark(_ParkHarness):
 		# nft refuses to drop a counter a rule still references, so the order is
 		# load-bearing, not cosmetic.
 		listing = (
-			f"\tip6 daddr {VM_V6} tcp flags syn / fin,syn,rst,ack "
-			f"counter name wake_{HEX} drop # handle 42\n"
+			f"\tip6 daddr {VM_V6} tcp flags syn / fin,syn,rst,ack counter name wake_{HEX} drop # handle 42\n"
 		)
 		self.install(_FakeHost(listing=listing))
 		park.unpark(UUID)

--- a/scripts/lib/atlas/test_park.py
+++ b/scripts/lib/atlas/test_park.py
@@ -9,6 +9,7 @@ SYN-only match / drop verb that make the trap "TCP only".
 
 import shlex
 import unittest
+from typing import ClassVar
 
 from atlas import park
 
@@ -102,7 +103,7 @@ class _FakeHost:
 class _ParkHarness(unittest.TestCase):
 	"""Swaps park's host-touching collaborators for the recorder."""
 
-	env: dict = {"VIRTUAL_MACHINE_IPV6": VM_V6}
+	env: ClassVar[dict] = {"VIRTUAL_MACHINE_IPV6": VM_V6}
 
 	def install(self, host: _FakeHost, env=None) -> None:
 		self.host = host

--- a/scripts/lib/atlas/test_park.py
+++ b/scripts/lib/atlas/test_park.py
@@ -1,0 +1,69 @@
+"""Unit tests for the host-side "parked" reachability + TCP-SYN wake trap
+(spec/32-sleepy-vms.md).
+
+Run with bare `python3 -m unittest atlas.test_park` from scripts/lib: no Frappe,
+no site, no host, no nft. These cover the counter-name derivation (and its
+inverse, which the daemon relies on), the nft argv construction, and the exact
+SYN-only match / drop verb that make the trap "TCP only".
+"""
+
+import shlex
+import unittest
+
+from atlas import park
+
+VM_V6 = "2400:6180:100:d0:0:1:5835:d003"
+UUID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+HEX = "3f2504e04f8941d39a0c0305e82c3301"
+
+
+class TestCounterName(unittest.TestCase):
+	def test_strips_dashes_and_prefixes(self):
+		self.assertEqual(park.counter_name(UUID), f"wake_{HEX}")
+
+	def test_round_trips_through_uuid(self):
+		self.assertEqual(park.uuid_for_counter(park.counter_name(UUID)), UUID)
+
+	def test_rejects_foreign_counter_names(self):
+		# Not ours, wrong length, or non-hex — the daemon must ignore these so it
+		# never derives a bogus uuid from another table's counter.
+		self.assertIsNone(park.uuid_for_counter("bytes_total"))
+		self.assertIsNone(park.uuid_for_counter("wake_short"))
+		self.assertIsNone(park.uuid_for_counter("wake_" + "z" * 32))
+
+
+class TestCounterCommand(unittest.TestCase):
+	def test_adds_named_table_counter(self):
+		self.assertEqual(
+			shlex.split(park.counter_command(UUID)),
+			["add", "counter", "inet", "atlas", f"wake_{HEX}"],
+		)
+
+
+class TestWakeRuleCommand(unittest.TestCase):
+	def test_matches_bare_syn_and_drops_into_named_counter(self):
+		command = park.wake_rule_command(VM_V6, UUID)
+		self.assertEqual(
+			shlex.split(command),
+			["add", "rule", "inet", "atlas", "forward", "ip6", "daddr", VM_V6,
+			 "tcp", "flags", "syn", "/", "fin,syn,rst,ack",
+			 "counter", "name", f"wake_{HEX}", "drop"],
+		)  # fmt: skip
+
+	def test_is_tcp_only_and_drops_not_rejects(self):
+		# "TCP only" (no ICMP/UDP wake) and drop-so-the-client-retransmits are the
+		# two load-bearing properties of the trap — assert them explicitly.
+		command = park.wake_rule_command(VM_V6, UUID)
+		self.assertIn("tcp flags syn / fin,syn,rst,ack", command)
+		self.assertTrue(command.rstrip().endswith("drop"))
+		self.assertNotIn("reject", command)
+
+	def test_quotes_the_v6_but_keeps_the_counter_name_literal(self):
+		# The /128 is data (goes through a quoted hole); the counter name is a fixed
+		# hex identifier and stays literal so nft parses it as an identifier.
+		command = park.wake_rule_command("2001:db8::1", UUID)
+		self.assertEqual(shlex.split(command).count(f"wake_{HEX}"), 1)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/lib/atlas/test_park.py
+++ b/scripts/lib/atlas/test_park.py
@@ -153,6 +153,35 @@ class TestPark(_ParkHarness):
 		self.assertTrue(self.host.issued(f"ip -6 route replace {VM_V6}/128"))
 
 
+class TestEnsureForwardChain(_ParkHarness):
+	def test_creates_table_and_chain_when_absent(self):
+		# The post-reboot case: every VM on the host is sleeping, so no unit ever
+		# runs vm-network-up and nothing has rebuilt the nft scaffold.
+		host = _FakeHost()
+		host.run_ok = lambda template, *a, **k: (  # nothing exists yet
+			host.commands.append(template.format(*a)) or False
+		)
+		self.install(host)
+		park.ensure_forward_chain()
+		self.assertTrue(host.issued("add table inet atlas"))
+		self.assertTrue(host.issued("add chain inet atlas forward"))
+
+	def test_is_a_noop_when_the_scaffold_exists(self):
+		self.install(_FakeHost())  # run_ok defaults to True for nft queries
+		park.ensure_forward_chain()
+		self.assertFalse(self.host.issued("add table"))
+		self.assertFalse(self.host.issued("add chain"))
+
+	def test_park_scaffolds_before_adding_the_counter(self):
+		# Ordering matters: `nft add counter inet atlas ...` fails outright if the
+		# table does not exist yet.
+		self.install(_FakeHost())
+		park.park(UUID)
+		listed = [i for i, c in enumerate(self.host.commands) if "list table inet atlas" in c]
+		added = [i for i, c in enumerate(self.host.commands) if "add counter inet atlas" in c]
+		self.assertTrue(listed and added and listed[0] < added[0])
+
+
 class TestUnpark(_ParkHarness):
 	def test_deletes_the_rule_before_the_counter(self):
 		# nft refuses to drop a counter a rule still references, so the order is

--- a/scripts/lib/atlas/test_park.py
+++ b/scripts/lib/atlas/test_park.py
@@ -65,5 +65,127 @@ class TestWakeRuleCommand(unittest.TestCase):
 		self.assertEqual(shlex.split(command).count(f"wake_{HEX}"), 1)
 
 
+class _FakeHost:
+	"""Records every `run`/`run_ok` the park module issues, and answers the two
+	queries it branches on: whether the dummy exists and what the forward chain
+	currently holds. Lets the host-mutating paths be asserted with no root, no
+	nft and no network — the same bare-unittest contract as the builders above.
+	"""
+
+	def __init__(self, *, device_exists=True, counter_exists=False, chain_text="", listing=""):
+		self.device_exists = device_exists
+		self.counter_exists = counter_exists
+		self.chain_text = chain_text
+		self.listing = listing
+		self.commands: list[str] = []
+
+	def run(self, template, *args, **kwargs):
+		self.commands.append(template.format(*args) if "{}" in template else template)
+		if template.startswith("sudo nft -a list chain"):
+			return self.listing
+		if template.startswith("sudo nft list chain"):
+			return self.chain_text
+		return ""
+
+	def run_ok(self, template, *args, **kwargs):
+		self.commands.append(template.format(*args) if "{}" in template else template)
+		if template.startswith("ip link show"):
+			return self.device_exists
+		if template.startswith("sudo nft list counter"):
+			return self.counter_exists
+		return True
+
+	def issued(self, fragment: str) -> bool:
+		return any(fragment in command for command in self.commands)
+
+
+class _ParkHarness(unittest.TestCase):
+	"""Swaps park's host-touching collaborators for the recorder."""
+
+	env: dict = {"VIRTUAL_MACHINE_IPV6": VM_V6}
+
+	def install(self, host: _FakeHost, env=None) -> None:
+		self.host = host
+		env = self.env if env is None else env
+		patches = {
+			"run": host.run,
+			"run_ok": host.run_ok,
+			"read_network_env_optional": lambda _path: env,
+			"default_route_device": lambda *a, **k: "eth0",
+		}
+		for name, replacement in patches.items():
+			original = getattr(park, name)
+			setattr(park, name, replacement)
+			self.addCleanup(setattr, park, name, original)
+
+
+class TestPark(_ParkHarness):
+	def test_no_network_env_is_a_noop(self):
+		# A VM that was never provisioned (or is already terminated) has no /128 to
+		# park; touching the host for it would install a trap pointing nowhere.
+		self.install(_FakeHost(), env={})
+		park.park(UUID)
+		self.assertEqual(self.host.commands, [])
+
+	def test_installs_ndp_route_counter_and_rule(self):
+		self.install(_FakeHost())
+		park.park(UUID)
+		self.assertTrue(self.host.issued(f"ip -6 neigh replace proxy {VM_V6} dev eth0"))
+		self.assertTrue(self.host.issued(f"ip -6 route replace {VM_V6}/128 dev {park.PARK_DEVICE}"))
+		self.assertTrue(self.host.issued(f"add counter inet atlas wake_{HEX}"))
+		self.assertTrue(self.host.issued(f"counter name wake_{HEX} drop"))
+
+	def test_creates_the_dummy_when_missing(self):
+		self.install(_FakeHost(device_exists=False))
+		park.park(UUID)
+		self.assertTrue(self.host.issued(f"ip link add {park.PARK_DEVICE} type dummy"))
+
+	def test_re_park_does_not_duplicate_the_rule_or_counter(self):
+		# The daemon re-parks every sleeping VM at boot. A second rule would split
+		# the packet count across two entries and the trap could miss the first SYN.
+		existing = f"ip6 daddr {VM_V6} tcp flags syn / fin,syn,rst,ack counter name wake_{HEX} drop"
+		self.install(_FakeHost(counter_exists=True, chain_text=existing))
+		park.park(UUID)
+		self.assertFalse(self.host.issued("add rule inet atlas forward"))
+		self.assertFalse(self.host.issued("add counter inet atlas"))
+		# Reachability is still re-asserted — that is the point of the boot re-sweep.
+		self.assertTrue(self.host.issued(f"ip -6 route replace {VM_V6}/128"))
+
+
+class TestUnpark(_ParkHarness):
+	def test_deletes_the_rule_before_the_counter(self):
+		# nft refuses to drop a counter a rule still references, so the order is
+		# load-bearing, not cosmetic.
+		listing = (
+			f"\tip6 daddr {VM_V6} tcp flags syn / fin,syn,rst,ack "
+			f"counter name wake_{HEX} drop # handle 42\n"
+		)
+		self.install(_FakeHost(listing=listing))
+		park.unpark(UUID)
+		delete_rule = next(i for i, c in enumerate(self.host.commands) if "delete rule" in c)
+		delete_counter = next(i for i, c in enumerate(self.host.commands) if "delete counter" in c)
+		self.assertLess(delete_rule, delete_counter)
+		self.assertTrue(self.host.issued("delete rule inet atlas forward handle 42"))
+
+	def test_removes_the_parked_route(self):
+		self.install(_FakeHost())
+		park.unpark(UUID)
+		self.assertTrue(self.host.issued(f"ip -6 route del {VM_V6}/128 dev {park.PARK_DEVICE}"))
+
+	def test_never_parked_vm_deletes_no_rule(self):
+		# An ordinary start calls unpark() too; with nothing parked it must not try
+		# to delete a rule it never installed.
+		self.install(_FakeHost(listing=""))
+		park.unpark(UUID)
+		self.assertFalse(self.host.issued("delete rule"))
+
+	def test_leaves_proxy_ndp_alone(self):
+		# vm-network-up re-`replace`s NDP and vm-network-down deletes it; unpark
+		# touching it would strip reachability from a VM that is coming back up.
+		self.install(_FakeHost())
+		park.unpark(UUID)
+		self.assertFalse(self.host.issued("neigh"))
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/scripts/lib/atlas/test_sleep_vm.py
+++ b/scripts/lib/atlas/test_sleep_vm.py
@@ -67,5 +67,35 @@ class TestRequireWakeTrap(unittest.TestCase):
 		)
 
 
+class TestParkForWake(unittest.TestCase):
+	"""A failed park must fail the Task, not report a successful sleep."""
+
+	def setUp(self) -> None:
+		self.sleep_vm = _load_sleep_vm()
+
+	def _with_park(self, raises):
+		def _park(_uuid):
+			if raises:
+				raise RuntimeError("nft table missing")
+
+		original = self.sleep_vm.park
+		self.sleep_vm.park = _park
+		self.addCleanup(setattr, self.sleep_vm, "park", original)
+
+	def test_success_is_silent(self) -> None:
+		self._with_park(False)
+		self.sleep_vm._park_for_wake("3f2504e0-4f89-41d3-9a0c-0305e82c3301")  # no raise
+
+	def test_failure_exits_non_zero(self) -> None:
+		# Reporting success here would tell the controller a VM is safely asleep
+		# when nothing can wake it — the same silent black hole the wake-trap
+		# preflight exists to prevent.
+		self._with_park(True)
+		with self.assertRaises(SystemExit) as caught:
+			self.sleep_vm._park_for_wake("3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+		self.assertIn("nft table missing", str(caught.exception))
+		self.assertIn("will not wake on inbound traffic", str(caught.exception))
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/scripts/lib/atlas/test_sleep_vm.py
+++ b/scripts/lib/atlas/test_sleep_vm.py
@@ -1,0 +1,71 @@
+"""Unit tests for sleep-vm.py's wake-trap preflight (spec/32-sleepy-vms.md).
+
+Run with bare `python3 -m unittest atlas.test_sleep_vm` from scripts/lib, like
+test_park.py: no Frappe, no site, no host.
+
+The guard under test exists because the failure it prevents is silent. A host
+with the scripts synced but the unit never installed will park a sleeping VM and
+never wake it — the sleep Task reports success and the VM is simply unreachable
+until an operator intervenes.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2]
+
+
+def _load_sleep_vm():
+	if str(_SCRIPTS_DIR / "lib") not in sys.path:
+		sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
+	spec = importlib.util.spec_from_file_location("sleep_vm", _SCRIPTS_DIR / "sleep-vm.py")
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class TestRequireWakeTrap(unittest.TestCase):
+	def setUp(self) -> None:
+		self.sleep_vm = _load_sleep_vm()
+		self.asked: list[str] = []
+
+	def _with_trap(self, active: bool):
+		def _run_ok(template, *args, **kwargs):
+			self.asked.append(template.format(*args) if "{}" in template else template)
+			return active
+
+		original = self.sleep_vm.run_ok
+		self.sleep_vm.run_ok = _run_ok
+		self.addCleanup(setattr, self.sleep_vm, "run_ok", original)
+
+	def test_passes_when_the_trap_is_active(self) -> None:
+		self._with_trap(True)
+		self.sleep_vm._require_wake_trap()  # must not raise
+		self.assertTrue(any("atlas-wake-trap.service" in c for c in self.asked))
+
+	def test_refuses_when_the_trap_is_inactive(self) -> None:
+		# Exiting non-zero fails the Task, so the controller leaves the VM Running
+		# rather than parking it somewhere nothing can wake it.
+		self._with_trap(False)
+		with self.assertRaises(SystemExit) as caught:
+			self.sleep_vm._require_wake_trap()
+		message = str(caught.exception)
+		self.assertIn("atlas-wake-trap.service", message)
+		self.assertIn("Bootstrap the server", message, "the message must name the fix")
+
+	def test_checks_the_trap_before_touching_the_vm(self) -> None:
+		# Ordering is the point: the guard runs before the snapshot preflight, so a
+		# trap-less host never gets as far as pausing vCPUs or stopping the unit.
+		source = (_SCRIPTS_DIR / "sleep-vm.py").read_text()
+		body = source.split("def main()", 1)[1]
+		self.assertLess(
+			body.index("_require_wake_trap()"),
+			body.index("_preflight(paths)"),
+			"the wake-trap guard must run before the snapshot preflight",
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/lib/atlas/test_wake_trap.py
+++ b/scripts/lib/atlas/test_wake_trap.py
@@ -32,9 +32,7 @@ HEX = "3f2504e04f8941d39a0c0305e82c3301"
 def _load_daemon():
 	if str(_SCRIPTS_DIR / "lib") not in sys.path:
 		sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
-	spec = importlib.util.spec_from_file_location(
-		"atlas_wake_trap", _SCRIPTS_DIR / "atlas-wake-trap.py"
-	)
+	spec = importlib.util.spec_from_file_location("atlas_wake_trap", _SCRIPTS_DIR / "atlas-wake-trap.py")
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
 	return module
@@ -51,9 +49,7 @@ class TestWakeCounters(unittest.TestCase):
 			return self.daemon._wake_counters()
 
 	def test_maps_wake_counters_to_uuids(self) -> None:
-		output = json.dumps(
-			{"nftables": [{"counter": {"name": f"wake_{HEX}", "packets": 3, "bytes": 180}}]}
-		)
+		output = json.dumps({"nftables": [{"counter": {"name": f"wake_{HEX}", "packets": 3, "bytes": 180}}]})
 		self.assertEqual(self._with_nft_output(output), {UUID: 3})
 
 	def test_ignores_counters_that_are_not_ours(self) -> None:
@@ -185,9 +181,7 @@ class TestResweep(unittest.TestCase):
 		other = "11111111-2222-3333-4444-555555555555"
 		with (
 			patch.object(self.daemon.os, "listdir", return_value=[UUID, other]),
-			patch.object(
-				self.daemon.os.path, "exists", side_effect=lambda path: UUID in str(path)
-			),
+			patch.object(self.daemon.os.path, "exists", side_effect=lambda path: UUID in str(path)),
 		):
 			self.assertEqual(self.daemon._sleeping_uuids(), [UUID])
 

--- a/scripts/lib/atlas/test_wake_trap.py
+++ b/scripts/lib/atlas/test_wake_trap.py
@@ -1,0 +1,196 @@
+"""Unit tests for the atlas-wake-trap daemon (spec/32-sleepy-vms.md).
+
+The daemon is the wake half of the parked SYN trap: it polls the `wake_<hex>`
+named counters and, on the first packet for a still-sleeping VM, does the local
+wake. These cover the three things it can get wrong without anyone noticing —
+misparsing `nft -j` output, waking a VM that is already awake, and failing to
+re-park after a reboot.
+
+Run with bare `python3 -m unittest atlas.test_wake_trap` from scripts/lib, like
+test_park.py: no Frappe, no site, no host, no nft. It has to live here rather
+than under atlas/tests/ because the Frappe app is also called `atlas` and would
+shadow the scripts package this daemon imports.
+
+The daemon is a top-level dashed file, not an importable module, so it is loaded
+by path — its own sys.path shim assumes the durable /var/lib/atlas/bin layout
+where the package sits beside it, which is not the repo layout.
+"""
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2]
+
+UUID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+HEX = "3f2504e04f8941d39a0c0305e82c3301"
+
+
+def _load_daemon():
+	if str(_SCRIPTS_DIR / "lib") not in sys.path:
+		sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
+	spec = importlib.util.spec_from_file_location(
+		"atlas_wake_trap", _SCRIPTS_DIR / "atlas-wake-trap.py"
+	)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class TestWakeCounters(unittest.TestCase):
+	"""_wake_counters turns `nft -j list counters` into {uuid: packets}."""
+
+	def setUp(self) -> None:
+		self.daemon = _load_daemon()
+
+	def _with_nft_output(self, output: str) -> dict:
+		with patch.object(self.daemon, "run", return_value=output):
+			return self.daemon._wake_counters()
+
+	def test_maps_wake_counters_to_uuids(self) -> None:
+		output = json.dumps(
+			{"nftables": [{"counter": {"name": f"wake_{HEX}", "packets": 3, "bytes": 180}}]}
+		)
+		self.assertEqual(self._with_nft_output(output), {UUID: 3})
+
+	def test_ignores_counters_that_are_not_ours(self) -> None:
+		# Another feature's named counter in the same table must not yield a uuid.
+		output = json.dumps(
+			{
+				"nftables": [
+					{"counter": {"name": "bytes_total", "packets": 9}},
+					{"counter": {"name": f"wake_{HEX}", "packets": 1}},
+				]
+			}
+		)
+		self.assertEqual(self._with_nft_output(output), {UUID: 1})
+
+	def test_missing_table_returns_empty(self) -> None:
+		# `nft` writes the error to stderr and run(check=False) hands back "".
+		self.assertEqual(self._with_nft_output(""), {})
+
+	def test_malformed_json_returns_empty(self) -> None:
+		# A partial read must not kill the poll loop.
+		self.assertEqual(self._with_nft_output("{not json"), {})
+
+	def test_non_counter_entries_are_skipped(self) -> None:
+		output = json.dumps({"nftables": [{"metainfo": {"version": "1.0"}}, "junk"]})
+		self.assertEqual(self._with_nft_output(output), {})
+
+
+class TestTick(unittest.TestCase):
+	"""_tick wakes only a VM that is still asleep and has a non-zero counter."""
+
+	def setUp(self) -> None:
+		self.daemon = _load_daemon()
+
+	def _tick(self, counters: dict, *, marker_exists: bool) -> list:
+		woken = []
+		with (
+			patch.object(self.daemon, "_wake_counters", return_value=counters),
+			patch.object(self.daemon.os.path, "exists", return_value=marker_exists),
+			patch.object(self.daemon, "_wake", side_effect=lambda paths: woken.append(paths.uuid)),
+		):
+			self.daemon._tick()
+		return woken
+
+	def test_wakes_on_the_first_packet(self) -> None:
+		self.assertEqual(self._tick({UUID: 1}, marker_exists=True), [UUID])
+
+	def test_zero_packets_does_not_wake(self) -> None:
+		self.assertEqual(self._tick({UUID: 0}, marker_exists=True), [])
+
+	def test_stale_counter_on_an_already_woken_vm_does_not_wake(self) -> None:
+		# vm-network-up removes the counter as it rebuilds the real path, so a
+		# lingering count with no marker is stale. The marker is the authority.
+		self.assertEqual(self._tick({UUID: 5}, marker_exists=False), [])
+
+	def test_one_failed_wake_does_not_skip_the_others(self) -> None:
+		other = "11111111-2222-3333-4444-555555555555"
+		woken = []
+
+		def _wake(paths):
+			if paths.uuid == UUID:
+				raise RuntimeError("systemctl failed")
+			woken.append(paths.uuid)
+
+		with (
+			patch.object(self.daemon, "_wake_counters", return_value={UUID: 1, other: 1}),
+			patch.object(self.daemon.os.path, "exists", return_value=True),
+			patch.object(self.daemon, "_wake", side_effect=_wake),
+		):
+			self.daemon._tick()  # must not raise
+		self.assertEqual(woken, [other])
+
+
+class TestWakeOrder(unittest.TestCase):
+	"""_wake removes the marker BEFORE starting the unit."""
+
+	def setUp(self) -> None:
+		self.daemon = _load_daemon()
+
+	def test_marker_is_removed_before_the_unit_starts(self) -> None:
+		# A reboot between the two steps must not leave a marker suppressing the
+		# unit — the VM would stay dark with no trap to wake it.
+		commands = []
+		paths = self.daemon.VirtualMachinePaths(UUID)
+		with patch.object(self.daemon, "run", side_effect=lambda t, *a, **k: commands.append(t.format(*a))):
+			self.daemon._wake(paths)
+		self.assertEqual(len(commands), 2)
+		self.assertIn("rm -f", commands[0])
+		self.assertIn("systemctl start", commands[1])
+
+
+class TestResweep(unittest.TestCase):
+	"""The boot re-sweep rebuilds park state from the on-disk markers, DB-free."""
+
+	def setUp(self) -> None:
+		self.daemon = _load_daemon()
+
+	def test_re_parks_every_marked_vm(self) -> None:
+		parked = []
+		with (
+			patch.object(self.daemon, "ensure_park_device"),
+			patch.object(self.daemon, "_sleeping_uuids", return_value=[UUID]),
+			patch.object(self.daemon, "park", side_effect=parked.append),
+		):
+			self.daemon._resweep_parked_vms()
+		self.assertEqual(parked, [UUID])
+
+	def test_one_failed_re_park_does_not_stop_the_sweep(self) -> None:
+		other = "11111111-2222-3333-4444-555555555555"
+		parked = []
+
+		def _park(uuid):
+			if uuid == UUID:
+				raise RuntimeError("nft busy")
+			parked.append(uuid)
+
+		with (
+			patch.object(self.daemon, "ensure_park_device"),
+			patch.object(self.daemon, "_sleeping_uuids", return_value=[UUID, other]),
+			patch.object(self.daemon, "park", side_effect=_park),
+		):
+			self.daemon._resweep_parked_vms()  # must not raise
+		self.assertEqual(parked, [other])
+
+	def test_unreadable_directory_yields_no_uuids(self) -> None:
+		with patch.object(self.daemon.os, "listdir", side_effect=OSError):
+			self.assertEqual(self.daemon._sleeping_uuids(), [])
+
+	def test_only_vms_carrying_a_marker_are_returned(self) -> None:
+		other = "11111111-2222-3333-4444-555555555555"
+		with (
+			patch.object(self.daemon.os, "listdir", return_value=[UUID, other]),
+			patch.object(
+				self.daemon.os.path, "exists", side_effect=lambda path: UUID in str(path)
+			),
+		):
+			self.assertEqual(self.daemon._sleeping_uuids(), [UUID])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/poll-vm-traffic.py
+++ b/scripts/poll-vm-traffic.py
@@ -93,6 +93,9 @@ def _read_bytes(ipv6: str, chain_dump: str) -> int:
 
 def _load_last(counter_file: str) -> int | None:
 	try:
+		# nosemgrep: frappe-security-file-traversal -- host script, not a Frappe request
+		# path: counter_file is VirtualMachinePaths(<uuid>).traffic_counter_file, built
+		# from a controller-supplied UUID, never from user input.
 		with open(counter_file) as f:
 			return int(json.load(f)["bytes"])
 	except (FileNotFoundError, KeyError, json.JSONDecodeError, ValueError, TypeError):
@@ -101,6 +104,7 @@ def _load_last(counter_file: str) -> int | None:
 
 def _save_last(counter_file: str, current: int) -> None:
 	try:
+		# nosemgrep: frappe-security-file-traversal -- see _load_last above.
 		with open(counter_file, "w") as f:
 			json.dump({"bytes": current}, f)
 	except OSError:

--- a/scripts/poll-vm-traffic.py
+++ b/scripts/poll-vm-traffic.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Poll per-VM nftables byte counters for a set of VMs on this host.
+# Returns active:bool per VM (True = bytes changed since last poll, False = idle).
+#
+# Delta computation runs entirely on the host: the last-seen byte total is stored
+# in /var/lib/atlas/virtual-machines/<uuid>/traffic-counter.json so the controller
+# only ever sees a bool — raw counters are host-local, ephemeral, and not DB state.
+#
+# Counter anomalies (reset, missing rule) are treated as active=True so a VM is
+# never incorrectly put to sleep after a chain flush or host reboot.
+
+import json
+import os
+import re
+import sys
+import typing
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import run, run_ok
+from atlas._task import TaskInputs, TaskResult
+from atlas.paths import VirtualMachinePaths
+
+
+@dataclass(frozen=True)
+class PollVmTrafficInputs(TaskInputs):
+	"""Poll nftables byte counters for the given VMs; return active:bool per VM."""
+
+	command: typing.ClassVar[str] = "poll-vm-traffic"
+	vms_json: str  # JSON: [{"name": "<uuid>", "ipv6_address": "<fdaa::...>"}]
+
+
+@dataclass(frozen=True)
+class PollVmTrafficResult(TaskResult):
+	counters: dict = field(default_factory=dict)  # {"<vm-name>": {"active": bool}}
+
+
+def main() -> None:
+	inputs = PollVmTrafficInputs.from_args()
+	vms = json.loads(inputs.vms_json)
+
+	if not vms:
+		PollVmTrafficResult(counters={}).emit()
+		return
+
+	if not run_ok("sudo nft list chain inet atlas forward"):
+		# Chain not yet created (host just rebooted before any VM started).
+		# Treat all as active so none are slept on a post-reboot poll anomaly.
+		result = {vm["name"]: {"active": True} for vm in vms}
+		PollVmTrafficResult(counters=result).emit()
+		return
+
+	chain_dump = run("sudo nft list chain inet atlas forward")
+	result = {}
+	for vm in vms:
+		name = vm["name"]
+		ipv6 = vm["ipv6_address"]
+		result[name] = {"active": _is_active(name, ipv6, chain_dump)}
+
+	PollVmTrafficResult(counters=result).emit()
+
+
+def _is_active(vm_name: str, ipv6: str, chain_dump: str) -> bool:
+	"""Compare the VM's current nft byte total to the last-seen value.
+	Returns True if traffic changed (active) or the counter is anomalous."""
+	current = _read_bytes(ipv6, chain_dump)
+	counter_file = VirtualMachinePaths(vm_name).traffic_counter_file
+	last = _load_last(counter_file)
+	_save_last(counter_file, current)
+
+	if last is None:
+		# First poll — no baseline yet; don't sleep a VM we've never observed.
+		return True
+	if current < last:
+		# Counter reset (chain flush or host reboot) — treat as active.
+		return True
+	return current > last
+
+
+def _read_bytes(ipv6: str, chain_dump: str) -> int:
+	"""Sum bytes from all nft forward rules that mention this VM's IPv6 address.
+	Summing handles the uncommon case where duplicate rules exist (two starts
+	without an intervening chain flush)."""
+	total = 0
+	for line in chain_dump.splitlines():
+		if ipv6 in line and "counter" in line:
+			m = re.search(r"\bbytes (\d+)", line)
+			if m:
+				total += int(m.group(1))
+	return total
+
+
+def _load_last(counter_file: str) -> int | None:
+	try:
+		with open(counter_file) as f:
+			return int(json.load(f)["bytes"])
+	except (FileNotFoundError, KeyError, json.JSONDecodeError, ValueError, TypeError):
+		return None
+
+
+def _save_last(counter_file: str, current: int) -> None:
+	try:
+		with open(counter_file, "w") as f:
+			json.dump({"bytes": current}, f)
+	except OSError:
+		pass
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/probe-woken-vms.py
+++ b/scripts/probe-woken-vms.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Probe whether each of the given Sleeping VMs has been WOKEN on the host — i.e.
+# atlas-wake-trap.py (or an operator's local wake) removed its `sleeping` marker.
+#
+# The controller's reconcile_sleeping_vms() calls this per server every minute so a
+# host-initiated (packet-triggered) wake is reflected back into the Frappe status
+# within one poll cycle: the host is the authority for a wake HAVING happened (only
+# it sees the inbound SYN); the controller just mirrors it into the DB. Read-only —
+# it changes nothing on the host.
+
+import json
+import os
+import sys
+import typing
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._task import TaskInputs, TaskResult
+from atlas.paths import VirtualMachinePaths
+
+
+@dataclass(frozen=True)
+class ProbeWokenVmsInputs(TaskInputs):
+	"""Return, per given Sleeping VM uuid, whether the host has woken it."""
+
+	command: typing.ClassVar[str] = "probe-woken-vms"
+	vms_json: str  # JSON: ["<uuid>", ...]
+
+
+@dataclass(frozen=True)
+class ProbeWokenVmsResult(TaskResult):
+	woken: dict = field(default_factory=dict)  # {"<uuid>": bool}
+
+
+def main() -> None:
+	inputs = ProbeWokenVmsInputs.from_args()
+	uuids = json.loads(inputs.vms_json)
+	# Woken = the sleeping marker is gone. wake-vm.py and atlas-wake-trap.py both
+	# remove it as the FIRST step of a wake (before `systemctl start`), so its
+	# absence is the authority that a wake has begun — the same signal the unit's
+	# ConditionPathNotExists keys on. A VM whose directory is already gone (a racing
+	# terminate) reads as woken too; reconcile only acts on rows still Sleeping.
+	woken = {uuid: not os.path.exists(VirtualMachinePaths(uuid).sleeping_marker) for uuid in uuids}
+	ProbeWokenVmsResult(woken=woken).emit()
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/reset-server.py
+++ b/scripts/reset-server.py
@@ -34,6 +34,7 @@
 #   - every per-VM rule in the nft `inet atlas forward` chain, the firewall
 #     chain, and every NDP proxy entry the VMs installed
 
+import json
 import os
 import sys
 import typing
@@ -136,6 +137,13 @@ def teardown_networking() -> None:
 		address, device = entry
 		run("sudo ip -6 neigh del proxy {} dev {}", address, device, check=False)
 
+	# Every parked-VM SYN trap: its forward rule + named counter (atlas.park). The
+	# per-VM vm-network-down above removed these for VMs it still knew about; this
+	# catches orphans whose VM directory was already gone. Delete the rules first
+	# (a counter a rule references can't be dropped), then the counters. The shared
+	# atlas-park0 dummy is bootstrap floor and is kept, like the nft table scaffold.
+	_sweep_park_state()
+
 
 def disconnect_nbd_and_dm_clone() -> None:
 	"""Disconnect any bound nbd client and remove any lingering dm-clone target —
@@ -174,6 +182,32 @@ def clear_state_directories() -> None:
 
 
 # --- host enumeration: read-only pokes, each tolerating absence ---------------
+
+
+def _sweep_park_state() -> None:
+	"""Delete every `wake_*` SYN-trap forward rule and named counter (atlas.park).
+	Best-effort and idempotent; rules first so the counters they reference can then
+	be dropped."""
+	chain = run("sudo nft -a list chain inet atlas forward", check=False)
+	for line in chain.splitlines():
+		if "wake_" in line and "handle" in line:
+			run("sudo nft delete rule inet atlas forward handle {}", line.split()[-1], check=False)
+	for name in _list_wake_counters():
+		run("sudo nft delete counter inet atlas {}", name, check=False)
+
+
+def _list_wake_counters() -> list[str]:
+	out = run("sudo nft -j list counters table inet atlas", check=False)
+	try:
+		data = json.loads(out)
+	except (json.JSONDecodeError, ValueError):
+		return []
+	names = []
+	for item in data.get("nftables", []):
+		counter = item.get("counter") if isinstance(item, dict) else None
+		if counter and str(counter.get("name", "")).startswith("wake_"):
+			names.append(counter["name"])
+	return names
 
 
 def _list_vm_directories() -> list[str]:

--- a/scripts/sleep-vm.py
+++ b/scripts/sleep-vm.py
@@ -128,7 +128,7 @@ def _park_for_wake(uuid: str) -> None:
 	on host reboot)."""
 	try:
 		park(uuid)
-	except Exception as error:  # noqa: BLE001 — never let park failure abort the sleep
+	except Exception as error:  # never let a park failure abort the sleep
 		print(f"park failed (VM will not auto-wake on TCP until re-parked): {error}", file=sys.stderr)
 
 

--- a/scripts/sleep-vm.py
+++ b/scripts/sleep-vm.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Put a Running VM to sleep: capture its full memory state, stop the unit, then
+# write a SLEEPING marker file. The marker prevents systemd from auto-starting the
+# VM on host reboot (ConditionPathNotExists in firecracker-vm@.service) and is the
+# authority for the Sleeping status in Frappe.
+#
+# Falls back to plain stop on any snapshot failure — the VM always ends up stopped;
+# only the next wake's speed differs. The SLEEPING marker is written after the unit
+# stops in both paths, so the reboot-suppression always takes effect.
+#
+# Mirrors snapshot-stop-vm.py's snapshot logic exactly; they share no library
+# because the jail/paths setup is identical and a shared lib would add indirection
+# with no reuse benefit (two callers, same repo, always evolved together).
+
+import json
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import CommandError, firecracker_api, install_directory, run, run_ok
+from atlas._task import TaskInputs, TaskResult
+from atlas.paths import ATLAS_ROOT, VirtualMachinePaths
+
+FREE_SPACE_MARGIN_BYTES = 256 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SleepVmInputs(TaskInputs):
+	"""Stop a VM with a memory snapshot and mark it sleeping (no reboot auto-start)."""
+
+	command: typing.ClassVar[str] = "sleep-vm"
+	virtual_machine_name: str
+	atlas_fc_uid: int
+
+
+@dataclass(frozen=True)
+class SleepVmResult(TaskResult):
+	memory_snapshot: bool
+	reason: str = ""
+	memory_snapshot_bytes: int = 0
+
+
+def main() -> None:
+	inputs = SleepVmInputs.from_args()
+	paths = VirtualMachinePaths(inputs.virtual_machine_name)
+
+	reason = _preflight(paths)
+	if reason:
+		_stop_and_sleep(paths, reason)
+		return
+
+	try:
+		_create_snapshot(paths, inputs.atlas_fc_uid)
+	except CommandError as error:
+		_stop_and_sleep(paths, f"snapshot failed: {error}")
+		return
+
+	run("sudo systemctl stop {}", paths.systemd_unit)
+	run("sudo touch {}", paths.sleeping_marker)
+	mem_bytes = int(run("sudo stat -c %s {}", paths.memory_snapshot_mem).strip())
+	SleepVmResult(memory_snapshot=True, memory_snapshot_bytes=mem_bytes).emit()
+	print(f"VM {inputs.virtual_machine_name} is now sleeping (memory snapshot captured).")
+
+
+def _preflight(paths: VirtualMachinePaths) -> str:
+	"""Return a non-empty reason string if a memory snapshot can't be taken."""
+	if not run_ok("sudo grep -q snapshot/READY {}", paths.jailer_launch):
+		return "launcher predates memory snapshots; re-provision the VM to enable fast start"
+	if not os.path.exists(paths.api_socket):
+		return "API socket missing; is the VM running?"
+	run("sudo rm -rf {}", paths.memory_snapshot_directory)
+	mem_size_mib = int(
+		run("sudo jq -r {} {}", '."machine-config".mem_size_mib', paths.firecracker_config).strip()
+	)
+	needed = mem_size_mib * 1024 * 1024 + FREE_SPACE_MARGIN_BYTES
+	available = int(run("df --output=avail -B1 {}", ATLAS_ROOT).splitlines()[1].strip())
+	if available < needed:
+		return f"not enough free space for a {mem_size_mib} MiB memory file ({available} B available)"
+	return ""
+
+
+def _create_snapshot(paths: VirtualMachinePaths, uid: int) -> None:
+	install_directory(paths.memory_snapshot_directory, mode="0700")
+	run("sudo chown {} {}", f"{uid}:{uid}", paths.memory_snapshot_directory)
+	firecracker_api(paths.api_socket_directory, paths.api_socket_name, "PATCH", "/vm", '{"state": "Paused"}')
+	firecracker_api(
+		paths.api_socket_directory,
+		paths.api_socket_name,
+		"PUT",
+		"/snapshot/create",
+		json.dumps(
+			{
+				"snapshot_type": "Full",
+				"snapshot_path": paths.memory_snapshot_vmstate_in_jail,
+				"mem_file_path": paths.memory_snapshot_mem_in_jail,
+			}
+		),
+	)
+	for snapshot_file in (paths.memory_snapshot_vmstate, paths.memory_snapshot_mem):
+		if not run_ok("sudo test -s {}", snapshot_file):
+			raise CommandError(["test", "-s", snapshot_file], 1, "snapshot file missing or empty")
+	run("sudo touch {}", paths.memory_snapshot_marker)
+
+
+def _stop_and_sleep(paths: VirtualMachinePaths, reason: str) -> None:
+	"""Fallback path: no memory snapshot, but still write the SLEEPING marker so
+	the unit won't auto-restart on host reboot. The stale snapshot marker (if any)
+	must not survive a partial run."""
+	run("sudo rm -f {}", paths.memory_snapshot_marker)
+	run("sudo systemctl stop {}", paths.systemd_unit)
+	run("sudo touch {}", paths.sleeping_marker)
+	SleepVmResult(memory_snapshot=False, reason=reason).emit()
+	print(f"VM {paths.uuid} is now sleeping (no memory snapshot): {reason}")
+
+
+if __name__ == "__main__":
+	main()

--- a/scripts/sleep-vm.py
+++ b/scripts/sleep-vm.py
@@ -26,6 +26,7 @@ from atlas.park import park
 from atlas.paths import ATLAS_ROOT, VirtualMachinePaths
 
 FREE_SPACE_MARGIN_BYTES = 256 * 1024 * 1024
+WAKE_TRAP_UNIT = "atlas-wake-trap.service"
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,8 @@ def main() -> None:
 	inputs = SleepVmInputs.from_args()
 	paths = VirtualMachinePaths(inputs.virtual_machine_name)
 
+	_require_wake_trap()
+
 	reason = _preflight(paths)
 	if reason:
 		_stop_and_sleep(paths, reason)
@@ -65,6 +68,28 @@ def main() -> None:
 	mem_bytes = int(run("sudo stat -c %s {}", paths.memory_snapshot_mem).strip())
 	SleepVmResult(memory_snapshot=True, memory_snapshot_bytes=mem_bytes).emit()
 	print(f"VM {inputs.virtual_machine_name} is now sleeping (memory snapshot captured).")
+
+
+def _require_wake_trap() -> None:
+	"""Refuse to sleep when nothing on this host could wake the VM again.
+
+	atlas-wake-trap.service is what turns an inbound SYN into a `systemctl start`.
+	Without it a slept VM is still parked — its /128 routes into the atlas-park0
+	dummy — so it answers nothing and stays dark until an operator clicks Start.
+	That is strictly worse than leaving the VM awake, and it fails SILENTLY: the
+	sleep Task succeeds and the tenant just sees a black hole.
+
+	This is not hypothetical. A host that had `sync-scripts` run but was never
+	re-bootstrapped had atlas-wake-trap.py and park.py on disk with no unit file
+	(units ship at bootstrap, not with a script sync); VMs slept there and could
+	not be woken by traffic at all. Fail loudly and leave the VM Running instead —
+	the Task row records why, and the fix is to bootstrap the server."""
+	if not run_ok("systemctl is-active --quiet {}", WAKE_TRAP_UNIT):
+		sys.exit(
+			f"refusing to sleep: {WAKE_TRAP_UNIT} is not active on this host, so an "
+			"inbound connection could not wake the VM. Bootstrap the server to install "
+			"and enable it."
+		)
 
 
 def _preflight(paths: VirtualMachinePaths) -> str:

--- a/scripts/sleep-vm.py
+++ b/scripts/sleep-vm.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib
 
 from atlas._run import CommandError, firecracker_api, install_directory, run, run_ok
 from atlas._task import TaskInputs, TaskResult
+from atlas.park import park
 from atlas.paths import ATLAS_ROOT, VirtualMachinePaths
 
 FREE_SPACE_MARGIN_BYTES = 256 * 1024 * 1024
@@ -60,6 +61,7 @@ def main() -> None:
 
 	run("sudo systemctl stop {}", paths.systemd_unit)
 	run("sudo touch {}", paths.sleeping_marker)
+	_park_for_wake(paths.uuid)
 	mem_bytes = int(run("sudo stat -c %s {}", paths.memory_snapshot_mem).strip())
 	SleepVmResult(memory_snapshot=True, memory_snapshot_bytes=mem_bytes).emit()
 	print(f"VM {inputs.virtual_machine_name} is now sleeping (memory snapshot captured).")
@@ -112,8 +114,22 @@ def _stop_and_sleep(paths: VirtualMachinePaths, reason: str) -> None:
 	run("sudo rm -f {}", paths.memory_snapshot_marker)
 	run("sudo systemctl stop {}", paths.systemd_unit)
 	run("sudo touch {}", paths.sleeping_marker)
+	_park_for_wake(paths.uuid)
 	SleepVmResult(memory_snapshot=False, reason=reason).emit()
 	print(f"VM {paths.uuid} is now sleeping (no memory snapshot): {reason}")
+
+
+def _park_for_wake(uuid: str) -> None:
+	"""Best-effort: install the parked reachability + TCP-SYN wake trap (atlas.park)
+	so an inbound TCP connection wakes the VM (spec/32). Done AFTER the marker is
+	written, so the VM is already officially sleeping. A failure here must not fail
+	the sleep — the VM still sleeps and stays wakeable by the operator; it just
+	won't auto-wake on a packet until something re-parks it (atlas-wake-trap re-parks
+	on host reboot)."""
+	try:
+		park(uuid)
+	except Exception as error:  # noqa: BLE001 — never let park failure abort the sleep
+		print(f"park failed (VM will not auto-wake on TCP until re-parked): {error}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/sleep-vm.py
+++ b/scripts/sleep-vm.py
@@ -145,16 +145,24 @@ def _stop_and_sleep(paths: VirtualMachinePaths, reason: str) -> None:
 
 
 def _park_for_wake(uuid: str) -> None:
-	"""Best-effort: install the parked reachability + TCP-SYN wake trap (atlas.park)
-	so an inbound TCP connection wakes the VM (spec/32). Done AFTER the marker is
-	written, so the VM is already officially sleeping. A failure here must not fail
-	the sleep — the VM still sleeps and stays wakeable by the operator; it just
-	won't auto-wake on a packet until something re-parks it (atlas-wake-trap re-parks
-	on host reboot)."""
+	"""Install the parked reachability + TCP-SYN wake trap (atlas.park) so an inbound
+	TCP connection wakes the VM (spec/32). Done AFTER the marker is written, so the
+	VM is already officially sleeping.
+
+	A failure here is NOT swallowed. The VM is stopped and marked sleeping by this
+	point, so we cannot undo it — but reporting success would tell the controller a
+	VM is safely asleep when nothing can wake it, the same silent black hole
+	_require_wake_trap() exists to prevent. Exit non-zero so the Task records the
+	failure and an operator sees it; the VM is still wakeable via Start, and
+	atlas-wake-trap re-parks every marked VM at its next startup."""
 	try:
 		park(uuid)
-	except Exception as error:  # never let a park failure abort the sleep
-		print(f"park failed (VM will not auto-wake on TCP until re-parked): {error}", file=sys.stderr)
+	except Exception as error:
+		sys.exit(
+			f"VM is stopped and marked sleeping, but parking the wake trap FAILED: {error}. "
+			"It will not wake on inbound traffic until re-parked (restart "
+			f"{WAKE_TRAP_UNIT} to re-park, or Start the VM)."
+		)
 
 
 if __name__ == "__main__":

--- a/scripts/systemd/atlas-wake-trap.service
+++ b/scripts/systemd/atlas-wake-trap.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Atlas wake-on-TCP trap for sleeping VMs
+# Wakes a Sleeping VM when it receives an inbound TCP SYN (spec/32-sleepy-vms.md):
+# polls the per-VM nft `wake_<uuid>` counters atlas.park installs and does the local
+# wake on the first packet. Needs the uplink up (it re-parks proxy-NDP/routes on
+# boot) and the local fs (the sleeping markers + network.env it re-parks from). Not
+# ordered Before=firecracker-vm@.service: a sleeping VM is suppressed on boot anyway
+# (ConditionPathNotExists), and the daemon's startup sweep re-parks it.
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# The durable atlas package lives under /var/lib/atlas/bin (placed by bootstrap);
+# the daemon's own sys.path shim adds that dir. Runs under the Atlas venv python
+# (/var/lib/atlas/venv/bin/python), like every other hook/unit — bootstrap's sanity
+# gate py_compiles it on that interpreter first.
+ExecStart=/var/lib/atlas/venv/bin/python /var/lib/atlas/bin/atlas-wake-trap.py
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/firecracker-vm@.service
+++ b/scripts/systemd/firecracker-vm@.service
@@ -2,6 +2,11 @@
 Description=Atlas Firecracker VM %i
 After=network-online.target
 Wants=network-online.target
+# Do not auto-start a sleeping VM on host reboot. sleep-vm.py writes this
+# marker after stopping the unit; wake-vm.py removes it before starting.
+# ConditionPathNotExists prevents the unit from starting while the file
+# exists, without disabling WantedBy (so wake-vm.py's systemctl start works).
+ConditionPathNotExists=/var/lib/atlas/virtual-machines/%i/sleeping
 
 [Service]
 Type=simple

--- a/scripts/vm-network-down.py
+++ b/scripts/vm-network-down.py
@@ -18,6 +18,7 @@ from atlas._run import run
 from atlas.firewall import remove_firewall
 from atlas.network_env import default_route_device, read_network_env_optional
 from atlas.networkd.localownership import remove_local_owned
+from atlas.park import unpark
 from atlas.paths import VirtualMachinePaths
 from atlas.private_network import remove_private_network
 from atlas.reserved_ip_nat import remove_reserved_ip_nat
@@ -29,6 +30,14 @@ def main() -> None:
 	uuid = sys.argv[1]
 
 	paths = VirtualMachinePaths(uuid)
+
+	# Clear any "parked" state first (the SYN-trap rule + named counter + the /128
+	# route out atlas-park0 a sleeping VM carries; see atlas.park). A stopped VM's
+	# unit will not re-run this ExecStopPost, so a Sleeping->Terminated (or a future
+	# Sleeping->Stopped) MUST reach the park cleanup here. No-op for a VM that was
+	# never parked. Runs before the rule-handle sweep below so the wake rule is gone
+	# by the time it lists the chain.
+	unpark(uuid)
 
 	# If the env file is gone (terminate-vm already ran) we still want to do our
 	# best to clean up. read_network_env_optional() returns an empty NetworkEnv

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -31,6 +31,7 @@ from atlas._run import run, run_ok
 from atlas.firewall import apply_persisted_firewall
 from atlas.network_env import default_route_device, read_network_env
 from atlas.networkd.localownership import add_local_owned
+from atlas.park import unpark
 from atlas.paths import VirtualMachinePaths
 from atlas.private_network import apply_private_network
 from atlas.reserved_ip_nat import (
@@ -45,6 +46,13 @@ def main() -> None:
 	if len(sys.argv) != 2:
 		sys.exit("usage: vm-network-up.py <virtual-machine-uuid>")
 	uuid = sys.argv[1]
+
+	# If this start is a WAKE, the VM was "parked" while sleeping (proxy-NDP + a
+	# /128 route out atlas-park0 + a TCP-SYN wake trap; see atlas.park). Remove that
+	# trap BEFORE rebuilding the real netns/route below, so the client's
+	# retransmitted SYN reaches the resumed guest instead of being dropped by the
+	# park rule. A no-op on an ordinary start (nothing was parked). spec/32.
+	unpark(uuid)
 
 	env = read_network_env(VirtualMachinePaths(uuid).network_env)
 	tap_device = env.require("TAP_DEVICE")

--- a/scripts/vm-network-up.py
+++ b/scripts/vm-network-up.py
@@ -214,16 +214,22 @@ def main() -> None:
 	#    host namespace to match on). The v4 masquerade rule (host postrouting,
 	#    100.64.0.0/16 -> uplink) is created in the nft scaffold above and covers the
 	#    guest's v4 egress once it reaches the host via the veth.
-	run(
-		"sudo nft add rule inet atlas forward ip6 daddr {} oifname {} accept",
-		virtual_machine_ipv6,
-		host_veth,
-	)
-	run(
-		"sudo nft add rule inet atlas forward ip6 saddr {} iifname {} accept",
-		virtual_machine_ipv6,
-		host_veth,
-	)
+	#    `counter` records per-VM byte totals that poll-vm-traffic.py reads to detect
+	#    idle VMs for the Sleepy VMs feature. Idempotency guards prevent duplicate
+	#    rules (which would split the counter across two entries) on restarts.
+	_forward = run("sudo nft list chain inet atlas forward")
+	if f"ip6 daddr {virtual_machine_ipv6} oifname {host_veth}" not in _forward:
+		run(
+			"sudo nft add rule inet atlas forward ip6 daddr {} oifname {} counter accept",
+			virtual_machine_ipv6,
+			host_veth,
+		)
+	if f"ip6 saddr {virtual_machine_ipv6} iifname {host_veth}" not in _forward:
+		run(
+			"sudo nft add rule inet atlas forward ip6 saddr {} iifname {} counter accept",
+			virtual_machine_ipv6,
+			host_veth,
+		)
 
 	# 7a. Private plane (the WireGuard host mesh, design §5). Present only once the
 	#     controller writes PRIVATE_ADDRESS + TENANT_PREFIX into network.env; absent

--- a/scripts/wake-vm.py
+++ b/scripts/wake-vm.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Wake a sleeping VM: remove the SLEEPING marker (so host reboots will auto-start
+# it again), then start the systemd unit. If a memory snapshot is present (the
+# READY marker exists), the launcher resumes the guest in milliseconds; otherwise
+# it cold-boots. Either way, when this script exits the unit has been started.
+
+import os
+import sys
+import typing
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from atlas._run import run
+from atlas._task import TaskInputs
+from atlas.paths import VirtualMachinePaths
+
+
+@dataclass(frozen=True)
+class WakeVmInputs(TaskInputs):
+	"""Remove the SLEEPING marker and start the VM's unit."""
+
+	command: typing.ClassVar[str] = "wake-vm"
+	virtual_machine_name: str
+
+
+def main() -> None:
+	inputs = WakeVmInputs.from_args()
+	paths = VirtualMachinePaths(inputs.virtual_machine_name)
+
+	# Remove the marker BEFORE starting the unit: if the unit's ConditionPathNotExists
+	# sees the marker it will silently refuse to start (exit 0, unit skipped).
+	# Remove first so a restart after a failed start also clears it.
+	run("sudo rm -f {}", paths.sleeping_marker)
+	run("sudo systemctl start {}", paths.systemd_unit)
+	print(f"VM {inputs.virtual_machine_name} woken.")
+
+
+if __name__ == "__main__":
+	main()

--- a/spec/32-sleepy-vms.md
+++ b/spec/32-sleepy-vms.md
@@ -42,7 +42,7 @@ Two per-minute scheduled jobs
 wired in [hooks.py](../atlas/hooks.py)):
 
 - **`poll_vm_traffic`** — for each server with `Running` `sleep_on_idle` VMs, runs
-  the server-scoped `poll-vm-traffic` Task. The host reads each VM's `inet atlas
+  the server-scoped `poll-vm-traffic` probe. The host reads each VM's `inet atlas
   forward` nftables **byte counters** (`ip6 {s,d}addr <vm> … counter accept`,
   installed by [vm-network-up.py](../scripts/vm-network-up.py)), compares to the
   last-seen value stored on the host (`traffic-counter.json`), and returns only
@@ -53,6 +53,20 @@ wired in [hooks.py](../atlas/hooks.py)):
   `last_traffic_at` is older than its `idle_timeout_seconds`. Skips
   `stop_protection` and re-reads status under the row so a concurrent poll can't
   race it.
+
+Both sweeps — and `reconcile_sleeping_vms` below — go through **`run_probe`**,
+not `run_task`: they record **no Task row**. A read-only poll on every server
+every minute is ~2,880 rows/server/day of "polled, nothing happened", which
+would drown the audit log the Task list exists to be. `run_probe` never raises
+either; a failure logs a warning and returns `""`, so one unreachable host
+cannot abort the sweep and the next tick simply retries. The trade is
+deliberate: **a failed poll is visible in the logs, not in the desk**. Anything
+that changes host state still uses `run_task`, where the row *is* the audit
+trail and the failure must propagate.
+
+`last_traffic_at` is also stamped on every transition into `Running` —
+`provision()`, `start()`, and `wake()` — so a VM that has just been started is
+never measured against an idle clock that predates it.
 
 ## Sleeping
 

--- a/spec/32-sleepy-vms.md
+++ b/spec/32-sleepy-vms.md
@@ -1,0 +1,172 @@
+# Sleepy VMs — auto-sleep idle VMs, wake on demand
+
+Free host RAM by putting an **idle** VM to sleep and resuming it on demand. A
+sleeping VM keeps its disk but releases its cgroup, so its RAM returns to the host
+(the whole point). It wakes three ways: an operator **Start**, a host reboot's
+recovery path, or — the reason a tenant never notices — **the first inbound TCP
+connection**. When a memory snapshot was captured on sleep, the wake resumes the
+guest in milliseconds instead of cold-booting.
+
+This is opt-in per VM (`sleep_on_idle`) and orthogonal to `memory_snapshot_on_stop`
+([05-virtual-machine-lifecycle.md](./05-virtual-machine-lifecycle.md)); it reuses
+that same in-jail memory-snapshot fast path.
+
+## State
+
+A VM gains the `Sleeping` status and three fields
+([02-doctypes.md](./02-doctypes.md)):
+
+| Field | Meaning |
+| --- | --- |
+| `sleep_on_idle` | Opt-in. Only these VMs are polled and auto-slept. |
+| `idle_timeout_seconds` | Idle window before auto-sleep. `validate()` enforces ≥ 120 (two poll cycles). |
+| `last_traffic_at` | Stamped by the traffic poller; seeded to `now()` at provision and at every start/wake so a fresh VM is never immediately slept. |
+
+Transitions (additions to the lifecycle state machine):
+
+```
+Running  → Sleeping   (auto, idle timeout)
+Sleeping → Running    (wake — operator Start, or host-initiated on inbound TCP)
+Sleeping → Terminated (terminate)
+```
+
+`sleep()` accepts only `Running`; `wake()` accepts only `Sleeping`; `start()` from
+`Sleeping` delegates to `wake()` (the desk **Start** button just works). `pause()`,
+`snapshot()`, `stop()`, `rebuild()`, `resize()` reject `Sleeping` with a message to
+stop or wake first — the memory snapshot is never silently consumed.
+
+## Detecting idleness
+
+Two per-minute scheduled jobs
+([virtual_machine.py](../atlas/atlas/doctype/virtual_machine/virtual_machine.py),
+wired in [hooks.py](../atlas/hooks.py)):
+
+- **`poll_vm_traffic`** — for each server with `Running` `sleep_on_idle` VMs, runs
+  the server-scoped `poll-vm-traffic` Task. The host reads each VM's `inet atlas
+  forward` nftables **byte counters** (`ip6 {s,d}addr <vm> … counter accept`,
+  installed by [vm-network-up.py](../scripts/vm-network-up.py)), compares to the
+  last-seen value stored on the host (`traffic-counter.json`), and returns only
+  `active: bool` per VM — no raw counters touch the DB. Active VMs get
+  `last_traffic_at = now()`. A counter reset (chain reload / reboot) reads as
+  active, so a VM is never slept on a measurement anomaly.
+- **`sleep_idle_vms`** — sleeps every `Running` `sleep_on_idle` VM whose
+  `last_traffic_at` is older than its `idle_timeout_seconds`. Skips
+  `stop_protection` and re-reads status under the row so a concurrent poll can't
+  race it.
+
+## Sleeping
+
+[sleep-vm.py](../scripts/sleep-vm.py):
+
+1. Capture a **full memory snapshot** in the jail (pause vCPUs → Firecracker
+   `PUT /snapshot/create` → `READY` marker), preflighted for disk space and launcher
+   support. On any failure, fall back to a plain stop — the VM still ends up
+   Sleeping; only the next wake's speed differs (`memory_snapshot=false`).
+2. `systemctl stop firecracker-vm@<uuid>.service`. Its `ExecStopPost`
+   ([vm-network-down.py](../scripts/vm-network-down.py)) tears the VM's host
+   networking **completely** down: the proxy-NDP entry, the `/128` route, the
+   netns/veth/tap, and the per-VM forward rules.
+3. Write the **`SLEEPING` marker** (`…/<uuid>/sleeping`). The unit's
+   `ConditionPathNotExists=…/sleeping` makes systemd skip the unit on host reboot
+   **without** disabling it, so the VM stays asleep across reboots while a Running
+   VM's `WantedBy` symlink is untouched. The marker is the authority for the
+   Sleeping status.
+4. **Park** the VM for a wake-on-TCP (below).
+
+## Capacity accounting
+
+A sleeping VM has released its RAM but still owns its disk LV and its in-jail
+`mem.bin`. [server_capacity.py](../atlas/atlas/api/server_capacity.py) therefore
+splits the axes: `Sleeping` is **excluded** from the RAM/CPU sums but **included**
+in disk. Without this a host with sleeping tenants looks overcommitted and
+placement refuses new VMs — defeating the feature.
+
+## Waking on the first inbound TCP connection
+
+Because step 2 above leaves a sleeping VM's `/128` **completely unrouted** (the host
+stops answering NDP for it), nothing — not even a SYN — would otherwise reach the
+host to trigger a wake. Three pieces close that gap, entirely host-side: **no proxy
+change and no inbound-to-Atlas API** (the [satellite](./30-core-service-boundary.md)
+read boundary stays read-only). A connection through the TCP/HTTP proxy is just a
+dial to the VM's `/128`, so it is trapped the same way as a direct `ssh [vm]:22`.
+
+### 1. Parked reachability ([park.py](../scripts/lib/atlas/park.py))
+
+On sleep, `park()` restores the **minimum** reachability to trap one SYN, with no
+running guest:
+
+- **proxy-NDP** for the `/128` on the uplink — the host keeps answering NDP, so the
+  upstream router still delivers the VM's packets here.
+- an **off-link `/128` route out a shared dummy** (`atlas-park0`, created at
+  bootstrap). Routing off-link (not to a local address) is what makes an inbound
+  packet **forwarded** — so it traverses `inet atlas forward` — instead of being
+  input-delivered and consumed by the host, the same principle the reserved-IP DNAT
+  relies on ([06-networking.md](./06-networking.md#ipv4-ingress-reserved-ip)).
+- one **forward rule**:
+  `ip6 daddr <vm> tcp flags syn / fin,syn,rst,ack counter name wake_<uuid> drop`.
+  It matches only a connection-opening TCP **SYN** (SYN set; FIN/RST/ACK clear).
+  `tcp flags` implies TCP, so **ICMP (`ping`) and UDP never match** — they fall
+  through, are forwarded out the dummy, and are discarded **without waking**
+  (the design is "TCP only"). The SYN is **dropped**, not rejected, so the client's
+  TCP stack retransmits after its RTO (~1 s) — by then the VM is up and the
+  retransmit reaches the live guest. The count lands in a **named** counter (only
+  named counters appear in `nft list counters`, the cheap surface the daemon polls);
+  the name is a pure function of the UUID, so no map is stored.
+
+### 2. The wake trap ([atlas-wake-trap.py](../scripts/atlas-wake-trap.py))
+
+An always-on host daemon (`atlas-wake-trap.service`, enabled at bootstrap) polls the
+`wake_<uuid>` counters about once a second. On the first packet for a still-sleeping
+VM it does the local wake — exactly [wake-vm.py](../scripts/wake-vm.py)'s two steps:
+remove the `SLEEPING` marker, then `systemctl start` the unit. The started unit's
+[vm-network-up.py](../scripts/vm-network-up.py) **unparks first** (removing the rule,
+counter, and dummy route) and then rebuilds the real netns, so the retransmitted SYN
+reaches the resumed guest. Counter poll (not NFQUEUE/NFLOG) because it needs no new
+host dependency and we only have to *detect* the dropped SYN, not deliver it.
+
+At startup — including after a host reboot, where a sleeping VM's unit is suppressed
+so `vm-network-up` never runs — the daemon **re-parks** every VM still carrying a
+`sleeping` marker, rebuilding `atlas-park0`, NDP, route, and rule from the on-disk
+markers + `network.env`, DB-free (the same self-heal pattern as `atlas-pool.service`).
+
+### 3. Adopting the wake into the DB ([virtual_machine.py](../atlas/atlas/doctype/virtual_machine/virtual_machine.py))
+
+The host can't reach Atlas's DB, so a per-minute `reconcile_sleeping_vms` job
+(ordered **before** `sleep_idle_vms`) probes each server's sleeping VMs
+(`probe-woken-vms` reports whether the marker is gone) and, for each woken VM,
+`_adopt_wake()` flips `Sleeping → Running`, stamps `last_started`/`last_traffic_at`
+(so the same-tick idle sweep won't re-sleep it), and clears `has_memory_snapshot`.
+It takes the **same row lock** `wake()` uses, so an operator wake and a host wake
+serialize: whichever commits first flips the status, the other no-ops. DB drift is
+at most one minute; the guest is reachable the whole time.
+
+## Interactions
+
+- **Host reboot** — the `SLEEPING` marker survives and suppresses the unit; the
+  wake-trap daemon re-parks on boot, so a sleeping VM stays both asleep and
+  wake-on-TCP after a reboot.
+- **Terminate / stop** — `vm-network-down.py` also `unpark()`s, so a
+  `Sleeping → Terminated` cleans the rule/counter/route even though the
+  already-stopped unit's `ExecStopPost` won't re-run. `reset-server` sweeps any
+  orphan `wake_*` counters; `atlas-park0` is kept as bootstrap floor.
+- **Per-VM firewall** ([20-firewall.md](./20-firewall.md)) — the `public_filter`
+  chain runs before `forward`, so a SYN to a **blocked** port is dropped before the
+  wake rule and does not wake (correct — that port is firewalled); a SYN to an
+  **allowed** port falls through to the wake rule and wakes.
+- **Migration** ([24-vm-migration.md](./24-vm-migration.md)) — migrating from
+  `Sleeping` is unsupported; wake or stop first.
+
+## Files
+
+Controller: `sleep()` / `wake()` / `start()` / the schedulers +
+`reconcile_sleeping_vms` / `_adopt_wake`
+([virtual_machine.py](../atlas/atlas/doctype/virtual_machine/virtual_machine.py)),
+[hooks.py](../atlas/hooks.py), [server_capacity.py](../atlas/atlas/api/server_capacity.py).
+Host: [sleep-vm.py](../scripts/sleep-vm.py), [wake-vm.py](../scripts/wake-vm.py),
+[poll-vm-traffic.py](../scripts/poll-vm-traffic.py),
+[probe-woken-vms.py](../scripts/probe-woken-vms.py),
+[atlas-wake-trap.py](../scripts/atlas-wake-trap.py),
+[park.py](../scripts/lib/atlas/park.py), and the park/unpark hooks in
+[vm-network-up.py](../scripts/vm-network-up.py) /
+[vm-network-down.py](../scripts/vm-network-down.py). Bootstrap creates `atlas-park0`
+and enables `atlas-wake-trap.service` ([bootstrap-server.py](../scripts/bootstrap-server.py)).

--- a/spec/32-sleepy-vms.md
+++ b/spec/32-sleepy-vms.md
@@ -87,6 +87,15 @@ never measured against an idle clock that predates it.
    Sleeping status.
 4. **Park** the VM for a wake-on-TCP (below).
 
+`sleep-vm` **refuses outright** when `atlas-wake-trap.service` is not active on
+the host. Without the daemon a slept VM is still parked — its `/128` routes into
+the `atlas-park0` dummy — so it answers nothing and stays dark until an operator
+clicks **Start**: strictly worse than staying awake, and silent, because the
+sleep itself succeeds. The gap is reachable in practice, since unit files ship at
+**bootstrap** and not with a script sync, so a synced-but-not-re-bootstrapped
+host has `atlas-wake-trap.py` on disk with no unit. Failing the Task leaves the
+VM `Running` and records the reason.
+
 ## Capacity accounting
 
 A sleeping VM has released its RAM but still owns its disk LV and its in-jail

--- a/spec/README.md
+++ b/spec/README.md
@@ -162,6 +162,7 @@ keep it the source of truth.
 28. [Snapshot backup to S3](./29-snapshot-backup.md) — *push a point-in-time snapshot off-host to S3 and rehydrate it back (same-VM rollback)*
 29. [The core ↔ service boundary and the `satellite` app](./30-core-service-boundary.md) — *how service logic (proxy, gateway, mesh, bench/site) leaves core for a separate app via an explicit VM-lifecycle seam*
 30. [Distributed network control plane (ANCP)](./31-ancp-network-control-plane.md) — *shipped: the decentralized `atlas-networkd` control plane (gossip + anti-entropy) that replaced the controller-driven WireGuard host mesh of [25](./25-private-networking.md)*
+31. [Sleepy VMs — auto-sleep idle VMs, wake on demand](./32-sleepy-vms.md) — *free host RAM by sleeping idle VMs; wake on operator Start or the first inbound TCP connection (fast resume from a memory snapshot)*
 
 ## First run on a fresh site
 
@@ -278,6 +279,7 @@ operator-facing features add to this list; new tests follow it.
 | Issue a TLS cert for a region  | `Root Domain` → **Issue / Renew Certificate**; `TLS Certificate` → **Issue/Renew / Push to Proxies**; DNS Settings / `Lets Encrypt Settings` → **Test Connection** | [13-tls.md](./13-tls.md) |
 | Route guest-created bench sites | (guest-driven, no operator action) the in-guest `bench-domain-provider register`/`deregister` POSTs reserve/remove a `Subdomain` the controller arbitrates (uniqueness, brand denylist, per-VM cap, own-VM scoping by source `/128`); the `wildcard-domains`/`proxy-servers` queries answer pilot's host-level questions; every call audited; `terminate()` is the only controller-side teardown | [18-bench-self-routing.md](./18-bench-self-routing.md) |
 | Refresh a host's capacity      | `Server` → **Refresh Capacity** (re-measure CPU/RAM/pool totals + fullness and stamp them, no re-bootstrap) | [28-placement.md](./28-placement.md) |
+| Auto-sleep idle VMs             | `Virtual Machine` → enable **`sleep_on_idle`** + set **`idle_timeout_seconds`** (idle VMs sleep to free host RAM; wake on **Start** or the first inbound TCP connection) | [32-sleepy-vms.md](./32-sleepy-vms.md) |
 | Run an ad-hoc task / reboot    | `Server` → **Run Task / Reboot**                        | [04-tasks.md](./04-tasks.md) |
 | Run an ad-hoc command on hosts/guests | `SSH Console` → **Execute** (fan one command across Servers and/or Virtual Machines; per-target output streams back; every run recorded as an `SSH Command Log`), or `Server` / `Virtual Machine` → **Run Command** (pre-targets the console at one row) | [04-tasks.md § The SSH Console](./04-tasks.md#the-ssh-console-ad-hoc-commands) |
 | Click any button on the desk   | every form button driven through `run_doc_method`       | (this section, *Desk-button coverage*) |


### PR DESCRIPTION
Frees host RAM by putting an **idle** VM to sleep and resuming it on demand. A sleeping VM keeps its disk but releases its cgroup, so its RAM returns to the host. It wakes on an operator **Start**, a host reboot's recovery path, or — the reason a tenant never notices — **the first inbound TCP connection**. Opt-in per VM via `sleep_on_idle`.

New spec chapter: `spec/32-sleepy-vms.md`.

## How the wake works

Sleeping tears the VM's host networking down completely, so nothing would otherwise reach the host to trigger a wake. Three host-side pieces close that, with **no proxy change and no inbound-to-Atlas API** — the satellite read boundary stays read-only:

- **`park.py`** restores the minimum reachability to trap one SYN with no running guest: proxy-NDP for the `/128`, an off-link `/128` route out a shared `atlas-park0` dummy (routing off-link is what makes the packet *forwarded*, so it traverses `inet atlas forward`), and one rule counting + **dropping** a connection-opening SYN into a named counter. `tcp flags` implies TCP, so **ICMP and UDP never wake it**. Drop rather than reject, so the client retransmits into the woken guest.
- **`atlas-wake-trap.service`** polls those counters ~1s and does the local wake. At startup it re-parks every VM still carrying a `sleeping` marker, DB-free — a host reboot suppresses a sleeping VM's unit, so `vm-network-up` never runs.
- **`reconcile_sleeping_vms`** adopts the host-initiated wake into the DB, taking the same row lock `wake()` uses so an operator wake and a host wake serialise.

## Notable decisions

- **The per-minute pollers record no Task row.** `poll-vm-traffic` and `probe-woken-vms` are read-only and run once per server per minute — ~2,880 rows/server/day of "polled, nothing happened". A new `run_probe()` runs them without persisting and never raises; failures log. Anything that mutates host state still uses `run_task`, where the row *is* the audit trail.
- **`sleep-vm` refuses when `atlas-wake-trap.service` is not active.** Found live: a host that had scripts synced but was never re-bootstrapped had the daemon script with no unit file (units ship at bootstrap, not with a script sync). VMs slept there were parked correctly, counter incrementing on every SYN, with nothing polling it — the sleep reported success and the VM was unreachable indefinitely. Worse than not sleeping, and silent at every layer.
- **Capacity splits the axes.** `Sleeping` is excluded from the RAM/CPU sums but included in disk; otherwise a host with sleeping tenants looks overcommitted and placement refuses new VMs, defeating the feature.
- **Migration from `Sleeping` is refused** with a message naming the fix — the memory snapshot is not transportable between hosts.

## Testing

- 35 controller tests (`atlas/tests/test_sleepy_vms.py`) and 32 bare-unittest host tests (`park`, the wake-trap daemon, the sleep guard).
- e2e: `phase-is-parked` / `phase-is-unparked` assert the counter, the SYN-only drop rule, the off-link route and a live daemon. The use case then runs the tenant-visible path on a real host — **ICMP does not wake it, a TCP connect does** — then asserts the park state is gone and the DB reconciles.
- Verified live on DigitalOcean. The wake stimulus is driven from a **second** host: a packet from the VM's own host is input-delivered and never reaches the forward chain, so a same-host dial would prove nothing. `_find_vantage` also excludes Fake-provider servers, which synthesise Task output without ever using SSH.

```
phase-is-parked    OK parked <uuid>
phase-wake-ping    OK pinged <vm-v6> (expecting NO wake)
phase7-is-sleeping Success          <- still asleep after the pings
phase-wake-tcp     OK woke <vm-v6>:22 after 1 attempt(s), 2s
phase-is-unparked  OK unparked <uuid>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)