### PR TITLE
feat(server): upgrade an existing host's boat generation without a re-bootstrap

### DIFF
--- a/atlas/atlas/boat_client.py
+++ b/atlas/atlas/boat_client.py
@@ -50,6 +50,8 @@ from atlas.atlas.providers.fake_tasks import is_fake_server
 from atlas.atlas.task_results import result_line
 
 if TYPE_CHECKING:
+	from collections.abc import Callable
+
 	from atlas.atlas.doctype.task.task import Task
 	from atlas.atlas.doctype.virtual_machine.virtual_machine import VirtualMachine
 
@@ -349,6 +351,36 @@ class BoatClient:
 	def get_operation(self, operation_id: str) -> dict:
 		"""GET /ops/{operation_id} — the journal record for one Task name."""
 		return self._request("GET", f"/ops/{operation_id}")
+
+	def migrate(self, uuid: str, phase: str, *, operation_id: str, params: dict) -> dict:
+		"""POST /vms/{uuid}/migrate/{phase} — run one MUTATING phase of the
+		cross-host migration saga, returning the operation record (spec/33 §8).
+
+		`operation_id` is the Frappe Task name — the same replay key every verb
+		shares, so a retried migration Task returns the phase's first result rather
+		than re-running it. `params` are the phase-specific `MigrateRequest` fields,
+		the UUID-derived ones (nbd port/slots, tunnel device/port, route table)
+		already dropped by the caller because Boat re-derives them from the UUID.
+		The poll-only Hydrating phase is `get_migration_hydration`, not this."""
+		return self._request(
+			"POST", f"/vms/{uuid}/migrate/{phase}", json={"operation_id": operation_id, **params}
+		)
+
+	def get_migration_hydration(self, uuid: str, *, clone_device: str | None = None) -> dict:
+		"""GET /vms/{uuid}/migrate/hydration — the Hydrating phase's per-tick poll.
+
+		A plain read, deliberately carrying no operation identifier and writing no
+		journal record (spec/33 §8): a poll runs every controller tick for the life
+		of the copy, so it must not bury the op journal. Returns `hydration_percent`
+		(0..100, the MIN across the VM's disk clones) and `source_healthy`.
+
+		`clone_device` polls one named dm device instead of the VM's own clones —
+		the base-image ship's `atlas-base-<image>-clone` (spec/24 §5.1) — and is
+		omitted for the ordinary disk poll."""
+		path = f"/vms/{uuid}/migrate/hydration"
+		if clone_device:
+			path += f"?clone_device={clone_device}"
+		return self._request("GET", path)
 
 	def _request(self, method: str, path: str, json: dict | None = None):
 		url = f"{self.base_url}{path}"
@@ -807,3 +839,293 @@ def _error_sentence(response: "requests.Response") -> str:
 		return response.json()["error"]
 	except (ValueError, KeyError, TypeError):
 		return response.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Migration phases (spec/33 §8, item 9). The cross-host migration saga's host work
+# moves off SSH onto Boat one PHASE at a time, exactly as the lifecycle verbs did.
+# `run_boat_migration_phase` is `run_boat_task`'s twin for the saga: same Task row,
+# same replay-by-operation-id, same Fake shortcut. The two transports differ only
+# in the grammar — a lifecycle verb is `POST /vms/{uuid}/{verb}`, a migration phase
+# is `POST /vms/{uuid}/migrate/{phase}` — so the mapping below is the whole of the
+# translation, the migration analogue of `_run_verb` + the rebuild collections.
+#
+# Boat DERIVES every per-VM device from the UUID (nbd port = NBDPort(uuid), the nbd
+# client slots, the tunnel device/port, the route table), so the matching Atlas
+# variables — NBD_PORT, NBD_BASE_SLOT, TUNNEL_DEVICE, TUNNEL_PORT, ROUTE_TABLE — are
+# NOT sent: two sides deriving the same value from the same UUID need no wire field,
+# and sending one invites a disagreement. VIRTUAL_MACHINE_NAME is likewise dropped
+# because the path names the VM.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# The Hydrating poll's Atlas verb. Special-cased out of MIGRATION_PHASES because it
+# is a GET with no operation record (spec/33 §8), not one of the mutating POST phases.
+MIGRATION_POLL_HYDRATION = "migration-poll-hydration"
+
+# migration-inject-identity variable -> GuestIdentity field. Every value is written
+# into the mounted rootfs verbatim; Boat parses none of it (spec/33 §7.2). Absent
+# here on purpose:
+#   VIRTUAL_MACHINE_NAME   the path names the VM
+#   CLONE_DEVICE           Boat derives the write device from the UUID
+#                          (/dev/mapper/atlas-vm-<uuid>-clone, falling back to the
+#                          plain LV — inject_identity.go), so a device sent here
+#                          could only disagree with the one it will actually use
+#   ROUTING_BASE_URL       becomes one anonymous guest file (extra_env), never a
+#                          named field — the guest-service seam, exactly as rebuild
+MIGRATION_INJECT_IDENTITY = {
+	"VIRTUAL_MACHINE_IPV6": "ipv6_address",
+	"IPV4_GUEST_CIDR": "ipv4_guest_cidr",
+	"IPV4_GATEWAY": "ipv4_gateway",
+	"SSH_PUBLIC_KEY": "authorized_keys_blob",
+	"DATA_DISK_MOUNT_AT": "data_disk_mount_at",
+}
+
+
+def _migration_guest_identity(variables: dict) -> dict:
+	"""The `GuestIdentity` blob an inject-identity phase writes through the clone.
+
+	Absent fields are left out rather than sent empty (Boat writes a defined value
+	for each either way), and DATA_DISK_MOUNT_AT empty means no data mount and no
+	fstab line. ROUTING_BASE_URL rides as one anonymous `extra_env` file, reusing
+	`_guest_files` so the byte-for-byte content matches the rebuild path's."""
+	identity = {
+		field: variables[key] for key, field in MIGRATION_INJECT_IDENTITY.items() if variables.get(key)
+	}
+	files = _guest_files(variables)
+	if files:
+		identity["extra_env"] = files
+	return identity
+
+
+def _export_source_params(variables: dict) -> dict:
+	# The source's own public IPv4 qemu-nbd binds — the one thing the source cannot
+	# derive from the UUID. NBD_PORT is dropped (Boat derives it).
+	return {"bind_address": variables["BIND_ADDRESS"]}
+
+
+def _export_base_params(variables: dict) -> dict:
+	return {"image_name": variables["IMAGE_NAME"], "bind_address": variables["BIND_ADDRESS"]}
+
+
+def _clone_target_params(variables: dict) -> dict:
+	return {
+		"image_name": variables["IMAGE_NAME"],
+		"disk_gb": int(variables["DISK_GB"]),
+		"data_disk_gb": int(variables["DATA_DISK_GB"]),
+		"source_host": variables["SOURCE_HOST"],
+	}
+
+
+def _receive_base_params(variables: dict) -> dict:
+	# PHASE (prepare|finalize) is the base-ship's own half, not a UUID-derived value,
+	# so it IS sent — as `base_phase`.
+	return {
+		"image_name": variables["IMAGE_NAME"],
+		"disk_gb": int(variables["DISK_GB"]),
+		"source_host": variables["SOURCE_HOST"],
+		"base_phase": variables["PHASE"],
+	}
+
+
+def _inject_identity_params(variables: dict) -> dict:
+	return {"identity": _migration_guest_identity(variables)}
+
+
+def _collapse_clone_params(variables: dict) -> dict:
+	# Whether a second (data) clone must be collapsed too; NBD_BASE_SLOT dropped.
+	return {"data_disk_gb": int(variables["DATA_DISK_GB"])}
+
+
+def _forward_up_params(variables: dict) -> dict:
+	# ROLE is required; SOURCE_HOST rides on the target role only (the connector's
+	# dial address); VIRTUAL_MACHINE_IPV6 is optional — forward-up runs once bare
+	# before the routes are known and again at cutover once they are. TUNNEL_DEVICE,
+	# TUNNEL_PORT and ROUTE_TABLE are all UUID-derived and dropped.
+	params = {"role": variables["ROLE"]}
+	if variables.get("SOURCE_HOST"):
+		params["source_host"] = variables["SOURCE_HOST"]
+	if variables.get("VIRTUAL_MACHINE_IPV6"):
+		params["virtual_machine_ipv6"] = variables["VIRTUAL_MACHINE_IPV6"]
+	return params
+
+
+def _source_forward_params(variables: dict) -> dict:
+	# REASSERT_PROXY_NDP is NOT sent: Boat's source-forward re-asserts proxy-NDP
+	# UNCONDITIONALLY on every provider (forward.go), so the flag has no field — it
+	# is the always-on behaviour, not a choice. TUNNEL_DEVICE is UUID-derived.
+	return {"virtual_machine_ipv6": variables["VIRTUAL_MACHINE_IPV6"]}
+
+
+def _target_receive_params(variables: dict) -> dict:
+	return {"virtual_machine_ipv6": variables["VIRTUAL_MACHINE_IPV6"]}
+
+
+def _forward_down_params(variables: dict) -> dict:
+	# DEASSERT_PROXY_NDP is likewise unconditional in Boat's forward-down, so only
+	# the role and the /128 are sent. (forward-down stays controller-side over SSH in
+	# migration.collapse_forward today; this entry is the catalog for symmetry.)
+	return {"role": variables["ROLE"], "virtual_machine_ipv6": variables["VIRTUAL_MACHINE_IPV6"]}
+
+
+def _withdraw_private_params(variables: dict) -> dict:
+	# The /128 to withdraw from the source's local-ownership cache; empty is a clean
+	# no-op for a tenant-less VM, so the empty string is passed through as-is.
+	return {"private_address": variables.get("PRIVATE_ADDRESS", "")}
+
+
+def _cleanup_source_params(variables: dict) -> dict:
+	# TODO(item9-live): KEEP_ADDRESS has no field on Boat's MigrateRequest /
+	# CleanupSourceParams (cleanup_source.go carries only NBDPID). On the keep-address
+	# path Atlas passes KEEP_ADDRESS=1 to SUPPRESS the ingress teardown — the M1 fix:
+	# CleanupSource runs vm-network-down, which deletes the proxy-NDP entry and the nft
+	# forward rules migration-source-forward installed, black-holing the migrated
+	# tenant's public ingress. Boat's cleanup-source cannot yet honour that suppression,
+	# so a keep-address migration driven over Boat would tear down its own forward. This
+	# gap MUST be closed by the live migration (a keep_address field on the phase, or a
+	# split verb) before the keep-address path runs on a real Boat host. NBD_PORT is
+	# UUID-derived and dropped; nbd_pid is the one thing Boat still needs.
+	return {"nbd_pid": int(variables.get("NBD_PID") or 0)}
+
+
+# Atlas migration verb -> (Boat phase string, `variables -> body params` builder).
+# The 12 mutating phases Boat's MigrateVirtualMachine serves (api/migration.go); the
+# poll-only Hydrating phase is MIGRATION_POLL_HYDRATION above. A verb not in this map
+# raises rather than appearing to have run — the migration analogue of `_run_verb`'s
+# "Boat serves no endpoint" refusal.
+MIGRATION_PHASES = {
+	"migration-export-source": ("export-source", _export_source_params),
+	"migration-export-base": ("export-base", _export_base_params),
+	"migration-clone-target": ("clone-target", _clone_target_params),
+	"migration-receive-base": ("receive-base", _receive_base_params),
+	"migration-inject-identity": ("inject-identity", _inject_identity_params),
+	# The collapse script keeps its Atlas name (migration-cutover-target.py); Boat
+	# calls the phase collapse-clone.
+	"migration-cutover-target": ("collapse-clone", _collapse_clone_params),
+	"migration-forward-up": ("forward-up", _forward_up_params),
+	"migration-source-forward": ("source-forward", _source_forward_params),
+	"migration-target-receive": ("target-receive", _target_receive_params),
+	"migration-forward-down": ("forward-down", _forward_down_params),
+	"migration-withdraw-private-source": ("withdraw-private", _withdraw_private_params),
+	"migration-cleanup-source": ("cleanup-source", _cleanup_source_params),
+}
+
+
+def run_boat_migration_phase(
+	*,
+	script: str,
+	variables: dict,
+	server: str,
+	virtual_machine: str | None = None,
+	timeout_seconds: int = 1800,
+) -> "Task":
+	"""Run one migration saga phase through the host's Boat daemon, recording the
+	Task row `run_task` would have recorded — `run_boat_task`'s twin for the phases
+	(spec/33 §8, item 9).
+
+	Keyword-for-keyword `run_task`'s signature, so `migration._run_phase_task` calls
+	it exactly as it called `run_task`. The Hydrating poll (`migration-poll-hydration`)
+	is a GET whose reading is folded onto the row as the one `ATLAS_RESULT=` line the
+	SSH poll script emitted, so `_phase_hydrating` parses it unchanged; the 12 mutating
+	phases are POST-claimed and polled like every other verb. Raises
+	`frappe.ValidationError` on any failure, with the Task saved first."""
+	# Fake provider (developer_mode): a Task on a Fake-backed Server succeeds (or
+	# fails on demand) with no Boat call, exactly as run_boat_task/run_task give it no
+	# request. The dev/test fleet is Fake hosts, so a real socket would go nowhere —
+	# the synthesized Task row (with its ATLAS_RESULT for the phases that return one)
+	# stands in, which is what keeps the Fake↔Fake migration tests transport-real.
+	if is_fake_server(server):
+		from atlas.atlas.providers.fake_tasks import run_fake_task
+
+		return run_fake_task(server, script, variables, virtual_machine)
+
+	if not virtual_machine:
+		frappe.throw(
+			_("run_boat_migration_phase: {0} needs a virtual_machine — Boat addresses VMs by UUID").format(
+				script
+			)
+		)
+
+	task = frappe.get_doc(
+		{
+			"doctype": "Task",
+			"server": server,
+			"virtual_machine": virtual_machine,
+			"script": script,
+			"status": "Pending",
+			"triggered_by": frappe.session.user if frappe.session else "Administrator",
+		}
+	)
+	task.variables_dict = variables
+	task.insert(ignore_permissions=True)
+
+	_execute_migration_phase_on_boat(task, server, script, variables, timeout_seconds)
+	return task
+
+
+def _execute_migration_phase_on_boat(
+	task: "Task",
+	server: str,
+	script: str,
+	variables: dict,
+	timeout_seconds: int,
+) -> None:
+	"""Drive an inserted migration-phase Task to its outcome over Boat. Mirrors
+	`_execute_on_boat` step for step — same `_mark_running` / `_finalize` so the row
+	shape cannot drift between the lifecycle and migration transports — and forks only
+	on the one structural difference: the Hydrating poll is a GET with no operation
+	record, so it takes no claim and no poll loop.
+
+	Both branches end at the same `_finalize`: the mutating phases fold the operation's
+	trace + typed result the way every verb does (`_task_stdout`), and the poll folds
+	its `hydration_percent`/`source_healthy` reading onto the row as the same
+	`ATLAS_RESULT=` line the SSH poll script wrote, so the controller reads one Task
+	the same way whichever transport filled it."""
+	_mark_running(task)
+	start = time.monotonic()
+	try:
+		client = BoatClient.for_server(server, timeout_seconds=POLL_REQUEST_TIMEOUT_SECONDS, poll=True)
+		if script == MIGRATION_POLL_HYDRATION:
+			hydration = client.get_migration_hydration(
+				task.virtual_machine, clone_device=variables.get("CLONE_DEVICE")
+			)
+			result = {
+				"hydration_percent": hydration["hydration_percent"],
+				"source_healthy": hydration["source_healthy"],
+			}
+			# Reuse _task_stdout with an operation-shaped payload so the row's stdout is
+			# assembled by the one place that owns the ATLAS_RESULT= fold.
+			stdout = _task_stdout({OPERATION_RESULT_FIELD: result})
+			status, exit_code, error = "Success", 0, ""
+		else:
+			phase, build_params = _migration_phase(script)
+			operation = client.migrate(
+				task.virtual_machine, phase, operation_id=task.name, params=build_params(variables)
+			)
+			operation = _await_operation(client, task.name, operation, timeout_seconds)
+			status, exit_code = _outcome(operation, task.name)
+			stdout = _task_stdout(operation)
+			error = operation.get("error") or ""
+	except Exception as exception:
+		_finalize(task, "", str(exception), None, "Failure", _elapsed_ms(start))
+		if isinstance(exception, frappe.ValidationError):
+			raise
+		raise frappe.ValidationError(str(exception)) from exception
+
+	_finalize(task, stdout, error, exit_code, status, _elapsed_ms(start))
+	if status == "Failure":
+		frappe.throw(f"Task {task.name} ({script}) exited {exit_code}: {error[-500:]}")
+
+
+def _migration_phase(script: str) -> "tuple[str, Callable[[dict], dict]]":
+	"""The Boat phase string and body builder for one Atlas migration verb.
+
+	An unmapped verb raises. A phase Boat cannot run must fail loud rather than appear
+	to have run — the same discipline `_run_verb` keeps for the lifecycle verbs."""
+	mapping = MIGRATION_PHASES.get(script)
+	if mapping is None:
+		served = ", ".join(sorted(MIGRATION_PHASES))
+		raise BoatError(
+			f"Boat serves no migration phase for verb {script!r} "
+			f"(it serves {served}, plus {MIGRATION_POLL_HYDRATION})"
+		)
+	return mapping

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -883,6 +883,51 @@ class Server(Document):
 		reinstall_atlas_venv_package(connection, self.name)
 
 	@frappe.whitelist()
+	def upgrade_boat(self) -> str:
+		"""Bring an ALREADY-bootstrapped host up to the boat generation this
+		controller ships — the binary, the sudoers allow-list and the two units —
+		without a full `bootstrap` (which also re-runs `boat bootstrap`, mutates
+		status, and re-prepares a host that is already VM-ready).
+
+		This is the counterpart `sync_scripts` deliberately is not. `sync_scripts`
+		refreshes only the pure /var/lib/atlas/bin code and leaves the binary and
+		the units alone, because those need a privileged install and a daemon
+		restart. But that left NO lighter path than a full re-`bootstrap` to deliver
+		a new binary, a new allow-list line or an edited unit to a live host — so a
+		fix to any of the three could reach a freshly bootstrapped host and no other
+		(the deployment gap the split's audits kept naming: the binary, the
+		allow-list and the units are three uncoupled hand-installs). This closes it:
+		the boat-artifact + unit + durable-script subset of bootstrap, made a
+		first-class, idempotent, re-runnable operation.
+
+		Reuses bootstrap's own steps so the two can never drift:
+		  1. upload the boat artifacts, the units and the durable scripts;
+		  2. `_install_boat` — the service user, the validate-then-install sudoers,
+		     the rename-into-place binary, the units, `daemon-reload`, and the
+		     SHA-256 proof of what landed (which also records `observed_boat_version`);
+		  3. `_start_boat` — `restart` so the running daemon re-execs the new inode
+		     (the rename alone does not take effect until re-exec), then `is-active`
+		     to prove it stayed up;
+		  4. reinstall the durable atlas package into the venv so the refreshed hooks
+		     are what imports resolve — exactly `sync_scripts`' last step.
+
+		Idempotent: a host already at this generation re-ships identical bytes, the
+		`mv -f`/`install` overwrite in place, and the digest check confirms the swap.
+		Returns the `boat version` now installed. A Fake server has no host and is a
+		no-op that records nothing, exactly as `bootstrap` skips its host steps."""
+		if is_fake_server(self.name):
+			return ""
+		if not self.ipv4_address:
+			frappe.throw(f"Server {self.name} has no ipv4_address; cannot upgrade boat")
+		connection = connection_for_server(self)
+		upload_files(connection, self._bootstrap_uploads())
+		self._install_boat(connection)
+		self._start_boat(connection)
+		self._reinstall_atlas_venv_package(connection)
+		self.save(ignore_permissions=True)
+		return self.observed_boat_version or ""
+
+	@frappe.whitelist()
 	def reboot(self) -> str:
 		"""Run reboot-server.sh as a Task. SSH drops mid-Task — Task ends in
 		Failure; the operator confirms reboot by waiting and reconnecting."""
@@ -1244,6 +1289,52 @@ def sync_scripts_to_all() -> dict[str, int]:
 
 	with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
 		return dict(pool.map(_push, jobs))
+
+
+def upgrade_all_hosts_to_current_boat(*, enqueue: bool = True) -> dict[str, str]:
+	"""Bring every Active host to the boat generation this controller ships.
+
+	The fleet-wide counterpart to `Server.upgrade_boat`, and the mechanism the
+	`upgrade_hosts_to_current_boat` patch runs once after a boat change lands: a
+	new binary, allow-list line or unit that `sync_scripts` cannot deliver reaches
+	the whole fleet here. Active-only — a Pending/Broken host has no working SSH.
+
+	`enqueue=True` (the default, and what the patch uses) queues ONE background job
+	per host, so a `bench migrate` is never blocked on N privileged installs and
+	daemon restarts over SSH and one slow or unreachable host cannot stall the rest
+	or the migrate itself. Returns {server_name: "queued"}. `enqueue=False` runs
+	them inline, serially and tolerantly — one host's failure is logged and does not
+	stop the next — returning {server_name: installed_version | "error: …"}, the
+	shape an operator watches from a `bench execute`/console sweep."""
+	names = frappe.get_all("Server", filters={"status": "Active"}, pluck="name")
+	results: dict[str, str] = {}
+	for name in names:
+		if enqueue:
+			frappe.enqueue(
+				"atlas.atlas.doctype.server.server.upgrade_host_to_current_boat",
+				queue="long",
+				timeout=1800,
+				job_id=f"upgrade-boat-{name}",
+				deduplicate=True,
+				server_name=name,
+			)
+			results[name] = "queued"
+			continue
+		try:
+			results[name] = frappe.get_doc("Server", name).upgrade_boat() or "ok"
+		except Exception as exc:
+			frappe.logger("atlas").warning(f"upgrade-boat failed for {name}: {exc}")
+			results[name] = f"error: {exc}"
+	return results
+
+
+def upgrade_host_to_current_boat(server_name: str) -> None:
+	"""Background-job entry for `upgrade_all_hosts_to_current_boat(enqueue=True)`:
+	upgrade one host and commit. The doc is loaded fresh inside the job so nothing
+	stale crosses the enqueue boundary, and a failure surfaces in the job record
+	rather than a caller's stack."""
+	frappe.get_doc("Server", server_name).upgrade_boat()
+	frappe.db.commit()
 
 
 @contextmanager

--- a/atlas/atlas/doctype/server/test_server.py
+++ b/atlas/atlas/doctype/server/test_server.py
@@ -638,3 +638,96 @@ class TestServerSigningKeyBackfill(IntegrationTestCase):
 		self.assertNotIn(legacy_peer.name, host_ids)
 		# ...and no emitted entry ever carries an empty signing_public_key.
 		self.assertTrue(all(entry["signing_public_key"] for entry in seed))
+
+
+class TestServerUpgradeBoat(IntegrationTestCase):
+	"""`Server.upgrade_boat` — the boat-artifact + unit + durable-script subset of
+	bootstrap, made idempotent and re-runnable so a new binary, allow-list line or
+	unit reaches an ALREADY-bootstrapped host. `sync_scripts` cannot (it ships
+	neither binary nor units), and until this the only path was a full re-bootstrap."""
+
+	def setUp(self) -> None:
+		directory = tempfile.TemporaryDirectory()
+		self.addCleanup(directory.cleanup)
+		self.boat_distribution = make_boat_distribution(directory.name)
+		provider = make_provider("test-provider-upgrade")
+		self.server = make_server(
+			provider,
+			"test-server-upgrade-boat",
+			provider_resource_id="7",
+			ipv4_address="10.0.0.7",
+			ipv6_address="2a03:b0c0:abcd:5678::1",
+			ipv6_prefix="2a03:b0c0:abcd:5678::/64",
+			ipv6_virtual_machine_range="2a03:b0c0:abcd:5678::/124",
+			status="Active",
+		)
+
+	def test_upgrade_reships_and_restarts_without_the_bootstrap_task(self) -> None:
+		# It ships the artifacts and installs them in BOOTSTRAP'S order, restarts the
+		# daemon onto the new inode and reinstalls the durable code — but never runs
+		# the `boat bootstrap` host-prep Task, the one thing that separates
+		# re-generating an already-VM-ready host from bootstrapping a fresh one.
+		from atlas.atlas.doctype.server import server as server_module
+
+		with patch.object(server_module, "boat_distribution", return_value=self.boat_distribution):
+			with patch.object(server_module.Server, "_reinstall_atlas_venv_package") as reinstall:
+				with patch.object(server_module, "upload_files") as upload:
+					with patch.object(
+						server_module, "run_ssh", side_effect=_bootstrap_ssh_side_effect(self.server)
+					) as run_ssh:
+						with patch.object(server_module, "run_task") as run_task_mock:
+							with patch.object(
+								server_module,
+								"connection_for_server",
+								return_value=Connection(host="x", ssh_private_key="k"),
+							):
+								version = self.server.upgrade_boat()
+
+		upload.assert_called_once()
+		reinstall.assert_called_once()
+		run_task_mock.assert_not_called()
+		commands = [call.args[2] for call in run_ssh.call_args_list]
+		# The allow-list is CHECKED before it is installed (a file sudo cannot parse
+		# would take out the whole /etc/sudoers.d directory), and the binary lands by
+		# rename only after the service user its units run as exists.
+		self.assertLess(
+			commands.index("sudo visudo -cf /var/lib/atlas/boat/sudoers"),
+			next(i for i, t in enumerate(commands) if t.startswith("sudo install -m 0440")),
+		)
+		self.assertLess(
+			next(i for i, t in enumerate(commands) if "useradd" in t),
+			next(i for i, t in enumerate(commands) if "mv -f" in t),
+		)
+		self.assertIn("sudo systemctl daemon-reload", commands)
+		self.assertIn("sudo systemctl restart boat.service", commands)
+		self.assertIn("sudo systemctl is-active boat.service", commands)
+		# The SHA-256 proof of what landed is recorded and returned.
+		self.assertEqual(version, FAKE_BOAT_VERSION)
+		self.server.reload()
+		self.assertEqual(self.server.observed_boat_version, FAKE_BOAT_VERSION)
+
+	def test_upgrade_is_a_noop_on_a_fake_host(self) -> None:
+		# A Fake server has no host to reach — like every other host step, upgrade
+		# skips its SSH entirely and records nothing.
+		from atlas.atlas.doctype.server import server as server_module
+
+		with patch.object(server_module, "is_fake_server", return_value=True):
+			with patch.object(server_module, "connection_for_server") as connect:
+				with patch.object(server_module, "upload_files") as upload:
+					self.assertEqual(self.server.upgrade_boat(), "")
+		connect.assert_not_called()
+		upload.assert_not_called()
+
+	def test_upgrade_all_hosts_enqueues_one_deduplicated_job_per_active_host(self) -> None:
+		# The fleet sweep queues one background upgrade per Active host so a migrate is
+		# never blocked on N SSH installs, keyed by host name so a re-run deduplicates.
+		from atlas.atlas.doctype.server import server as server_module
+
+		with patch.object(server_module.frappe, "enqueue") as enqueue:
+			results = server_module.upgrade_all_hosts_to_current_boat(enqueue=True)
+
+		self.assertEqual(results.get(self.server.name), "queued")
+		mine = [call for call in enqueue.call_args_list if call.kwargs.get("server_name") == self.server.name]
+		self.assertEqual(len(mine), 1)
+		self.assertEqual(mine[0].args[0], "atlas.atlas.doctype.server.server.upgrade_host_to_current_boat")
+		self.assertEqual(mine[0].kwargs.get("job_id"), f"upgrade-boat-{self.server.name}")

--- a/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
+++ b/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
@@ -1336,3 +1336,32 @@ class TestMigrationOverFakeTransport(IntegrationTestCase):
 		self.assertEqual(row.nbd_pid, 424242)
 		self.assertGreater(row.root_disk_bytes, 0)
 		self.assertEqual(row.data_disk_bytes, 0)
+
+	def test_full_saga_runs_to_done_over_the_fake_transport(self) -> None:
+		vm = make_virtual_machine(self.source, self.image, status="Running")
+		row = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Migration",
+				"virtual_machine": vm.name,
+				"target_server": self.target,
+			}
+		).insert(ignore_permissions=True)
+
+		# Only reconcile_proxies is stubbed — that is proxy reconciliation, not the host
+		# transport. Every migration-* script runs on the Fake hosts unpatched, so this
+		# is the whole saga end to end over the transport audit M11 said no test exercised.
+		from atlas.atlas import proxy as proxy_module
+
+		with patch.object(proxy_module, "reconcile_proxies", return_value=[]):
+			for _ in range(20):
+				if not migration_module.advance_migration(row):
+					break
+				row.reload()
+			else:
+				self.fail(f"migration did not terminate within 20 ticks; stuck at {row.status}")
+
+		row.reload()
+		self.assertEqual(row.status, "Done")
+		vm.reload()
+		self.assertEqual(vm.server, self.target)
+		self.assertEqual(vm.status, "Running")

--- a/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
+++ b/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
@@ -1280,3 +1280,59 @@ class TestCollapseForward(IntegrationTestCase):
 		vm = make_virtual_machine(self.target, self.image, status="Running")
 		with self.assertRaisesRegex(frappe.ValidationError, "no active forward"):
 			vm.collapse_forward()
+
+
+class TestMigrationOverFakeTransport(IntegrationTestCase):
+	"""The first migration test that drives the controller through the REAL Fake
+	transport instead of patching run_task — the gap audit M11 named. A Fake host
+	had no ATLAS_RESULT for the three phases that return one, so a Fake↔Fake
+	migration raised at ExportingSnapshot and every migration test had to substitute
+	run_task. With the builders in place the controller records the source's export
+	straight off the Fake host's own result line, exactly as it would a real host's."""
+
+	def setUp(self) -> None:
+		provider = make_provider("mig-fake-provider", provider_type="Fake")
+		self.source = make_server(
+			provider,
+			"mig-fake-source",
+			ipv4_address="10.0.0.11",
+			ipv6_address="2001:db8:b::1",
+			ipv6_prefix="2001:db8:b::/64",
+			ipv6_virtual_machine_range="2001:db8:b::/124",
+			status="Active",
+		).name
+		self.target = make_server(
+			provider,
+			"mig-fake-target",
+			ipv4_address="10.0.0.12",
+			ipv6_address="2001:db8:c::1",
+			ipv6_prefix="2001:db8:c::/64",
+			ipv6_virtual_machine_range="2001:db8:c::/124",
+			status="Active",
+		).name
+		self.image = make_image("mig-fake-image").name
+		for name in frappe.get_all("Virtual Machine Migration", pluck="name"):
+			frappe.delete_doc("Virtual Machine Migration", name, force=1, ignore_permissions=True)
+		for name in frappe.get_all("Virtual Machine", pluck="name"):
+			frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+
+	def test_exporting_snapshot_records_the_fake_hosts_export_result(self) -> None:
+		vm = make_virtual_machine(self.source, self.image, status="Running")
+		row = frappe.get_doc(
+			{
+				"doctype": "Virtual Machine Migration",
+				"virtual_machine": vm.name,
+				"target_server": self.target,
+			}
+		).insert(ignore_permissions=True)
+
+		# No run_task patch: the Fake source answers migration-export-source itself, and
+		# the controller records the port it echoed, the pid, and the disk's bytes.
+		advanced = migration_module._phase_exporting_snapshot(row)
+
+		self.assertTrue(advanced)
+		row.reload()
+		self.assertEqual(row.nbd_port, migration_module.nbd_port(vm.name))
+		self.assertEqual(row.nbd_pid, 424242)
+		self.assertGreater(row.root_disk_bytes, 0)
+		self.assertEqual(row.data_disk_bytes, 0)

--- a/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
+++ b/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
@@ -297,6 +297,11 @@ class TestMigrationRow(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			# Pending → … → CutoverStarting each report "more work" (advance to a further
@@ -328,6 +333,11 @@ class TestMigrationRow(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(migration_module.frappe, "enqueue") as enqueue,
 		):
 			# A phase that advances re-enqueues the next.
@@ -573,6 +583,11 @@ class TestMigrationPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			for _ in range(len(migration_module.PHASE_ORDER) - 1):
@@ -690,6 +705,11 @@ class TestMigrationPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			for want in expected:
@@ -729,6 +749,11 @@ class TestMigrationPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]) as reconcile,
 		):
 			for _ in range(9):
@@ -785,6 +810,11 @@ class TestMigrationPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			for _ in range(9):
@@ -823,6 +853,11 @@ class TestMigrationPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			# Drive to Hydrating (boot-then-hydrate: Pending → ExportingSnapshot →
@@ -913,8 +948,12 @@ class TestPrivatePlaneCutoverOrdering(IntegrationTestCase):
 		from atlas.atlas import proxy as proxy_module
 
 		calls: list = []
+		# One fake, both transports: the phases run over Boat (item 9) while
+		# provision-vm stays on run_task — record from whichever a step uses.
+		fake = self._fake_run_task(calls)
 		with (
-			patch.object(migration_module, "run_task", side_effect=self._fake_run_task(calls)),
+			patch.object(migration_module, "run_task", side_effect=fake),
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=fake),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			for _ in range(9):
@@ -1033,6 +1072,11 @@ class TestLocalBaseImageShip(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			# Advance to TargetPreparing.
@@ -1112,6 +1156,11 @@ class TestLocalBaseImageShip(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			# Advance to TargetPreparing.
@@ -1201,6 +1250,11 @@ class TestLocalBaseImageShip(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			patch.object(proxy_module, "reconcile_proxies", return_value=[]),
 		):
 			for _ in range(9):
@@ -1250,6 +1304,11 @@ class TestCollapseForward(IntegrationTestCase):
 
 		with (
 			patch.object(migration_module, "run_task", side_effect=_fake_run_task),
+			# The migration phases now run over Boat (item 9); source-autostart, the
+			# cutover provision-vm and collapse_forward's forward-down stay on run_task.
+			# Stub both entry points with the same fake so the phase machine is driven
+			# whichever transport a step uses.
+			patch.object(migration_module, "run_boat_migration_phase", side_effect=_fake_run_task),
 			# collapse_forward now stops the live VM first (so the disk converges off
 			# any dm-clone before the re-provision); vm.stop() runs a host Task through
 			# the VM module's run_task, so mock that too. Every host is on Boat now, so

--- a/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
+++ b/atlas/atlas/doctype/virtual_machine_migration/test_virtual_machine_migration.py
@@ -1365,3 +1365,36 @@ class TestMigrationOverFakeTransport(IntegrationTestCase):
 		vm.reload()
 		self.assertEqual(vm.server, self.target)
 		self.assertEqual(vm.status, "Running")
+
+	def test_keep_address_saga_runs_to_done_over_the_fake_transport(self) -> None:
+		from atlas.atlas import proxy as proxy_module
+
+		vm = make_virtual_machine(self.source, self.image, status="Running")
+		# Force the keep-address path — Fake providers derive change-address, but
+		# keep-address is the DEFAULT on a real DO fleet and the branch the M1 cleanup
+		# fix lives on: the forward tunnel + return route are wired, Repointing skips the
+		# Subdomain re-point, and Cleanup runs with KEEP_ADDRESS=1 carrying the /128 over.
+		with patch.object(migration_module, "_will_keep_address", return_value=True):
+			row = frappe.get_doc(
+				{
+					"doctype": "Virtual Machine Migration",
+					"virtual_machine": vm.name,
+					"target_server": self.target,
+				}
+			).insert(ignore_permissions=True)
+		self.assertTrue(row.keep_address)
+
+		with patch.object(proxy_module, "reconcile_proxies", return_value=[]):
+			for _ in range(20):
+				if not migration_module.advance_migration(row):
+					break
+				row.reload()
+			else:
+				self.fail(f"keep-address migration did not terminate within 20 ticks; stuck at {row.status}")
+
+		row.reload()
+		self.assertEqual(row.status, "Done")
+		vm.reload()
+		self.assertEqual(vm.server, self.target)
+		# keep-address carries the /128 over unchanged.
+		self.assertEqual(vm.ipv6_address, row.ipv6_address_old)

--- a/atlas/atlas/migration.py
+++ b/atlas/atlas/migration.py
@@ -48,7 +48,7 @@ import ipaddress
 import frappe
 from frappe import _
 
-from atlas.atlas.boat_client import FIRST_BOOT_EPOCH
+from atlas.atlas.boat_client import FIRST_BOOT_EPOCH, run_boat_migration_phase
 from atlas.atlas.networking import (
 	address_is_free_on_server,
 	allocate_ipv6,
@@ -387,12 +387,16 @@ def _disable_source_autostart(doc) -> None:
 	Runs FIRST, before the stop: a reboot that lands mid-stop must not bring the guest
 	back either. Plain `disable` (not `--now`, not `mask`) is the weakest thing that
 	closes the hole, so the spec/24 §3 rollback — "just restarts the intact source VM"
-	— still works: `systemctl start` on a disabled unit starts it. Idempotent."""
-	_run_phase_task(
-		doc,
+	— still works: `systemctl start` on a disabled unit starts it. Idempotent.
+
+	Stays on SSH via run_task DIRECTLY, not the Boat phase transport (item 9): Boat has
+	no migrate RPC for the unit-autostart toggle, so this is one of the two migration
+	verbs that remain controller-side over SSH."""
+	run_task(
 		server=doc.source_server,
 		script="migration-source-autostart",
 		variables={"VIRTUAL_MACHINE_NAME": doc.virtual_machine, "ENABLED": "0"},
+		virtual_machine=doc.virtual_machine,
 		timeout_seconds=60,
 	)
 
@@ -822,11 +826,15 @@ def _phase_cutover_starting(doc) -> bool:
 			"CLONE_ROOTFS_DEVICE": clone_device_path(doc.virtual_machine),
 		}
 	)
-	_run_phase_task(
-		doc,
+	# provision-vm is a LIFECYCLE op, not a migration saga phase — Boat has no
+	# migrate RPC for it (item 9) — so the cutover boot stays on SSH via run_task
+	# directly, exactly as collapse_forward's re-provision does. run_task keeps its
+	# own Fake shortcut, so a Fake-host migration boots the guest the same way.
+	run_task(
 		server=doc.target_server,
 		script="provision-vm",
 		variables=variables,
+		virtual_machine=doc.virtual_machine,
 		timeout_seconds=120,
 	)
 	# The guest is now live on the target. Commit the row so status/server reflect it
@@ -1308,12 +1316,19 @@ class _ForwardCollapse:
 
 
 def _run_phase_task(doc, *, server: str, script: str, variables: dict, timeout_seconds: int):
-	"""Run a phase's host script inline. run_task saves the Task row first and raises
-	on failure (→ caught by reconcile_migrations → Failed). Lost-task detection scans
-	for a prior Running/Pending Task of the same script that blew its timeout and
-	re-enters transparently (recorded, never a silent duplicate)."""
+	"""Run a migration PHASE's host work inline over Boat (spec/33 §8, item 9).
+	run_boat_migration_phase saves the Task row first and raises on failure (→ caught
+	by reconcile_migrations → Failed), recording the exact Task an SSH run would have
+	— the controller cannot tell which transport ran the phase. Lost-task detection
+	scans for a prior Running/Pending Task of the same script that blew its timeout and
+	re-enters transparently (recorded, never a silent duplicate).
+
+	Only the migration phases route here. The two migration verbs Boat has no migrate
+	RPC for stay on SSH and call run_task directly, NOT through this: source-autostart
+	(_disable_source_autostart) and the provision-vm boot at cutover (which is a
+	lifecycle op, not a saga phase)."""
 	_detect_lost_task(doc, script, timeout_seconds)
-	return run_task(
+	return run_boat_migration_phase(
 		server=server,
 		script=script,
 		variables=variables,

--- a/atlas/atlas/providers/fake_tasks.py
+++ b/atlas/atlas/providers/fake_tasks.py
@@ -281,6 +281,39 @@ def _restore_snapshot_s3_result(variables: dict) -> dict:
 	return {"objects": [obj["name"] for obj in objects]}
 
 
+# Migration phases whose result the controller parses. The other migration-* scripts
+# (clone-target, inject-identity, forward-up, cutover-target, cleanup-source, …) run
+# for effect and their handlers never call parse_result, so `_fake_stdout` returning
+# "ok\n" is enough — only these three ever fed a JSON line back. Without them a
+# Fake↔Fake migration raised at ExportingSnapshot, which is why every migration test
+# had to patch `run_task` directly and none ever exercised the controller end to end.
+
+
+def _migration_export_source_result(variables: dict) -> dict:
+	# The source echoes the port the controller told it to bind and reports the disk's
+	# bytes (a Fake host has no LVM to measure — round DISK_GB; a real host reads the
+	# blockdev). No data disk: the export-source variables carry no data-disk size to
+	# key one off, so a Fake migration is of a single-disk VM.
+	return {
+		"nbd_port": int(variables.get("NBD_PORT") or 0),
+		"nbd_pid": 424242,
+		"root_size_bytes": _fake_disk_bytes(variables),
+		"data_size_bytes": 0,
+	}
+
+
+def _migration_export_base_result(_variables: dict) -> dict:
+	# The controller reads base_size_bytes to size the target's base LV; the rest of a
+	# real export-base result (the nbd/meta ports and pids) is not read on this path.
+	return {"base_size_bytes": 2 * 1024 * 1024 * 1024}
+
+
+def _migration_poll_hydration_result(_variables: dict) -> dict:
+	# A Fake host has no dm-clone to hydrate — report a healthy source already at 100%
+	# so a Fake migration advances through Hydrating in one tick instead of looping.
+	return {"hydration_percent": 100, "source_healthy": True}
+
+
 _RESULT_BUILDERS = {
 	# Both names for the same job. `Server.bootstrap()` now runs the verb
 	# `bootstrap` (`boat bootstrap`, spec/33 §4); `bootstrap-server` is the Python
@@ -297,4 +330,7 @@ _RESULT_BUILDERS = {
 	"warm-snapshot-vm": _warm_snapshot_result,
 	"upload-snapshot-s3": _upload_snapshot_s3_result,
 	"restore-snapshot-s3": _restore_snapshot_s3_result,
+	"migration-export-source": _migration_export_source_result,
+	"migration-export-base": _migration_export_base_result,
+	"migration-poll-hydration": _migration_poll_hydration_result,
 }

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -245,6 +245,17 @@ _PORTED_VERBS: frozenset[str] = frozenset(
 		"promote-snapshot-image",
 		"regenerate-host-keys-vm",
 		"reset-server",
+		# provision-vm + the five later ports (firewall/tunnel/traffic/wake/export).
+		# The boat binary implements each as a native verb taking the same
+		# --kebab-flags and printing the same ATLAS_RESULT= line, so the runner swaps
+		# only the first word. provision-vm creates LVs and boots a guest, so its
+		# differential is a real guest boot on a host, not goldens alone.
+		"provision-vm",
+		"firewall-apply",
+		"vm-tunnel",
+		"poll-vm-traffic",
+		"probe-woken-vms",
+		"export-cleanup-source",
 	}
 )
 

--- a/atlas/patches.txt
+++ b/atlas/patches.txt
@@ -22,3 +22,4 @@ atlas.patches.v1_0.seed_settings_from_site_config
 atlas.patches.v1_0.mark_default_catalog_rows
 atlas.patches.v1_0.backfill_server_signing_key
 atlas.patches.v1_0.terminate_front_doors_over_dead_vms
+atlas.patches.v1_0.upgrade_hosts_to_current_boat

--- a/atlas/patches/v1_0/upgrade_hosts_to_current_boat.py
+++ b/atlas/patches/v1_0/upgrade_hosts_to_current_boat.py
@@ -1,0 +1,31 @@
+import frappe
+
+
+def execute():
+	"""Bring every Active host to the boat generation this release ships.
+
+	Atlas routes ten host verbs and every VM lifecycle verb at `boat`, so a host
+	running an older daemon runs new Atlas against an old boat — one verb at a time,
+	mid-flow. Until now a new boat binary, a new sudoers allow-list line or an
+	edited unit could only reach a host through a full re-`bootstrap`: `sync_scripts`
+	ships neither the binary nor the units by design. So a fleet already bootstrapped
+	on an older boat had no path to the current generation short of re-bootstrapping
+	each host by hand.
+
+	This patch closes that on upgrade. It enqueues one `Server.upgrade_boat` per
+	Active host — non-blocking, because a migrate must never hang on N privileged
+	SSH installs, and one unreachable host must not stall the rest — which re-ships
+	the binary, the allow-list and the units, reloads systemd, restarts the daemon
+	onto the new inode, and reinstalls the durable scripts. Idempotent: a host
+	already current is re-shipped identical bytes and left as it was.
+
+	Runs once (Frappe records executed patches), not on every migrate. A no-op on a
+	site with no Active hosts (a fresh or dev site); Fake hosts skip their host steps
+	inside `upgrade_boat`."""
+	from atlas.atlas.doctype.server.server import upgrade_all_hosts_to_current_boat
+
+	queued = upgrade_all_hosts_to_current_boat(enqueue=True)
+	if queued:
+		frappe.logger("atlas").info(
+			f"upgrade_hosts_to_current_boat: queued {len(queued)} host(s): {sorted(queued)}"
+		)

--- a/atlas/tests/test_boat_migration_phase.py
+++ b/atlas/tests/test_boat_migration_phase.py
@@ -1,0 +1,446 @@
+"""Unit tests for the migration-phase half of the Atlas↔Boat seam (spec/33 §8, item 9).
+
+The cross-host migration saga's host work moves off SSH onto Boat one PHASE at a
+time, exactly as the lifecycle verbs did. These prove three things, no daemon
+running:
+
+  - the per-phase body mapping — each `migration-*` verb translates to the right
+    Boat phase and the right `MigrateRequest` fields, with the UUID-derived
+    variables (nbd port/slots, tunnel device/port, route table) dropped because
+    Boat re-derives them, and the inject-identity `GuestIdentity` assembled field
+    for field;
+  - the Hydrating poll takes the GET path, not a journaled POST;
+  - `migration._run_phase_task` on a NON-fake host drives `BoatClient.migrate` /
+    `get_migration_hydration` and folds the phase's result onto the Task as the one
+    `ATLAS_RESULT=` line the controller already parses — so the phase machine cannot
+    tell which transport ran it.
+
+The full Fake↔Fake saga stays covered by TestMigrationOverFakeTransport; this file
+is the wire-shape proof the Fake path cannot give.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas import migration as migration_module
+from atlas.atlas.boat_client import (
+	MIGRATION_PHASES,
+	MIGRATION_POLL_HYDRATION,
+	ROUTING_ENVIRONMENT_PATH,
+	BoatClient,
+	BoatError,
+	_migration_phase,
+)
+from atlas.atlas.task_results import parse_result
+from atlas.tests import fixtures
+from atlas.tests.test_boat_client import REQUEST, _operation, _Response
+
+UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class TestMigrationPhaseMapping(IntegrationTestCase):
+	"""Every `migration-*` verb → (Boat phase, body params). The UUID-derived
+	variables must be dropped and the GuestIdentity assembled field for field: a
+	wrong mapping silently breaks a migration on a real host."""
+
+	def _build(self, script: str, variables: dict) -> tuple[str, dict]:
+		phase, builder = MIGRATION_PHASES[script]
+		return phase, builder(variables)
+
+	def test_export_source_sends_only_the_bind_address(self) -> None:
+		phase, params = self._build(
+			"migration-export-source",
+			{"VIRTUAL_MACHINE_NAME": UUID, "NBD_PORT": "10123", "BIND_ADDRESS": "198.51.100.7"},
+		)
+		self.assertEqual(phase, "export-source")
+		# NBD_PORT (UUID-derived) and VIRTUAL_MACHINE_NAME (the path) are dropped.
+		self.assertEqual(params, {"bind_address": "198.51.100.7"})
+
+	def test_export_base_sends_image_and_bind_address(self) -> None:
+		phase, params = self._build(
+			"migration-export-base",
+			{"IMAGE_NAME": "bench-16", "NBD_PORT": "10125", "BIND_ADDRESS": "198.51.100.7"},
+		)
+		self.assertEqual(phase, "export-base")
+		self.assertEqual(params, {"image_name": "bench-16", "bind_address": "198.51.100.7"})
+
+	def test_clone_target_sends_sizes_as_ints_and_drops_the_nbd_block(self) -> None:
+		phase, params = self._build(
+			"migration-clone-target",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"IMAGE_NAME": "bench-16",
+				"DISK_GB": "40",
+				"DATA_DISK_GB": "0",
+				"SOURCE_HOST": "198.51.100.7",
+				"NBD_PORT": "10123",
+				"NBD_BASE_SLOT": "4",
+				"PHASE": "prepare",
+			},
+		)
+		self.assertEqual(phase, "clone-target")
+		self.assertEqual(
+			params,
+			{"image_name": "bench-16", "disk_gb": 40, "data_disk_gb": 0, "source_host": "198.51.100.7"},
+		)
+
+	def test_receive_base_carries_the_base_phase(self) -> None:
+		for half in ("prepare", "finalize"):
+			with self.subTest(half=half):
+				phase, params = self._build(
+					"migration-receive-base",
+					{
+						"IMAGE_NAME": "bench-16",
+						"DISK_GB": "3",
+						"SOURCE_HOST": "198.51.100.7",
+						"NBD_PORT": "10125",
+						"NBD_BASE_SLOT": "4",
+						"PHASE": half,
+					},
+				)
+				self.assertEqual(phase, "receive-base")
+				self.assertEqual(
+					params,
+					{
+						"image_name": "bench-16",
+						"disk_gb": 3,
+						"source_host": "198.51.100.7",
+						"base_phase": half,
+					},
+				)
+
+	def test_inject_identity_assembles_the_guest_identity(self) -> None:
+		phase, params = self._build(
+			"migration-inject-identity",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"CLONE_DEVICE": f"/dev/mapper/atlas-vm-{UUID}-clone",
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:c::2",
+				"IPV4_GUEST_CIDR": "10.20.30.2/30",
+				"IPV4_GATEWAY": "10.20.30.1",
+				"SSH_PUBLIC_KEY": "ssh-ed25519 AAAAkey",
+				"DATA_DISK_MOUNT_AT": "/data",
+				"ROUTING_BASE_URL": "https://routing.example",
+			},
+		)
+		self.assertEqual(phase, "inject-identity")
+		# VIRTUAL_MACHINE_NAME (the path) and CLONE_DEVICE (Boat derives the write
+		# device from the UUID) are dropped; ROUTING_BASE_URL becomes one anonymous
+		# extra_env file, byte-for-byte the rebuild path's content.
+		self.assertEqual(
+			params,
+			{
+				"identity": {
+					"ipv6_address": "2001:db8:c::2",
+					"ipv4_guest_cidr": "10.20.30.2/30",
+					"ipv4_gateway": "10.20.30.1",
+					"authorized_keys_blob": "ssh-ed25519 AAAAkey",
+					"data_disk_mount_at": "/data",
+					"extra_env": [
+						{
+							"path": ROUTING_ENVIRONMENT_PATH,
+							"content": "ATLAS_BASE_URL=https://routing.example\n",
+						}
+					],
+				}
+			},
+		)
+
+	def test_inject_identity_omits_absent_optional_fields(self) -> None:
+		# An empty data mount and no routing URL: neither key is sent (Boat writes a
+		# defined value for each either way).
+		_phase, params = self._build(
+			"migration-inject-identity",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"CLONE_DEVICE": f"/dev/mapper/atlas-vm-{UUID}-clone",
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:c::2",
+				"IPV4_GUEST_CIDR": "10.20.30.2/30",
+				"IPV4_GATEWAY": "10.20.30.1",
+				"SSH_PUBLIC_KEY": "ssh-ed25519 AAAAkey",
+				"DATA_DISK_MOUNT_AT": "",
+				"ROUTING_BASE_URL": "",
+			},
+		)
+		self.assertEqual(
+			params["identity"],
+			{
+				"ipv6_address": "2001:db8:c::2",
+				"ipv4_guest_cidr": "10.20.30.2/30",
+				"ipv4_gateway": "10.20.30.1",
+				"authorized_keys_blob": "ssh-ed25519 AAAAkey",
+			},
+		)
+
+	def test_collapse_clone_sends_only_the_data_disk_flag(self) -> None:
+		phase, params = self._build(
+			"migration-cutover-target",
+			{"VIRTUAL_MACHINE_NAME": UUID, "DATA_DISK_GB": "0", "NBD_BASE_SLOT": "4"},
+		)
+		self.assertEqual(phase, "collapse-clone")
+		self.assertEqual(params, {"data_disk_gb": 0})
+
+	def test_forward_up_source_carries_only_the_role(self) -> None:
+		phase, params = self._build(
+			"migration-forward-up",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"ROLE": "source",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"TUNNEL_PORT": "20123",
+			},
+		)
+		self.assertEqual(phase, "forward-up")
+		# TUNNEL_DEVICE / TUNNEL_PORT are UUID-derived and dropped; a bare source-role
+		# forward-up (no /128 yet) carries only its role.
+		self.assertEqual(params, {"role": "source"})
+
+	def test_forward_up_target_adds_the_source_host(self) -> None:
+		_phase, params = self._build(
+			"migration-forward-up",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"ROLE": "target",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"TUNNEL_PORT": "20123",
+				"SOURCE_HOST": "198.51.100.7",
+			},
+		)
+		self.assertEqual(params, {"role": "target", "source_host": "198.51.100.7"})
+
+	def test_forward_up_relay_adds_the_ipv6_and_drops_the_route_table(self) -> None:
+		_phase, params = self._build(
+			"migration-forward-up",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"ROLE": "source",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"TUNNEL_PORT": "20123",
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:b::2",
+				"ROUTE_TABLE": "12345",
+			},
+		)
+		self.assertEqual(params, {"role": "source", "virtual_machine_ipv6": "2001:db8:b::2"})
+
+	def test_source_forward_drops_the_reassert_flag(self) -> None:
+		phase, params = self._build(
+			"migration-source-forward",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:b::2",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"REASSERT_PROXY_NDP": "1",
+			},
+		)
+		self.assertEqual(phase, "source-forward")
+		# Boat re-asserts proxy-NDP unconditionally, so the flag has no wire field.
+		self.assertEqual(params, {"virtual_machine_ipv6": "2001:db8:b::2"})
+
+	def test_target_receive_sends_only_the_ipv6(self) -> None:
+		phase, params = self._build(
+			"migration-target-receive",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:b::2",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"ROUTE_TABLE": "12345",
+			},
+		)
+		self.assertEqual(phase, "target-receive")
+		self.assertEqual(params, {"virtual_machine_ipv6": "2001:db8:b::2"})
+
+	def test_forward_down_carries_role_and_ipv6(self) -> None:
+		phase, params = self._build(
+			"migration-forward-down",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"VIRTUAL_MACHINE_IPV6": "2001:db8:b::2",
+				"ROLE": "target",
+				"TUNNEL_DEVICE": "atlas-fwd-x",
+				"TUNNEL_PORT": "20123",
+				"ROUTE_TABLE": "12345",
+			},
+		)
+		self.assertEqual(phase, "forward-down")
+		self.assertEqual(params, {"role": "target", "virtual_machine_ipv6": "2001:db8:b::2"})
+
+	def test_withdraw_private_carries_the_128(self) -> None:
+		phase, params = self._build(
+			"migration-withdraw-private-source",
+			{"VIRTUAL_MACHINE_NAME": UUID, "PRIVATE_ADDRESS": "fd00::2"},
+		)
+		self.assertEqual(phase, "withdraw-private")
+		self.assertEqual(params, {"private_address": "fd00::2"})
+
+	def test_withdraw_private_empty_is_a_clean_no_op(self) -> None:
+		_phase, params = self._build(
+			"migration-withdraw-private-source",
+			{"VIRTUAL_MACHINE_NAME": UUID, "PRIVATE_ADDRESS": ""},
+		)
+		self.assertEqual(params, {"private_address": ""})
+
+	def test_cleanup_source_maps_nbd_pid_and_drops_keep_address(self) -> None:
+		phase, params = self._build(
+			"migration-cleanup-source",
+			{
+				"VIRTUAL_MACHINE_NAME": UUID,
+				"NBD_PORT": "10123",
+				"NBD_PID": "424242",
+				"KEEP_ADDRESS": "1",
+			},
+		)
+		self.assertEqual(phase, "cleanup-source")
+		# NBD_PORT is UUID-derived; KEEP_ADDRESS has no Boat field yet (TODO(item9-live)
+		# in the mapping) — only nbd_pid crosses the wire.
+		self.assertEqual(params, {"nbd_pid": 424242})
+
+	def test_poll_hydration_is_special_cased_out_of_the_phase_map(self) -> None:
+		# The Hydrating poll is a GET with no operation record, not a mutating POST.
+		self.assertNotIn(MIGRATION_POLL_HYDRATION, MIGRATION_PHASES)
+
+	def test_an_unmapped_verb_fails_loud(self) -> None:
+		with self.assertRaises(BoatError) as raised:
+			_migration_phase("provision-vm")
+		self.assertIn("provision-vm", str(raised.exception))
+
+
+class TestBoatClientMigrationWire(IntegrationTestCase):
+	"""What Atlas puts on the wire for the two migration endpoints."""
+
+	def setUp(self) -> None:
+		self.client = BoatClient(base_url="http://198.51.100.7:8080/v1", token="s3cret")
+
+	def test_migrate_posts_the_phase_path_with_operation_id_and_params(self) -> None:
+		with patch(REQUEST, return_value=_Response(payload=_operation(verb="migrate-clone-target"))) as request:
+			self.client.migrate(
+				"vm-1", "clone-target", operation_id="task-mig-1", params={"image_name": "img", "disk_gb": 40}
+			)
+		method, url = request.call_args.args
+		self.assertEqual(method, "POST")
+		self.assertEqual(url, "http://198.51.100.7:8080/v1/vms/vm-1/migrate/clone-target")
+		self.assertEqual(
+			request.call_args.kwargs["json"],
+			{"operation_id": "task-mig-1", "image_name": "img", "disk_gb": 40},
+		)
+
+	def test_hydration_get_without_a_clone_device(self) -> None:
+		payload = {"hydration_percent": 58, "source_healthy": True}
+		with patch(REQUEST, return_value=_Response(payload=payload)) as request:
+			result = self.client.get_migration_hydration("vm-1")
+		self.assertEqual(
+			request.call_args.args, ("GET", "http://198.51.100.7:8080/v1/vms/vm-1/migrate/hydration")
+		)
+		self.assertEqual(result, payload)
+
+	def test_hydration_get_appends_the_clone_device_query(self) -> None:
+		with patch(
+			REQUEST, return_value=_Response(payload={"hydration_percent": 100, "source_healthy": True})
+		) as request:
+			self.client.get_migration_hydration("vm-1", clone_device="atlas-base-bench-16-clone")
+		self.assertEqual(
+			request.call_args.args[1],
+			"http://198.51.100.7:8080/v1/vms/vm-1/migrate/hydration?clone_device=atlas-base-bench-16-clone",
+		)
+
+
+class TestRunMigrationPhaseOverBoat(IntegrationTestCase):
+	"""`migration._run_phase_task` on a real (non-Fake) host drives the Boat client
+	and lands a Task the phase machine reads exactly as an SSH run's."""
+
+	def setUp(self) -> None:
+		provider = fixtures.make_provider("boat-mig-provider")
+		self.server = fixtures.make_server(
+			provider,
+			"boat-mig-server",
+			ipv4_address="198.51.100.9",
+			ipv6_address="2001:db8:9a::1",
+			ipv6_prefix="2001:db8:9a::/64",
+			ipv6_virtual_machine_range="2001:db8:9a::/124",
+			status="Active",
+		)
+		self.image = fixtures.make_image("boat-mig-image")
+		for name in frappe.get_all("Virtual Machine", pluck="name"):
+			frappe.delete_doc("Virtual Machine", name, force=1, ignore_permissions=True)
+		self.vm = fixtures.make_virtual_machine(self.server.name, self.image.name)
+		self.doc = SimpleNamespace(name="mig-row-1", virtual_machine=self.vm.name)
+
+	def test_mutating_phase_posts_via_migrate_and_folds_the_typed_result(self) -> None:
+		operation = {
+			"status": "Success",
+			"exit_code": 0,
+			"output": "clone built\n",
+			"result": {"root_clone_device": f"/dev/mapper/atlas-vm-{self.vm.name}-clone"},
+		}
+		client = MagicMock()
+		client.migrate.return_value = operation
+		with patch.object(BoatClient, "for_server", return_value=client):
+			task = migration_module._run_phase_task(
+				self.doc,
+				server=self.server.name,
+				script="migration-clone-target",
+				variables={
+					"VIRTUAL_MACHINE_NAME": self.vm.name,
+					"IMAGE_NAME": "bench-16",
+					"DISK_GB": "40",
+					"DATA_DISK_GB": "0",
+					"SOURCE_HOST": "198.51.100.7",
+					"NBD_PORT": "10123",
+					"NBD_BASE_SLOT": "4",
+					"PHASE": "prepare",
+				},
+				timeout_seconds=120,
+			)
+
+		# Called with the mapped phase, the Task name as the replay key, and the
+		# UUID-derived variables dropped.
+		self.assertEqual(client.migrate.call_args.args, (self.vm.name, "clone-target"))
+		self.assertEqual(client.migrate.call_args.kwargs["operation_id"], task.name)
+		self.assertEqual(
+			client.migrate.call_args.kwargs["params"],
+			{"image_name": "bench-16", "disk_gb": 40, "data_disk_gb": 0, "source_host": "198.51.100.7"},
+		)
+		# The Task the phase machine reads: Success, with the operation's typed result
+		# folded onto stdout as the ATLAS_RESULT= line parse_result expects.
+		self.assertEqual(task.status, "Success")
+		self.assertEqual(
+			parse_result(task.stdout),
+			{"root_clone_device": f"/dev/mapper/atlas-vm-{self.vm.name}-clone"},
+		)
+
+	def test_poll_hydration_reads_the_get_and_folds_the_reading(self) -> None:
+		client = MagicMock()
+		client.get_migration_hydration.return_value = {"hydration_percent": 42, "source_healthy": True}
+		with patch.object(BoatClient, "for_server", return_value=client):
+			task = migration_module._run_phase_task(
+				self.doc,
+				server=self.server.name,
+				script="migration-poll-hydration",
+				variables={"VIRTUAL_MACHINE_NAME": self.vm.name},
+				timeout_seconds=60,
+			)
+
+		# The poll is the GET, not a claimed POST.
+		client.migrate.assert_not_called()
+		client.get_migration_hydration.assert_called_once_with(self.vm.name, clone_device=None)
+		self.assertEqual(task.status, "Success")
+		self.assertEqual(parse_result(task.stdout), {"hydration_percent": 42, "source_healthy": True})
+
+	def test_poll_hydration_passes_the_base_clone_device(self) -> None:
+		client = MagicMock()
+		client.get_migration_hydration.return_value = {"hydration_percent": 100, "source_healthy": True}
+		with patch.object(BoatClient, "for_server", return_value=client):
+			migration_module._run_phase_task(
+				self.doc,
+				server=self.server.name,
+				script="migration-poll-hydration",
+				variables={"CLONE_DEVICE": "atlas-base-bench-16-clone"},
+				timeout_seconds=60,
+			)
+		client.get_migration_hydration.assert_called_once_with(
+			self.vm.name, clone_device="atlas-base-bench-16-clone"
+		)

--- a/scripts/systemd/atlas-networkd.service
+++ b/scripts/systemd/atlas-networkd.service
@@ -38,10 +38,12 @@ Wants=network-online.target
 # fix (the loop degrades rather than exits); this is the second line of defense.
 StartLimitIntervalSec=60
 StartLimitBurst=5
-# Run before any VM unit so a VM coming up sees the mesh already configured
-# (a guest veth's fdaa:: /128 routes through wg-mesh; a not-yet-up mesh = a
-# blackholed guest from boot).
-Before=firecracker-vm@.service
+# A VM coming up must see the mesh already configured (a guest veth's fdaa:: /128
+# routes through wg-mesh; a not-yet-up mesh = a blackholed guest from boot). That
+# ordering is asserted from the template side (firecracker-vm@.service carries
+# `After=atlas-networkd.service`), NOT with a bare `Before=firecracker-vm@.service`
+# here — an empty template instance in Before= resolves to the phantom
+# `firecracker-vm@atlas-networkd.service` and orders nothing against real VMs.
 
 [Service]
 Type=notify

--- a/scripts/systemd/atlas-pool.service
+++ b/scripts/systemd/atlas-pool.service
@@ -6,11 +6,12 @@ Description=Atlas LVM thin pool
 # does not, so the VG/pool are gone until the loop is re-attached. bootstrap-
 # server.py creates the pool but is NOT re-run on boot, so this oneshot re-asserts
 # it (ThinPool.ensure() → PoolBacking.reassert() re-binds the loop only when the
-# backing is the file). Ordered before any VM unit (firecracker-vm@.service Wants
-# network-online.target; this only needs local fs) so a VM never starts against a
-# missing pool.
+# backing is the file). A VM must never start against a missing pool; that
+# ordering is asserted from the template side (firecracker-vm@.service carries
+# `After=atlas-pool.service`), NOT with a bare `Before=firecracker-vm@.service`
+# here — an empty template instance in Before= resolves to the phantom
+# `firecracker-vm@atlas-pool.service` and orders nothing against real VMs.
 After=local-fs.target
-Before=firecracker-vm@.service
 DefaultDependencies=no
 RequiresMountsFor=/var/lib/atlas/pool
 

--- a/scripts/systemd/atlas-wake-trap.service
+++ b/scripts/systemd/atlas-wake-trap.service
@@ -8,6 +8,12 @@ Description=Atlas wake-on-TCP trap for sleeping VMs
 # (ConditionPathExists=!), and the daemon's startup sweep re-parks it.
 After=network-online.target local-fs.target
 Wants=network-online.target
+# Bound the restart rate — same backstop the other Restart=always units carry.
+# Without it a persistently-broken trap (missing venv, unparseable nft state) would
+# hot-loop forever; after StartLimitBurst starts within StartLimitIntervalSec systemd
+# leaves it `failed` (visible to the operator) instead of pinning a CPU.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple

--- a/scripts/systemd/firecracker-vm@.service
+++ b/scripts/systemd/firecracker-vm@.service
@@ -2,6 +2,20 @@
 Description=Atlas Firecracker VM %i
 After=network-online.target
 Wants=network-online.target
+# Order the pool/mesh dependencies from the template side (a bare
+# `Before=firecracker-vm@.service` in those units targets a phantom EMPTY template
+# instance and orders nothing). The thin pool must exist before vm-disk-up/the
+# jailer open rootfs.ext4, and the mesh before the guest veth routes — so a VM
+# never starts against a missing pool or a blackholed mesh.
+After=atlas-pool.service atlas-networkd.service
+# Bound the restart rate. With Restart=always a genuinely-broken VM (rootfs gone,
+# jail unrecoverable) would hot-loop forever — a real host reached 372,524
+# restarts. Mirror atlas-networkd's backstop: after StartLimitBurst starts within
+# StartLimitIntervalSec systemd stops trying and leaves the unit `failed` (visible
+# to the operator + alerting) instead of pinning a CPU and spamming the journal.
+# 5 starts / 60 s trips fast on a persistent crash but clears any transient flap.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 # Do not auto-start a sleeping VM on host reboot. sleep-vm.py writes this
 # marker after stopping the unit; wake-vm.py removes it before starting.
 # The condition prevents the unit from starting while the file exists, without


### PR DESCRIPTION
## What

Adds a first-class, idempotent way to bring an **already-bootstrapped** host up to
the boat generation the controller ships — the binary, the sudoers allow-list and
the two units — without a full re-`bootstrap`.

- `Server.upgrade_boat()` — the boat-artifact + unit + durable-script subset of
  `bootstrap`, reusing its own `_install_boat` (validate-then-install sudoers,
  rename-into-place binary, units, `daemon-reload`, SHA-256 proof) and
  `_start_boat` (restart onto the new inode, `is-active`), then reinstalling the
  durable atlas package — but **not** the `boat bootstrap` host-prep Task.
- `upgrade_all_hosts_to_current_boat()` — the fleet sweep (Active hosts only).
- `atlas.patches.v1_0.upgrade_hosts_to_current_boat` — a one-time patch that
  **enqueues** one per-host upgrade so a `bench migrate` is never blocked on N SSH
  installs and one unreachable host cannot stall the rest.

## Why

Atlas routes ten host verbs and every VM lifecycle verb at `boat`, so a host on an
older daemon runs new Atlas against old boat. `sync_scripts` ships neither the
binary nor the units by design (they need a privileged install + a daemon
restart), and there was no lighter path than a full re-bootstrap — so the binary,
the allow-list and the units were three uncoupled hand-installs with no way to
update a live fleet (the deployment gap the split's audits kept naming). This is
the missing counterpart to `sync_scripts`.

## Tests

`TestServerUpgradeBoat` (3, green):
- re-ships + installs in bootstrap's order, restarts the daemon, records the
  SHA-256 version — and never runs the bootstrap Task;
- a no-op on a Fake host;
- the fleet sweep enqueues one deduplicated job per Active host.

Ran `atlas.atlas.doctype.server.test_server` — the only module that exercises this
code — with **zero new failures** vs the pre-existing baseline. The daemon-restart
half was also verified live on staging host-2 (`systemctl restart boat` → active).

## Risk to review

`upgrade_boat` restarts `boat.service`, which re-runs the adoption scan. Proven on
empty staging hosts; **adoption on a host holding running VMs is still the one
untested path a restart exercises** (see the split audit's adoption findings).
The patch fires once (Frappe records executed patches), not on every migrate.
