### PR TITLE
fix(central): a terminated VM must not leave its front door Running

### DIFF
--- a/atlas/atlas/doctype/pilot/pilot.py
+++ b/atlas/atlas/doctype/pilot/pilot.py
@@ -228,13 +228,18 @@ class Pilot(Document):
 
 		No-op when ATTACHED: an attached Pilot shares a VM the owning Site created and
 		tears down — terminating it here would double-terminate (and race the Site's own
-		VM teardown). The attached Pilot's teardown is only its Subdomain + its own row."""
+		VM teardown). The attached Pilot's teardown is only its Subdomain + its own row.
+
+		`front_door_terminating` tells the VM this aggregate is already tearing itself
+		down, so it skips `_terminate_front_doors`: this Pilot marks and saves itself in
+		`terminate()`, and re-marking there would emit its status event twice."""
 		if self.attached:
 			return
 		if not self.virtual_machine or not frappe.db.exists("Virtual Machine", self.virtual_machine):
 			return
 		vm = frappe.get_doc("Virtual Machine", self.virtual_machine)
 		if vm.status != "Terminated":
+			vm.flags.front_door_terminating = True
 			vm.terminate()
 
 	@frappe.whitelist()

--- a/atlas/atlas/doctype/site/site.py
+++ b/atlas/atlas/doctype/site/site.py
@@ -215,11 +215,17 @@ class Site(Document):
 			pilot.terminate()
 
 	def _terminate_backing_vm(self) -> None:
-		"""Terminate the backing VM if one was created and is not already gone."""
+		"""Terminate the backing VM if one was created and is not already gone.
+
+		`front_door_terminating` tells the VM its aggregates are already tearing
+		themselves down, so it skips `_terminate_front_doors` — this Site marks and saves
+		itself below, and the attached Pilot was marked by `_terminate_pilot` above.
+		Without the flag both would be re-marked and their status events emitted twice."""
 		if not self.virtual_machine or not frappe.db.exists("Virtual Machine", self.virtual_machine):
 			return
 		vm = frappe.get_doc("Virtual Machine", self.virtual_machine)
 		if vm.status != "Terminated":
+			vm.flags.front_door_terminating = True
 			vm.terminate()
 
 	@frappe.whitelist()

--- a/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/test_virtual_machine.py
@@ -584,6 +584,79 @@ class TestVirtualMachine(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Subdomain", subdomain.name))
 		self.assertIsNone(frappe.db.get_value("Pilot", pilot.name, "subdomain_doc"))
 
+	def test_terminate_marks_the_owning_pilot_terminated(self) -> None:
+		"""Terminating the VM directly — what Central's terminate_server and the desk's
+		Terminate button both do — must not leave the Pilot claiming Running. Central
+		mirrors the AGGREGATE's status, so a stale Running there is a dead server shown
+		as live, with Open minting a session for a gateway that answers nothing."""
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		_ensure_active_root_domain()
+		vm = _new_vm()
+		pilot = frappe.get_doc({"doctype": "Pilot", "subdomain": "orphan-check"})
+		pilot.flags.attach_vm = vm.name
+		pilot.insert(ignore_permissions=True)
+		pilot.db_set("status", "Running")
+
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task", return_value=fake_task(name="task-term")):
+			vm.terminate()
+
+		self.assertEqual(frappe.db.get_value("Pilot", pilot.name, "status"), "Terminated")
+
+	def test_terminate_marks_both_aggregates_of_a_self_serve_vm(self) -> None:
+		"""A self-serve VM is backed by a Site AND its attached Pilot on the one microVM.
+		Reaching only the first (front_door_for_vm stops at the Pilot) would leave the
+		Site — the tenant's actual site — reported Running over a VM that is gone."""
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		_ensure_active_root_domain()
+		vm = _new_vm()
+		site = frappe.get_doc({"doctype": "Site", "subdomain": "bothends"})
+		site.flags.attach_vm = vm.name
+		site.insert(ignore_permissions=True)
+		site.db_set("virtual_machine", vm.name)
+		site.db_set("status", "Running")
+		pilot = frappe.get_doc({"doctype": "Pilot", "subdomain": "bothends-pilot"})
+		pilot.flags.attach_vm = vm.name
+		pilot.insert(ignore_permissions=True)
+		pilot.db_set("status", "Running")
+
+		vm.db_set("status", "Stopped")
+		vm.reload()
+		with patch.object(module, "run_task", return_value=fake_task(name="task-term")):
+			vm.terminate()
+
+		self.assertEqual(frappe.db.get_value("Pilot", pilot.name, "status"), "Terminated")
+		self.assertEqual(frappe.db.get_value("Site", site.name, "status"), "Terminated")
+
+	def test_pilot_terminate_does_not_double_report(self) -> None:
+		"""When the PILOT initiates, it marks and saves itself — the VM must not re-mark
+		it, or the same status event is emitted twice to Central."""
+		from atlas.atlas.doctype.virtual_machine import virtual_machine as module
+
+		_ensure_active_root_domain()
+		vm = _new_vm()
+		pilot = frappe.get_doc({"doctype": "Pilot", "subdomain": "selfterm"})
+		pilot.flags.attach_vm = vm.name
+		pilot.insert(ignore_permissions=True)
+		pilot.db_set("status", "Running")
+		pilot.db_set("attached", 0)
+		pilot.reload()
+
+		vm.db_set("status", "Stopped")
+		with (
+			patch.object(module, "run_task", return_value=fake_task(name="task-term")),
+			patch("atlas.atlas.central_report.report_pilot_status") as reported,
+		):
+			pilot.terminate()
+
+		self.assertEqual(frappe.db.get_value("Pilot", pilot.name, "status"), "Terminated")
+		# The VM's propagation is skipped (flags.front_door_terminating), so the only
+		# report is the Pilot's own save → on_pilot_update. Never two.
+		self.assertLessEqual(reported.call_count, 1)
+
 	def test_parse_size_bytes(self) -> None:
 		from atlas.atlas.task_results import parse_result
 

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -1048,10 +1048,59 @@ class VirtualMachine(Document):
 		self._delete_custom_domains()
 		self._delete_snapshots()
 		self._deprovision_proxy()
+		self._terminate_front_doors()
 		# The VM's private /128 leaves the local-ownership cache (vm-network-down.py
 		# removes it on teardown); atlas-networkd's scan detects the change and gossips
 		# the withdrawal (spec/31 §11). No controller-side reconcile.
 		return task.name
+
+	def _terminate_front_doors(self) -> None:
+		"""Mark every aggregate backed by this VM Terminated, and push that status.
+
+		A `Pilot`/`Site` is the AUTHORITATIVE status Central mirrors for a bench VM
+		(`front_door.FrontDoor.status`, `central_report.on_vm_update`, which suppresses the
+		raw VM status for exactly these VMs). The aggregate→VM direction was wired —
+		`Pilot.terminate()` tears down its VM — but the VM→aggregate direction was not, so
+		terminating the VM DIRECTLY left the aggregate claiming Running forever. That is
+		not a corner: it is what Central's own `terminate_server` does (it invokes the
+		action on the Virtual Machine), and what the desk's Terminate button on a VM does.
+
+		Nothing corrected it afterwards, either: `vm.deleted` fires from `on_trash` and
+		Atlas never deletes the row (terminate is a status flip), and the reconcile pull
+		(`api.inventory.tenant_vms`) reports the FRONT DOOR's status — so it re-asserted
+		Running rather than repairing it. The result was a tenant seeing a dead server
+		listed as Running, with Open minting a session for a gateway that answers nothing.
+
+		Both aggregates, not just the handoff owner: a self-serve VM carries a Site AND
+		its attached Pilot (`front_doors_for_vm`), and leaving either behind reproduces the
+		bug on that half. `db_set` skips `on_update`, so the status event is emitted
+		explicitly — the same gap `report_pilot_status` / `report_site_status` exist to
+		close. Delivery is best-effort by design (a queued POST); a Central that is down
+		must not fail a terminate, so emission is guarded but the status write is not.
+
+		Skipped when the aggregate is the one doing the terminating (`Pilot.terminate()` /
+		`Site.terminate()` set `flags.front_door_terminating` before calling us): it marks
+		and saves itself, and re-marking here would fire the same event twice."""
+		if self.flags.get("front_door_terminating"):
+			return
+		from atlas.atlas.front_door import front_doors_for_vm
+
+		for door in front_doors_for_vm(self.name):
+			doc = door.doc
+			if doc.status == "Terminated":
+				continue
+			doc.db_set("status", "Terminated")
+			try:
+				from atlas.atlas import central_report
+
+				if doc.doctype == "Pilot":
+					central_report.report_pilot_status(doc)
+				else:
+					central_report.report_site_status(doc)
+			except Exception:
+				# The status is already persisted; a reporting failure must not undo the
+				# terminate. Central's own reconcile now reads the corrected status.
+				frappe.log_error(title=f"front-door terminate report failed: {doc.doctype} {doc.name}")
 
 	def _deprovision_proxy(self) -> None:
 		"""If this VM fronted traffic as a proxy, drop it out of the fleet on terminate

--- a/atlas/atlas/front_door.py
+++ b/atlas/atlas/front_door.py
@@ -88,9 +88,30 @@ def front_door_for_vm(vm_name: str) -> FrontDoor | None:
 	"""The Pilot or Site backing a VM as a `FrontDoor`, or None for a plain VM.
 
 	The single VM→front-door resolver: replaces the Pilot-only `pilot_for_vm` at the
-	Central seam so a Site-backed VM (create_site) resolves its login handoff too."""
+	Central seam so a Site-backed VM (create_site) resolves its login handoff too.
+
+	Returns the FIRST match in `_FRONT_DOOR_DOCTYPES` order — Pilot before Site — which
+	is deliberate for the handoff: a self-serve VM carries BOTH a Site and its attached
+	Pilot, and what Central deep-links is the console, not the tenant site. Use
+	`front_doors_for_vm` when you need every aggregate rather than the one that owns the
+	handoff."""
 	for doctype in _FRONT_DOOR_DOCTYPES:
 		name = frappe.db.get_value(doctype, {"virtual_machine": vm_name}, "name")
 		if name:
 			return FrontDoor(frappe.get_doc(doctype, name))
 	return None
+
+
+def front_doors_for_vm(vm_name: str) -> list["FrontDoor"]:
+	"""EVERY aggregate backed by this VM, not just the one that owns the handoff.
+
+	A self-serve VM is backed by two: the `Site` (the tenant's Frappe site) and the
+	attached `Pilot` (its admin console), which share the one microVM. `front_door_for_vm`
+	answers "who owns the login handoff" and stops at the first; anything that must act on
+	the VM's whole ownership — terminating it, above all — has to reach both, or one
+	aggregate is left claiming to be Running over a VM that no longer exists."""
+	doors = []
+	for doctype in _FRONT_DOOR_DOCTYPES:
+		for name in frappe.get_all(doctype, filters={"virtual_machine": vm_name}, pluck="name"):
+			doors.append(FrontDoor(frappe.get_doc(doctype, name)))
+	return doors

--- a/atlas/patches.txt
+++ b/atlas/patches.txt
@@ -21,3 +21,4 @@ atlas.patches.v1_0.move_region_to_atlas_settings
 atlas.patches.v1_0.seed_settings_from_site_config
 atlas.patches.v1_0.mark_default_catalog_rows
 atlas.patches.v1_0.backfill_server_signing_key
+atlas.patches.v1_0.terminate_front_doors_over_dead_vms

--- a/atlas/patches/v1_0/terminate_front_doors_over_dead_vms.py
+++ b/atlas/patches/v1_0/terminate_front_doors_over_dead_vms.py
@@ -1,0 +1,35 @@
+"""Mark every Pilot/Site that outlived its backing VM Terminated.
+
+Until `VirtualMachine._terminate_front_doors` existed, terminating a VM directly — which
+is what Central's `terminate_server` does, and the desk's Terminate button on a VM — left
+the owning aggregate claiming `Running` forever. Nothing corrected it afterwards: Atlas
+never deletes the VM row (terminate is a status flip, so `vm.deleted` never fired), and
+the reconcile pull reports the FRONT DOOR's status, so it re-asserted Running instead of
+repairing it. Tenants saw dead servers listed as Running.
+
+The code fix stops new ones accruing; this repairs the rows already stranded. No events
+are emitted here — the periodic reconcile reads `front_door.status` (`api.inventory
+.tenant_vms`), so Central's mirror converges on its own once Atlas's own truth is right,
+without a migrate-time event storm.
+
+A missing VM row counts as dead too: the aggregate can never serve again either way.
+"""
+
+import frappe
+
+
+def execute():
+	for doctype in ("Pilot", "Site"):
+		for row in frappe.get_all(
+			doctype,
+			filters={"status": ("!=", "Terminated")},
+			fields=["name", "virtual_machine"],
+		):
+			if not row.virtual_machine:
+				# Never got a VM (failed before provisioning). Its own status already
+				# tells that story; nothing to reconcile against.
+				continue
+			vm_status = frappe.db.get_value("Virtual Machine", row.virtual_machine, "status")
+			if vm_status is not None and vm_status != "Terminated":
+				continue
+			frappe.db.set_value(doctype, row.name, "status", "Terminated", update_modified=False)


### PR DESCRIPTION
## The bug

Central mirrors a bench VM's status from its **aggregate** (`Pilot`/`Site`), not the raw
VM — `central_report.on_vm_update` deliberately suppresses the raw status for exactly
these VMs, on the stated assumption that *"terminate/delete still ride the aggregate's
own status event + `vm.deleted`, so no signal is lost."*

Both halves of that assumption were false.

* The **aggregate → VM** direction was wired (`Pilot.terminate()` tears down its VM). The
  **VM → aggregate** direction was not. So terminating the VM directly left the
  Pilot/Site claiming `Running` forever — and that is the normal path, not a corner:
  Central's own `terminate_server` invokes the action on the *Virtual Machine*
  (`run_doc_method`), so `Pilot.terminate()` never runs. The desk's Terminate button on a
  VM does the same.
* `vm.deleted` fires from `on_trash`, and Atlas **never deletes the VM row** — terminate
  is a status flip. It has been emitted **zero times, ever** (`Central Event Log`
  all-time count = 0).

Nor could the backstop repair it: the reconcile pull (`api.inventory.tenant_vms`) returns
`front_door.status if front_door else vm.status` — the *aggregate's* status — so every
10 minutes it re-asserted `Running`.

**Tenant-visible result:** a dead server listed as Running, and **Open** minting a signed
session for a gateway with nothing behind it.

Found live on the `x.frappe.dev` staging fleet: **23 Pilots and 6 Sites** Running over
Terminated VMs.

## The fix

`VirtualMachine.terminate()` now marks every aggregate backed by the VM Terminated and
pushes that status.

**Every** aggregate, not just the handoff owner. A self-serve VM carries a `Site` *and*
its attached `Pilot` on the one microVM, and `front_door_for_vm` stops at the first
(Pilot — deliberately, since that is what Central deep-links). Reaching only one leaves
the other half of the same VM reporting Running. New `front_doors_for_vm` returns them
all; `front_door_for_vm` keeps its first-match contract for the login handoff.

`db_set` skips `on_update`, so the status event is emitted explicitly — the same gap
`report_pilot_status` / `report_site_status` already exist to close. Emission is wrapped:
the status write must not be undone by a Central that happens to be down.

When the aggregate is the one terminating, it marks and saves itself, so
`Pilot`/`Site._terminate_backing_vm` set `flags.front_door_terminating` and the VM skips
the propagation rather than emitting the same event twice.

`atlas.patches.v1_0.terminate_front_doors_over_dead_vms` repairs the rows already
stranded. It emits nothing: the reconcile reads `front_door.status`, so Central converges
on its own once Atlas's truth is right, without a migrate-time event storm.

## Verified live

Repair, on staging:

```
Atlas    stranded Pilots/Sites   (23, 6) -> (0, 0)
Central  Assets Running          23 -> 3     Terminated 18 -> 41
```

Then a throwaway server terminated through **Central's `terminate_server`** — the exact
call that produced all of them:

| | before | after |
|---|---|---|
| Atlas `Pilot` | Running | **Terminated** |
| Atlas `Virtual Machine` | Running | Terminated |
| `Subdomain` rows | `termcheck`, `termcheck-pilot` | *(none)* |
| both FQDNs over HTTPS | 200 / 200 | 404 / 404 |
| **Central `Asset`** | Running | **Terminated** |

Central's `Asset.last_event_at` is `16:53:18.433`, matching the `vm.status_changed`
delivered `ok` at `16:53:18.433` — it converged from the **event push**, not the 10-minute
reconcile.

## Tests

330 green. The two propagation tests were **negative-controlled**: with
`_terminate_front_doors` neutralized they fail, which is the only way to know they assert
anything. A third pins the no-double-report guard.

## Not in scope here

* The **inverse** condition also exists on that fleet and is untouched: 3 attached
  consoles `Terminated` while their VM still runs (all marked a day before this work;
  cause unknown).
* `Pilot Credential` stays `Active` after termination. Not exploitable via Open —
  `sso.get_bench_link` gates on the Asset being `Running` — but it is the same credential
  hygiene gap as `sso` filtering on `status: Active` without requiring a `token_hash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
