### PR TITLE
fix(pilot): give a server's admin console a front door (#128)

### DIFF
--- a/atlas/atlas/doctype/pilot/pilot.py
+++ b/atlas/atlas/doctype/pilot/pilot.py
@@ -29,7 +29,7 @@ from frappe import _
 from frappe.model.document import Document
 
 from atlas.atlas.placement import active_root_domain
-from atlas.atlas.subdomain_label import validate_label, validate_reserved
+from atlas.atlas.subdomain_label import PILOT_SUFFIX, validate_label, validate_reserved
 
 # How long a freshly-minted login URL stays usable, keyed by build_mode — the TTL
 # of the token deploy-site.py minted (bench/deploy-site.py). admin:
@@ -81,6 +81,31 @@ class Pilot(Document):
 		Site's `url` (also `https://<host>`) so the console + billing views open it the
 		same way."""
 		return f"https://{self.bench_fqdn}"
+
+	@property
+	def console_fqdn(self) -> str:
+		"""The host the bench ADMIN console is fronted at — what `[admin].domain` in the
+		guest's bench.toml must say, and the label that needs a proxy route.
+
+		Which shape depends on what the bench serves at `bench_fqdn`, i.e. on `build_mode`
+		(the effective deploy mode: inherited from the backing VM's image, and forced to
+		`admin` for an attached pilot):
+
+		- **admin** — the bench IS the console, so it owns `bench_fqdn` outright and the
+		  console host is the bench host. Covers every attached pilot (the console that
+		  comes with a Site) and a stand-alone pilot baked from an admin image.
+		- **site** — `bench_fqdn` serves the baked SITE, so the console needs a host of
+		  its own or it would collide with the site's vhost:
+		  `<subdomain>-pilot.<region domain>`, the same suffix a Site's attached console
+		  uses (`subdomain_label.PILOT_SUFFIX`). This is the server case.
+
+		Derived, never stored, and deterministic: `_create_subdomain` routes it and
+		`_deploy` wires it in two separate steps, and a re-driven provision (retry =
+		re-run) must derive the same host both times.
+		"""
+		if (self.build_mode or "site") == "admin":
+			return self.bench_fqdn
+		return f"{self.subdomain}{PILOT_SUFFIX}.{active_root_domain().domain}"
 
 	# ----- lifecycle -----------------------------------------------------
 
@@ -440,7 +465,21 @@ def _deploy(pilot) -> dict:
 	# the shared VM's build_mode is `site`; pass mode explicitly so the deploy wires the
 	# admin vhost, not another site rename. A stand-alone Pilot passes None → the VM's mode.
 	mode = pilot.build_mode if pilot.attached else None
-	return deploy_site(pilot.virtual_machine, pilot.bench_fqdn, mode=mode) or {}
+	return (
+		deploy_site(
+			pilot.virtual_machine,
+			pilot.bench_fqdn,
+			mode=mode,
+			# Site mode renames the baked site onto bench_fqdn and only wires
+			# `[admin].domain` when it is told a host. Without this a stand-alone pilot (a
+			# server) shipped with the baked `admin.localhost` placeholder still in
+			# bench.toml, so its console answered on no real hostname at all. Admin mode
+			# already defaults the domain to the FQDN it was given, so passing the same
+			# value there is a no-op that keeps the two paths honest.
+			admin_domain=pilot.console_fqdn,
+		)
+		or {}
+	)
 
 
 def _create_subdomain(pilot) -> str:
@@ -459,7 +498,48 @@ def _create_subdomain(pilot) -> str:
 			"active": 1,
 		}
 	).insert(ignore_permissions=True)
+	_create_console_subdomain(pilot)
 	return subdomain.name
+
+
+def _create_console_subdomain(pilot) -> str | None:
+	"""Route the bench ADMIN console's own host, when it needs one of its own.
+
+	A stand-alone pilot (a server) serves the baked SITE at `bench_fqdn`, so its console
+	lives at `<subdomain>-pilot.<region domain>` (`Pilot.console_fqdn`) and that label
+	needs its own proxy route or the console is unreachable — `[admin].domain` in the
+	guest points at a host nothing routes. Both halves have to land for the console to
+	work: this row is the route, `_deploy`'s `admin_domain` is the vhost.
+
+	No-op for an attached pilot, whose console IS `bench_fqdn` — `_create_subdomain`
+	already routed it, and inserting the same label twice would just collide.
+
+	Get-or-create, because retry = re-run (taste #16): a provision that got the route
+	and then failed at the deploy is re-driven from the top, and a bare insert would die
+	on a duplicate key with the route in fact already live. A label that resolves
+	somewhere else is a genuine conflict, so that fails loud rather than silently
+	repointing someone else's host."""
+	if pilot.console_fqdn == pilot.bench_fqdn:
+		return None
+	label = pilot.console_fqdn.split(".", 1)[0]
+	existing = frappe.db.get_value("Subdomain", label, "virtual_machine")
+	if existing is not None:
+		if existing != pilot.virtual_machine:
+			frappe.throw(
+				_("Subdomain '{0}' already routes to VM {1}, not this pilot's {2}").format(
+					label, existing, pilot.virtual_machine
+				)
+			)
+		return label
+	console = frappe.get_doc(
+		{
+			"doctype": "Subdomain",
+			"subdomain": label,
+			"virtual_machine": pilot.virtual_machine,
+			"active": 1,
+		}
+	).insert(ignore_permissions=True)
+	return console.name
 
 
 def _regenerate_login(pilot) -> dict:

--- a/atlas/atlas/doctype/pilot/test_pilot.py
+++ b/atlas/atlas/doctype/pilot/test_pilot.py
@@ -211,6 +211,84 @@ class TestPilot(IntegrationTestCase):
 		self.assertEqual(subdomain.virtual_machine, pilot.virtual_machine)
 		self.assertTrue(subdomain.active)
 
+	# ----- the admin console's front door (issue #128) --------------------
+
+	def _site_mode_pilot(self, subdomain: str = "srv"):
+		"""A stand-alone pilot off a SITE-mode image — what `create_server` provisions.
+		Its bench_fqdn serves the baked site, so the console needs a host of its own."""
+		image = fixtures.make_image("fake-bench-site-image", build_mode="site")
+		return fixtures.make_pilot(
+			subdomain,
+			vm_spec={"server": self.server.name, "image": image.name},
+			tenant=ensure_tenant(TEAM),
+		)
+
+	def test_console_fqdn_falls_back_to_the_bench_host_in_admin_mode(self) -> None:
+		"""An admin-mode bench IS the console, so it needs no separate host."""
+		pilot = self._new_pilot("acme")
+		self.assertEqual(pilot.build_mode, "admin")
+		self.assertEqual(pilot.console_fqdn, pilot.bench_fqdn)
+
+	def test_console_fqdn_is_suffixed_in_site_mode(self) -> None:
+		"""A server's bench_fqdn serves the site, so its console gets `<label>-pilot`."""
+		pilot = self._site_mode_pilot("srv")
+		self.assertEqual(pilot.build_mode, "site")
+		self.assertEqual(pilot.bench_fqdn, "srv.blr1.frappe.dev")
+		self.assertEqual(pilot.console_fqdn, "srv-pilot.blr1.frappe.dev")
+
+	def test_provision_routes_the_console_host_in_site_mode(self) -> None:
+		"""The console's host needs its own proxy route or it resolves nowhere — before
+		this, a server got only its site's route and the console was unreachable."""
+		pilot = self._site_mode_pilot("srv")
+		self._drive_provision(pilot)
+		console = frappe.db.get_value("Subdomain", "srv-pilot", ["virtual_machine", "active"], as_dict=True)
+		self.assertIsNotNone(console)
+		self.assertEqual(console.virtual_machine, pilot.virtual_machine)
+		self.assertTrue(console.active)
+
+	def test_provision_adds_no_console_route_in_admin_mode(self) -> None:
+		"""The admin-mode console is already on bench_fqdn — a second row would just
+		collide with the one `_create_subdomain` inserted."""
+		pilot = self._new_pilot("acme")
+		self._drive_provision(pilot)
+		self.assertFalse(frappe.db.exists("Subdomain", "acme-pilot"))
+
+	def test_deploy_wires_the_console_host_as_admin_domain(self) -> None:
+		"""Site mode only writes `[admin].domain` when the deploy is told a host; without
+		it the guest keeps the baked `admin.localhost` placeholder."""
+		pilot = self._site_mode_pilot("srv")
+		# The Fake server short-circuits _deploy before it reaches deploy_site (both are
+		# imported inside the function, so patch them at their source modules).
+		with (
+			patch("atlas.atlas.providers.fake_tasks.is_fake_server", return_value=False),
+			patch("atlas.atlas.deploy_site.deploy_site", return_value={}) as m_deploy,
+		):
+			pilot_module._deploy(pilot)
+		self.assertEqual(m_deploy.call_args.kwargs["admin_domain"], "srv-pilot.blr1.frappe.dev")
+
+	def test_console_route_is_idempotent_across_a_retry(self) -> None:
+		"""Retry = re-run: re-driving a provision must not die on the console row's
+		duplicate key when the route is already live."""
+		pilot = self._site_mode_pilot("srv")
+		self.assertEqual(pilot_module._create_console_subdomain(pilot), "srv-pilot")
+		self.assertEqual(pilot_module._create_console_subdomain(pilot), "srv-pilot")
+
+	def test_console_route_pointing_elsewhere_fails_loud(self) -> None:
+		"""A label already routing to someone else is a real conflict, not something to
+		silently repoint."""
+		pilot = self._site_mode_pilot("srv")
+		other = fixtures.make_virtual_machine(self.server, self.admin_image)
+		frappe.get_doc(
+			{
+				"doctype": "Subdomain",
+				"subdomain": "srv-pilot",
+				"virtual_machine": other.name,
+				"active": 1,
+			}
+		).insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError):
+			pilot_module._create_console_subdomain(pilot)
+
 	def test_provision_failure_marks_failed_and_raises(self) -> None:
 		pilot = self._new_pilot("acme")
 		frappe.db.set_value("Virtual Machine", pilot.virtual_machine, "status", "Running")

--- a/atlas/atlas/doctype/pilot/test_pilot.py
+++ b/atlas/atlas/doctype/pilot/test_pilot.py
@@ -273,6 +273,24 @@ class TestPilot(IntegrationTestCase):
 		self.assertEqual(pilot_module._create_console_subdomain(pilot), "srv-pilot")
 		self.assertEqual(pilot_module._create_console_subdomain(pilot), "srv-pilot")
 
+	def test_front_door_gateway_is_the_console_in_site_mode(self) -> None:
+		"""`gateway_url` is what Central deep-links with a `?sid=`, and only the console
+		verifies that token — pointing it at a server's site host lands the user on the
+		site's login page as Guest instead of in their bench."""
+		from atlas.atlas.front_door import front_door_for_vm
+
+		pilot = self._site_mode_pilot("srv")
+		front_door = front_door_for_vm(pilot.virtual_machine)
+		self.assertEqual(front_door.gateway_url, "https://srv-pilot.blr1.frappe.dev")
+
+	def test_front_door_gateway_is_the_fqdn_in_admin_mode(self) -> None:
+		"""An admin-mode bench already answers the sid on its own host — unchanged."""
+		from atlas.atlas.front_door import front_door_for_vm
+
+		pilot = self._new_pilot("acme")
+		front_door = front_door_for_vm(pilot.virtual_machine)
+		self.assertEqual(front_door.gateway_url, "https://acme.blr1.frappe.dev")
+
 	def test_console_route_pointing_elsewhere_fails_loud(self) -> None:
 		"""A label already routing to someone else is a real conflict, not something to
 		silently repoint."""

--- a/atlas/atlas/front_door.py
+++ b/atlas/atlas/front_door.py
@@ -54,9 +54,18 @@ class FrontDoor:
 
 	@property
 	def gateway_url(self) -> str:
-		# The aggregate's name IS the fqdn (Contract A) for both Pilot and Site, so the
-		# front-door URL is `https://<name>` either way — the same value Pilot.gateway_url
-		# derives and Site's `url` uses.
+		# What Central DEEP-LINKS: it opens this URL with a Central-signed `?sid=`, which
+		# only the bench's admin console verifies. So for a Pilot the answer is its
+		# console host, not its name. Those are the same thing for an admin-mode pilot
+		# (including every attached console, whose name already carries `-pilot`), but a
+		# site-mode pilot — a server — is named after the host serving the TENANT SITE,
+		# and that site has no idea what the sid means: opening it drops the user on the
+		# site's login page as Guest instead of in their bench.
+		#
+		# A Site front door has no console of its own; its name IS the fqdn (Contract A)
+		# and its handoff is the one-click `login_url`, not the sid, so it keeps `name`.
+		if self.doc.doctype == "Pilot":
+			return f"https://{self.doc.console_fqdn}"
 		return f"https://{self.doc.name}"
 
 	@property

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -142,6 +142,10 @@ class TestCentralReport(IntegrationTestCase):
 		# name == <subdomain>.<region domain>, so stand that in as the name here.
 		pilot = SimpleNamespace(
 			name="acme.blr1.frappe.dev",
+			# FrontDoor reads gateway_url off a Pilot's console host, so the stand-in has
+			# to carry both (admin-mode here, hence console == name).
+			doctype="Pilot",
+			console_fqdn="acme.blr1.frappe.dev",
 			virtual_machine=vm.name,
 			tenant=None,
 			status="Running",
@@ -474,6 +478,10 @@ class TestCentralReportPilot(IntegrationTestCase):
 			tenant=None,
 			status=status,
 			gateway_url="https://acme.blr1.frappe.dev",
+			# The host the console answers a Central `?sid=` on — what FrontDoor reports
+			# as gateway_url. Same as the name for this admin-mode stand-in; a site-mode
+			# pilot's would carry the `-pilot` suffix.
+			console_fqdn="acme.blr1.frappe.dev",
 			login_url=login_url,
 			login_url_expires_at="2026-07-04 10:19:56",
 			doctype="Pilot",


### PR DESCRIPTION
Fixes #128 for **new server creation**.

## The bug

A stand-alone Pilot — what `create_server` provisions — deploys in `site` mode, so
its `bench_fqdn` serves the baked **site**. Its admin console had nowhere to live,
and both halves of "reachable" were missing:

1. **No vhost.** `[admin].domain` in the guest's `bench.toml` kept the baked
   `admin.localhost` placeholder. Site mode only writes that key when the deploy is
   handed a host (`if inputs.admin_domain:` in `bench/deploy-site.py`), and
   `pilot._deploy` never passed one.
2. **No route.** Nothing registered a Subdomain for a console host, so even with a
   vhost there was no proxy entry pointing at the VM — issue #128's
   "not setting up the route for `-pilot.xxxxx` domains".

Only an *attached* pilot (the console that ships with a Site) worked, because it
deploys in `admin` mode and owns `bench_fqdn` outright.

## The change

Add `Pilot.console_fqdn`, derived off `build_mode` — the effective deploy mode
(inherited from the backing VM's image at insert, forced to `admin` when attached):

| build_mode | serves at `bench_fqdn` | console host |
| --- | --- | --- |
| `admin` | the console itself | `bench_fqdn` (unchanged) |
| `site` | the baked site | `<subdomain>-pilot.<region domain>` |

The suffix is `subdomain_label.PILOT_SUFFIX`, the same one a Site's attached console
already uses, so the two paths name consoles identically.

- `_create_subdomain` registers the console host's route when it differs from the
  bench host (get-or-create, so a re-driven provision doesn't die on a duplicate key;
  a label already routing elsewhere fails loud rather than silently repointing).
- `_deploy` passes it as `admin_domain`, so the guest wires the vhost. Admin mode
  already defaults that to the FQDN it was given, so passing the same value there is
  a no-op — the two paths stay honest.

Deriving it rather than storing it keeps the route and the vhost agreeing across a
retry: `_create_subdomain` and `_deploy` are separate steps and must compute the same
host both times.

No change to `bench/deploy-site.py` — its site-mode branch already wires
`[admin].domain` (and re-points the baked site's `pilot_endpoint`) as soon as it is
given a host. This just gives it one.

## Verification

**On the staging fleet**, server created through Central end to end:

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    --resolve consolefix-pilot.sites.x.frappe.dev:443:<proxy> \
    https://consolefix-pilot.sites.x.frappe.dev/
200                       # serves the Pilot UI (<title>Pilot</title>)

# guest bench.toml
[admin]
domain = "consolefix-pilot.sites.x.frappe.dev"     # was "admin.localhost"

# Subdomain rows now routing to the VM
consolefix-pilot,  consolefix
```

Control — a server created *before* the change, on the same fleet and proxy:

```
consolefix-pilot.sites.x.frappe.dev  ->  200
prathcheck-pilot.sites.x.frappe.dev  ->  404
```

The site's own host is untouched in both (`200` on `/api/method/ping`).

**Unit tests**: 7 added, covering both modes, the route, the `admin_domain` handoff,
retry idempotency, and the conflicting-label throw. Full `test_pilot` module runs
green (24 tests) on a local test site.

## Note on scope

This fixes the **server** case, which is what #128 asks for here. The issue's item 1
also covers `-pilot` hosts generally; attached (Site) consoles already got their route
via `_create_subdomain` and are unchanged by this PR.

---

## Second commit: Central's "Open" pointed at the tenant site

Giving the console a host is only half of it — Central was still deep-linking the
wrong one.

`FrontDoor.gateway_url` is what Central opens with a Central-signed `?sid=`
(`central/api/sso.py::_asset_login_link`), and only the bench's admin console
verifies that token. It was derived from the aggregate's *name*, which for a
site-mode Pilot is the host serving the **tenant site**. The site has no idea what
the sid means:

```
GET https://<srv>.<domain>/?sid=<jwt>
→ 200   <title>Login</title>   set-cookie: sid=Guest        # dumped on a login page
```

Now a Pilot front door reports its **console** host. That is the same value as its
name for an admin-mode pilot — including every attached console, whose name already
carries `-pilot` — so only the server case changes. A Site front door has no console
of its own and hands off via its one-click `login_url` rather than a sid, so it keeps
using its name.

Both the push (`_pilot_vm_payload`) and pull (`tenant_vms`) paths build the mirror
through `FrontDoor`, so the Asset picks it up either way.

**Verified on staging against a real server** — after a reconcile:

```
Asset.gateway_url   https://openprobe.sites.x.frappe.dev
                 →  https://openprobe-pilot.sites.x.frappe.dev

central.api.sso.get_bench_link(asset=…)
                 →  https://openprobe-pilot.sites.x.frappe.dev/?sid=<jwt>
     following it →  200   <title>Pilot</title>              # the bench console
```

The two `SimpleNamespace` Pilot stand-ins in `test_central` grew `doctype` /
`console_fqdn` so they still implement what `FrontDoor` reads.

**Test runs** (local test site): `test_pilot` 26, `test_central` 42, `test_site` 37,
`api/test_provision` 6 — all green.
