### PR TITLE
feat(boat): drive the host verbs over HTTP, not SSH

### DIFF
--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -68,6 +68,25 @@ def run_task(
 
 		return run_fake_task(server, script, variables, virtual_machine)
 
+	# The host verbs the boat daemon serves over HTTP no longer open an SSH
+	# connection: they run through the daemon, journaled by op_id, exactly as the
+	# lifecycle verbs do (spec/33 §2.4). The delegation lives here, at the one SSH
+	# chokepoint every host verb passed through, so no call site changes transport —
+	# it states the verb and this routes it. The connection= path is bootstrap's,
+	# whose verb is never HTTP-served, so this is reached only with server= set.
+	from atlas.atlas import scripts_catalog
+
+	if server is not None and scripts_catalog.runs_on_boat_http(script):
+		from atlas.atlas.boat_client import run_boat_host_task
+
+		return run_boat_host_task(
+			script=script,
+			variables=variables,
+			server=server,
+			virtual_machine=virtual_machine,
+			timeout_seconds=timeout_seconds,
+		)
+
 	if connection is None:
 		server_doc = frappe.get_doc("Server", server)
 		connection = connection_for_server(server_doc)

--- a/atlas/atlas/_ssh/runner.py
+++ b/atlas/atlas/_ssh/runner.py
@@ -137,6 +137,19 @@ def run_probe(
 
 		return fake_stdout(script, variables)
 
+	# The read-only sweeps the boat daemon serves over HTTP no longer open an SSH
+	# connection: they run through the daemon's non-journaling read path, exactly
+	# as run_task delegates the mutating host verbs (spec/33 §2.4). run_boat_host_read
+	# keeps run_probe's contract — it never raises and returns "" on failure.
+	from atlas.atlas import scripts_catalog
+
+	if scripts_catalog.runs_on_boat_http_read(script):
+		from atlas.atlas.boat_client import run_boat_host_read
+
+		return run_boat_host_read(
+			script=script, variables=variables, server=server, timeout_seconds=timeout_seconds
+		)
+
 	try:
 		connection = connection_for_server(frappe.get_doc("Server", server))
 		stdout, stderr, exit_code = _run_remote_script(connection, script, variables, timeout_seconds)

--- a/atlas/atlas/boat_client.py
+++ b/atlas/atlas/boat_client.py
@@ -360,6 +360,19 @@ class BoatClient:
 			body["variables"] = variables
 		return self._request("POST", f"/host-verbs/{verb}", json=body)
 
+	def run_host_read(self, verb: str, *, variables: dict) -> dict:
+		"""POST /host-reads/{verb} — run one READ-ONLY host verb (the per-minute
+		sweeps poll-vm-traffic / probe-woken-vms) and return `{output}`, the same
+		stdout run_probe read off the SSH channel for `parse_result`.
+
+		No `operation_id`: a read is not journaled and not replayed, so the daemon
+		writes no operation record. Synchronous — the reply IS the output, not a
+		claim to poll."""
+		body: dict = {}
+		if variables:
+			body["variables"] = variables
+		return self._request("POST", f"/host-reads/{verb}", json=body)
+
 	def migrate(self, uuid: str, phase: str, *, operation_id: str, params: dict) -> dict:
 		"""POST /vms/{uuid}/migrate/{phase} — run one MUTATING phase of the
 		cross-host migration saga, returning the operation record (spec/33 §8).
@@ -817,6 +830,34 @@ def _execute_host_verb_on_boat(
 	_finalize(task, _task_stdout(operation), error, exit_code, status, _elapsed_ms(start))
 	if status == "Failure":
 		frappe.throw(f"Task {task.name} ({script}) exited {exit_code}: {error[-500:]}")
+
+
+def run_boat_host_read(
+	*,
+	script: str,
+	variables: dict,
+	server: str,
+	timeout_seconds: int = 30,
+) -> str:
+	"""Run a read-only host verb through the host's Boat daemon over HTTP, returning
+	its output for `parse_result` — `run_probe`'s twin for the sweeps that were
+	`boat <verb>` over SSH (poll-vm-traffic, probe-woken-vms).
+
+	Keyword-for-keyword `run_probe`'s signature, so `run_probe` delegates to it with
+	no caller changing. It NEVER raises, exactly as `run_probe` never does: a failed
+	read logs a warning and returns "" — a missed sweep is at most one extra idle
+	minute, and the next tick retries — so callers need no try/except of their own.
+	Records no Task row (the daemon writes no operation for a read)."""
+	if is_fake_server(server):
+		from atlas.atlas.providers.fake_tasks import fake_stdout
+
+		return fake_stdout(script, variables)
+	try:
+		client = BoatClient.for_server(server, timeout_seconds=timeout_seconds)
+		return client.run_host_read(script, variables=variables).get("output", "")
+	except Exception as exception:
+		frappe.logger("atlas").warning(f"boat read {script} on {server} failed: {exception}")
+		return ""
 
 
 def _run_verb(client: BoatClient, script: str, uuid: str, operation_id: str, variables: dict) -> dict:

--- a/atlas/atlas/boat_client.py
+++ b/atlas/atlas/boat_client.py
@@ -96,26 +96,18 @@ FIRST_BOOT_EPOCH = 1
 # verb produces beyond its trace, which on the SSH path travels as the script's one
 # `ATLAS_RESULT=` JSON line (spec/04, `task_results.parse_result`).
 #
-# **Not in the contract yet.** `api/openapi.yaml` gives `Operation` only `output`,
-# `error` and `exit_code`, so today a Boat verb that computes a result — `sleep`
-# computes exactly the boolean `VirtualMachine.sleep` wants — discards it on the way
-# out. What Boat needs to add is one optional free-form object on `Operation`:
+# It is an optional free-form object on `Operation` in `api/openapi.yaml`, present
+# only on a verb that has a result and only when it succeeded. `sleep-vm` populates
+# it with `{"memory_snapshot": ..., "reason": ..., "memory_snapshot_bytes": ...}`;
+# the host verbs that emit an ATLAS_RESULT= line (`snapshot-vm`, `warm-snapshot-vm`,
+# `snapshot-stop-vm`, `vm-tunnel`, the s3 backups) carry theirs here too — the daemon
+# reads the line off the verb's stdout and folds it into this field.
 #
-#     result:
-#       type: object
-#       additionalProperties: true
-#       description: The verb's typed result. Same payload the SSH script's one
-#                    ATLAS_RESULT= line carries, so a Task reads the same either way.
-#
-# populated by every verb that has one — today `sleep-vm` with
-# `{"memory_snapshot": <SleepResult.MemorySnapshot>}`, and the same field for
-# `snapshot-vm` / `warm-snapshot-vm` (`size_bytes`, `memory_bytes`,
-# `host_signature`) whenever those verbs move onto Boat.
-#
-# Atlas is written against the field NOW, so the day it lands, every call site that
-# parses a verb's structured output reads it with no second mechanism — see
-# `_task_stdout`. Until then a Boat Task simply carries no result line, and the one
-# caller that reads one survives its absence.
+# `_task_stdout` folds a present result back onto the Task's stdout as the very
+# `ATLAS_RESULT=` line an SSH script would have printed, so a call site that parses
+# its verb's structured output reads one Task the same way whichever transport ran
+# it. A verb with no result omits the field, and the one caller that reads one
+# survives its absence via `parse_optional_result`.
 OPERATION_RESULT_FIELD = "result"
 
 # The statuses an operation stops at. Anything else means it is still running.
@@ -351,6 +343,22 @@ class BoatClient:
 	def get_operation(self, operation_id: str) -> dict:
 		"""GET /ops/{operation_id} — the journal record for one Task name."""
 		return self._request("GET", f"/ops/{operation_id}")
+
+	def run_host_verb(self, verb: str, *, operation_id: str, variables: dict) -> dict:
+		"""POST /host-verbs/{verb} — run one host operation Atlas used to drive as
+		`boat <verb>` over SSH (provision, the snapshot family, sync-image, per-VM
+		networking), returning the operation record.
+
+		`variables` is the SAME UPPER_SNAKE dict the SSH runner rendered to
+		`--kebab-case` flags; the daemon renders it to the verb's argv, so a verb's
+		inputs are stated once and mean the same thing whichever transport carried
+		them. `operation_id` is the Frappe Task name — the replay key every verb
+		shares, so a retried host-verb Task returns its first result rather than
+		running the verb twice (spec/33 §2.7)."""
+		body: dict = {"operation_id": operation_id}
+		if variables:
+			body["variables"] = variables
+		return self._request("POST", f"/host-verbs/{verb}", json=body)
 
 	def migrate(self, uuid: str, phase: str, *, operation_id: str, params: dict) -> dict:
 		"""POST /vms/{uuid}/migrate/{phase} — run one MUTATING phase of the
@@ -724,6 +732,87 @@ def _execute_on_boat(
 	# Fold the daemon's own record onto the row: its trace becomes the Task's
 	# stdout, its one-sentence error the stderr. The operator surface is the
 	# same text it has always been.
+	error = operation.get("error") or ""
+	_finalize(task, _task_stdout(operation), error, exit_code, status, _elapsed_ms(start))
+	if status == "Failure":
+		frappe.throw(f"Task {task.name} ({script}) exited {exit_code}: {error[-500:]}")
+
+
+def run_boat_host_task(
+	*,
+	script: str,
+	variables: dict,
+	server: str,
+	virtual_machine: str | None = None,
+	timeout_seconds: int = 1800,
+) -> "Task":
+	"""Run a host verb through the host's Boat daemon over HTTP, recording the Task
+	row `run_task` would have recorded — `run_boat_task`'s twin for the host verbs
+	(the operations that were `boat <verb>` over SSH: provision, the snapshot family,
+	sync-image, per-VM networking).
+
+	Keyword-for-keyword `run_task`'s signature, so `run_task` delegates to it with no
+	call site changing transport (see `_ssh.runner.run_task`). Unlike `run_boat_task`
+	it does NOT require a `virtual_machine`: a host-scoped verb (sync-image,
+	export-cleanup-source) names none, and the daemon serializes it host-wide. A
+	VM-scoped verb carries its UUID in the variables (VIRTUAL_MACHINE_NAME), which is
+	both the turn it takes on the host and the Task's `virtual_machine` link here.
+
+	Raises `frappe.ValidationError` on any failure — transport error, non-2xx, or a
+	failed operation — with the Task row saved first, exactly as the SSH path did."""
+	# Fake provider (developer_mode): a Task on a Fake-backed Server succeeds (or
+	# fails on demand) with no Boat call, exactly as run_task/run_boat_task give it no
+	# request — so a call site that delegated here from run_task behaves identically
+	# on the dev/test fleet, which is all Fake hosts.
+	if is_fake_server(server):
+		from atlas.atlas.providers.fake_tasks import run_fake_task
+
+		return run_fake_task(server, script, variables, virtual_machine)
+
+	task = frappe.get_doc(
+		{
+			"doctype": "Task",
+			"server": server,
+			"virtual_machine": virtual_machine,
+			"script": script,
+			"status": "Pending",
+			"triggered_by": frappe.session.user if frappe.session else "Administrator",
+		}
+	)
+	task.variables_dict = variables
+	task.insert(ignore_permissions=True)
+
+	_execute_host_verb_on_boat(task, server, script, variables, timeout_seconds)
+	return task
+
+
+def _execute_host_verb_on_boat(
+	task: "Task",
+	server: str,
+	script: str,
+	variables: dict,
+	timeout_seconds: int,
+) -> None:
+	"""Drive an inserted host-verb Task to its outcome over Boat. Mirrors
+	`_execute_on_boat` step for step — same `_mark_running` / `_await_operation` /
+	`_finalize`, so the row shape cannot drift between the lifecycle and host-verb
+	transports — and forks only on the one difference: the verb is posted to
+	`POST /host-verbs/{verb}` with its whole variables dict, rather than mapped to a
+	typed endpoint, because a host verb's inputs are the same UPPER_SNAKE dict the
+	SSH runner rendered to flags and the daemon renders them the same way."""
+	_mark_running(task)
+	start = time.monotonic()
+	try:
+		client = BoatClient.for_server(server, timeout_seconds=POLL_REQUEST_TIMEOUT_SECONDS, poll=True)
+		operation = client.run_host_verb(script, operation_id=task.name, variables=variables)
+		operation = _await_operation(client, task.name, operation, timeout_seconds)
+		status, exit_code = _outcome(operation, task.name)
+	except Exception as exception:
+		_finalize(task, "", str(exception), None, "Failure", _elapsed_ms(start))
+		if isinstance(exception, frappe.ValidationError):
+			raise
+		raise frappe.ValidationError(str(exception)) from exception
+
 	error = operation.get("error") or ""
 	_finalize(task, _task_stdout(operation), error, exit_code, status, _elapsed_ms(start))
 	if status == "Failure":

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -341,6 +341,27 @@ def runs_on_boat_http(verb: str) -> bool:
 	return verb in HTTP_HOST_VERBS
 
 
+# The READ-ONLY host verbs the boat daemon serves over HTTP — `POST
+# /v1/host-reads/{verb}`, the non-journaling read path for the per-minute sweeps
+# Atlas runs through `run_probe`. This set MUST equal boat's `servedHostReads`
+# (cmd/boat/hostverb_dispatch.go). They are grant-free — they only read nft counters
+# and sleeping markers, the wake trap's own reads — so serving them over the daemon
+# adds no new privilege, and unlike the mutating verbs they write no Task row.
+HTTP_HOST_READS: frozenset[str] = frozenset(
+	{
+		"poll-vm-traffic",
+		"probe-woken-vms",
+	}
+)
+
+
+def runs_on_boat_http_read(verb: str) -> bool:
+	"""True iff Atlas drives this read-only sweep through the boat daemon over HTTP
+	(`run_boat_host_read`) rather than as `boat <verb>` over SSH. `run_probe`
+	delegates on this, the read twin of `run_task`'s host-verb delegation."""
+	return verb in HTTP_HOST_READS
+
+
 # Production Task scripts are shipped durably to the host's /var/lib/atlas/bin by
 # Server.bootstrap()/sync_scripts() — the same place the importable atlas package
 # and the systemd hooks already live. Python verbs are then invoked as

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -329,6 +329,17 @@ HTTP_HOST_VERBS: frozenset[str] = frozenset(
 		"regenerate-host-keys-vm",
 		"firewall-apply",
 		"export-cleanup-source",
+		# The heavier verbs, switched on now that boat serves them (their scoped
+		# grants are in sudoers.d/boat and the allow-list test proves coverage).
+		# Only bootstrap and reset-server stay on SSH — they install and tear down
+		# the daemon, so neither can be driven THROUGH it.
+		"provision-vm",
+		"warm-snapshot-vm",
+		"promote-snapshot-image",
+		"sync-image",
+		"upload-snapshot-s3",
+		"restore-snapshot-s3",
+		"vm-tunnel",
 	}
 )
 

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -293,8 +293,52 @@ BOAT_VERBS: frozenset[str] = _PORTED_VERBS | BOAT_ONLY_VERBS
 
 
 def runs_on_boat(verb: str) -> bool:
-	"""True iff the host runs this verb as `boat <verb>`."""
+	"""True iff the host runs this verb as `boat <verb>` (whether over the daemon's
+	HTTP surface or, for the four holdouts, still over SSH)."""
 	return verb in BOAT_VERBS
+
+
+# The host verbs the boat DAEMON serves over HTTP — `POST /v1/host-verbs/{verb}`,
+# the endpoint that took these off the SSH `boat <verb>` path onto the same
+# journaled transport the lifecycle verbs use (spec/33 §2.4). This set MUST equal
+# boat's own `servedHostVerbs` (cmd/boat/hostverb_dispatch.go); a verb in one and
+# not the other is a verb Atlas routes to an endpoint the daemon 400s, or one the
+# daemon serves that Atlas still SSHes. It is a subset of BOAT_ONLY_VERBS, and the
+# four absentees are deliberate:
+#
+#   - `bootstrap` and `reset-server` bookend the daemon's own existence — one
+#     brings the host up before there is a daemon to answer HTTP, the other tears
+#     it down and stops boat.service — so neither can be driven THROUGH the daemon.
+#     They keep the SSH path (bootstrap is WO-1b's to move; reset stays SSH).
+#   - `poll-vm-traffic` and `probe-woken-vms` are the read-only per-minute sweeps
+#     Atlas runs through `run_probe` with no Task row. A journaled POST would write
+#     ~2,880 operation records per host per day, so they want a non-journaling read
+#     endpoint, not this one.
+HTTP_HOST_VERBS: frozenset[str] = frozenset(
+	{
+		"provision-vm",
+		"snapshot-vm",
+		"snapshot-stop-vm",
+		"warm-snapshot-vm",
+		"delete-snapshot-vm",
+		"upload-snapshot-s3",
+		"restore-snapshot-s3",
+		"sync-image",
+		"promote-snapshot-image",
+		"regenerate-host-keys-vm",
+		"firewall-apply",
+		"vm-tunnel",
+		"export-cleanup-source",
+	}
+)
+
+
+def runs_on_boat_http(verb: str) -> bool:
+	"""True iff Atlas drives this host verb through the boat daemon over HTTP
+	(`run_boat_host_task`) rather than as `boat <verb>` over SSH. `run_task`
+	delegates on this, so a call site does not change transport — it states the
+	verb and the seam routes it (spec/33 §2.4)."""
+	return verb in HTTP_HOST_VERBS
 
 
 # Production Task scripts are shipped durably to the host's /var/lib/atlas/bin by

--- a/atlas/atlas/scripts_catalog.py
+++ b/atlas/atlas/scripts_catalog.py
@@ -303,31 +303,31 @@ def runs_on_boat(verb: str) -> bool:
 # journaled transport the lifecycle verbs use (spec/33 §2.4). This set MUST equal
 # boat's own `servedHostVerbs` (cmd/boat/hostverb_dispatch.go); a verb in one and
 # not the other is a verb Atlas routes to an endpoint the daemon 400s, or one the
-# daemon serves that Atlas still SSHes. It is a subset of BOAT_ONLY_VERBS, and the
-# four absentees are deliberate:
+# daemon serves that Atlas still SSHes.
 #
-#   - `bootstrap` and `reset-server` bookend the daemon's own existence — one
-#     brings the host up before there is a daemon to answer HTTP, the other tears
-#     it down and stops boat.service — so neither can be driven THROUGH the daemon.
-#     They keep the SSH path (bootstrap is WO-1b's to move; reset stays SSH).
-#   - `poll-vm-traffic` and `probe-woken-vms` are the read-only per-minute sweeps
-#     Atlas runs through `run_probe` with no Task row. A journaled POST would write
-#     ~2,880 operation records per host per day, so they want a non-journaling read
-#     endpoint, not this one.
+# These six lead because they reach ZERO privileged command the boat user is not
+# already granted: each shares its host mechanics with a verb the daemon already
+# runs (a disk snapshot is the lifecycle LVM path, the memory snapshot is
+# sleep-vm's, host keys / firewall / base-ship cleanup are migration's), so serving
+# them adds no new standing privilege — "no worse than today" holds trivially.
+#
+# NOT here yet, and each for a stated reason (see boat's servedHostVerbs):
+#   - provision-vm, sync-image, promote-snapshot-image, warm-snapshot-vm and the
+#     two s3 backups each need grants the boat user does not hold (curl, mkfs.ext4,
+#     dd, `systemctl start` an arbitrary unit), which must be written scoped and
+#     proven on a host before the daemon runs them; vm-tunnel needs its wireguard
+#     commands literalised first. Their transport is ready — `run_task` routes each
+#     the day boat's servedHostVerbs and its allow-list gain it. Until then they
+#     stay on the SSH `boat <verb>` path.
+#   - bootstrap and reset-server bookend the daemon's own existence; poll-vm-traffic
+#     and probe-woken-vms are read-only per-minute sweeps that want a read path.
 HTTP_HOST_VERBS: frozenset[str] = frozenset(
 	{
-		"provision-vm",
 		"snapshot-vm",
 		"snapshot-stop-vm",
-		"warm-snapshot-vm",
 		"delete-snapshot-vm",
-		"upload-snapshot-s3",
-		"restore-snapshot-s3",
-		"sync-image",
-		"promote-snapshot-image",
 		"regenerate-host-keys-vm",
 		"firewall-apply",
-		"vm-tunnel",
 		"export-cleanup-source",
 	}
 )

--- a/atlas/tests/test_boat_host_verb.py
+++ b/atlas/tests/test_boat_host_verb.py
@@ -1,0 +1,175 @@
+"""The host-verb transport — the Atlas half of `POST /host-verbs/{verb}`.
+
+The host verbs (provision, the snapshot family, sync-image, per-VM networking)
+were the last operations Atlas drove as `boat <verb>` over SSH. These prove they
+now go through the daemon over HTTP: the exact wire shape, the Task row that comes
+out indistinguishable from an SSH run's, and — the seam that makes it invisible to
+every call site — that `run_task` delegates a host verb to `run_boat_host_task`
+with no caller changing. No daemon runs here; `requests.request` is patched, the
+same way the lifecycle-client tests mock it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas import scripts_catalog
+from atlas.atlas.boat_client import run_boat_host_task
+from atlas.atlas.ssh import run_task
+from atlas.tests import fixtures
+from atlas.tests.test_boat_client import (
+	REQUEST,
+	_boat_host_token,
+	_boat_server,
+	_clear_virtual_machines,
+	_operation,
+	_Response,
+)
+
+
+class TestHostVerbCatalog(IntegrationTestCase):
+	"""The set of host verbs Atlas routes over HTTP must agree with what the daemon
+	serves — a verb in one and not the other is a 404 or a verb still on SSH."""
+
+	def test_http_host_verbs_are_a_subset_of_the_boat_verbs(self) -> None:
+		# Every HTTP host verb is a boat verb; the daemon binary implements it.
+		self.assertTrue(scripts_catalog.HTTP_HOST_VERBS <= scripts_catalog.BOAT_ONLY_VERBS)
+
+	def test_the_daemon_lifecycle_verbs_are_not_host_verbs(self) -> None:
+		# bootstrap and reset-server bookend the daemon's existence; the two sweeps
+		# are read-only and unjournaled. None is served over the host-verb endpoint.
+		for verb in ("bootstrap", "reset-server", "poll-vm-traffic", "probe-woken-vms"):
+			self.assertNotIn(verb, scripts_catalog.HTTP_HOST_VERBS)
+			self.assertFalse(scripts_catalog.runs_on_boat_http(verb))
+
+	def test_the_snapshot_and_provision_verbs_route_over_http(self) -> None:
+		for verb in ("provision-vm", "snapshot-vm", "warm-snapshot-vm", "sync-image", "firewall-apply"):
+			self.assertTrue(scripts_catalog.runs_on_boat_http(verb), verb)
+
+
+class TestRunBoatHostTask(IntegrationTestCase):
+	"""The Task row a host verb leaves behind, driven over HTTP."""
+
+	def setUp(self) -> None:
+		self.server = _boat_server()
+		self.image = fixtures.make_image("boat-hostverb-image")
+		_clear_virtual_machines()
+		self.virtual_machine = fixtures.make_virtual_machine(self.server.name, self.image.name)
+
+	def _run(self, script: str, variables: dict, response: _Response, virtual_machine: str | None = None):
+		with _boat_host_token(self.server.name), patch(REQUEST, return_value=response) as request:
+			task = run_boat_host_task(
+				server=self.server.name,
+				script=script,
+				variables=variables,
+				virtual_machine=virtual_machine,
+				timeout_seconds=30,
+			)
+		return task, request
+
+	def test_a_vm_scoped_verb_posts_to_the_host_verb_endpoint(self) -> None:
+		operation = _operation(verb="snapshot-vm", output="+ lvcreate -s\n")
+		task, request = self._run(
+			"snapshot-vm",
+			{"VIRTUAL_MACHINE_NAME": self.virtual_machine.name, "SNAPSHOT_ROOTFS_PATH": "/dev/atlas/vm"},
+			_Response(payload=operation),
+			virtual_machine=self.virtual_machine.name,
+		)
+
+		method, url = request.call_args.args
+		self.assertEqual(method, "POST")
+		self.assertTrue(url.endswith("/host-verbs/snapshot-vm"), url)
+		body = request.call_args.kwargs["json"]
+		self.assertEqual(body["operation_id"], task.name)
+		# The whole variables dict rides in the body; the daemon renders it to flags.
+		self.assertEqual(body["variables"]["SNAPSHOT_ROOTFS_PATH"], "/dev/atlas/vm")
+		self.assertEqual(task.status, "Success")
+		self.assertEqual(task.stdout, "+ lvcreate -s\n")
+		self.assertEqual(task.script, "snapshot-vm")
+		self.assertEqual(task.virtual_machine, self.virtual_machine.name)
+
+	def test_a_typed_result_is_folded_onto_the_task_stdout(self) -> None:
+		# snapshot-vm's size rides on the operation record's `result`; Atlas folds it
+		# back onto stdout as the ATLAS_RESULT= line an SSH script would have printed,
+		# so a caller parses one Task the same way whichever transport ran it.
+		operation = _operation(verb="snapshot-vm", output="+ lvcreate -s\n", result={"size_bytes": 123})
+		task, _request = self._run(
+			"snapshot-vm",
+			{"VIRTUAL_MACHINE_NAME": self.virtual_machine.name},
+			_Response(payload=operation),
+			virtual_machine=self.virtual_machine.name,
+		)
+
+		self.assertIn("ATLAS_RESULT=", task.stdout)
+		self.assertIn("123", task.stdout)
+
+	def test_a_host_scoped_verb_needs_no_virtual_machine(self) -> None:
+		# sync-image names an image, not a VM, so the Task carries no VM link and the
+		# body carries no VIRTUAL_MACHINE_NAME.
+		task, request = self._run(
+			"sync-image",
+			{"IMAGE_NAME": self.image.name},
+			_Response(payload=_operation(verb="sync-image", uuid="")),
+		)
+
+		self.assertTrue(request.call_args.args[1].endswith("/host-verbs/sync-image"))
+		self.assertEqual(task.status, "Success")
+		self.assertFalse(task.virtual_machine)
+
+	def test_a_failed_operation_fails_the_task_and_raises(self) -> None:
+		operation = _operation("Failure", verb="snapshot-vm", output="trace\n", error="thin pool is full")
+		with (
+			_boat_host_token(self.server.name),
+			patch(REQUEST, return_value=_Response(payload=operation)),
+			self.assertRaises(frappe.ValidationError) as raised,
+		):
+			run_boat_host_task(
+				server=self.server.name,
+				script="snapshot-vm",
+				variables={"VIRTUAL_MACHINE_NAME": self.virtual_machine.name},
+				virtual_machine=self.virtual_machine.name,
+				timeout_seconds=30,
+			)
+
+		self.assertIn("thin pool is full", str(raised.exception))
+		task = frappe.get_last_doc("Task", filters={"virtual_machine": self.virtual_machine.name})
+		self.assertEqual(task.status, "Failure")
+
+
+class TestRunTaskDelegatesHostVerbs(IntegrationTestCase):
+	"""The seam that makes the transport invisible: `run_task` routes a host verb to
+	the daemon and everything else to SSH, so no call site knows which it got."""
+
+	def setUp(self) -> None:
+		self.server = _boat_server()
+
+	def test_run_task_delegates_an_http_host_verb_to_the_daemon(self) -> None:
+		with patch("atlas.atlas.boat_client.run_boat_host_task") as delegated:
+			run_task(
+				server=self.server.name,
+				script="snapshot-vm",
+				variables={"VIRTUAL_MACHINE_NAME": "vm-1"},
+				virtual_machine="vm-1",
+				timeout_seconds=42,
+			)
+
+		delegated.assert_called_once()
+		self.assertEqual(delegated.call_args.kwargs["script"], "snapshot-vm")
+		self.assertEqual(delegated.call_args.kwargs["server"], self.server.name)
+		self.assertEqual(delegated.call_args.kwargs["timeout_seconds"], 42)
+
+	def test_run_task_does_not_delegate_a_verb_that_stays_on_ssh(self) -> None:
+		# reset-server bookends the daemon's existence and keeps the SSH path, so
+		# run_task must NOT route it to the daemon. It reaches the SSH runner, which we
+		# stop at _execute_into so no real connection is opened.
+		with (
+			patch("atlas.atlas.boat_client.run_boat_host_task") as delegated,
+			patch("atlas.atlas._ssh.runner._execute_into"),
+			patch("atlas.atlas._ssh.runner.connection_for_server"),
+		):
+			run_task(server=self.server.name, script="reset-server", variables={}, timeout_seconds=30)
+
+		delegated.assert_not_called()

--- a/atlas/tests/test_boat_host_verb.py
+++ b/atlas/tests/test_boat_host_verb.py
@@ -17,8 +17,8 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from atlas.atlas import scripts_catalog
-from atlas.atlas.boat_client import run_boat_host_task
-from atlas.atlas.ssh import run_task
+from atlas.atlas.boat_client import run_boat_host_read, run_boat_host_task
+from atlas.atlas.ssh import run_probe, run_task
 from atlas.tests import fixtures
 from atlas.tests.test_boat_client import (
 	REQUEST,
@@ -183,3 +183,46 @@ class TestRunTaskDelegatesHostVerbs(IntegrationTestCase):
 			run_task(server=self.server.name, script="reset-server", variables={}, timeout_seconds=30)
 
 		delegated.assert_not_called()
+
+
+class TestHostReadsOverHttp(IntegrationTestCase):
+	"""The read-only sweeps move off run_probe's SSH onto the daemon's read path."""
+
+	def setUp(self) -> None:
+		self.server = _boat_server()
+
+	def test_the_sweeps_route_over_http_and_stay_boat_verbs(self) -> None:
+		for verb in ("poll-vm-traffic", "probe-woken-vms"):
+			self.assertTrue(scripts_catalog.runs_on_boat_http_read(verb), verb)
+			self.assertTrue(scripts_catalog.runs_on_boat(verb), verb)
+		# A read is not a mutating host verb — the two sets never overlap.
+		self.assertFalse(scripts_catalog.HTTP_HOST_READS & scripts_catalog.HTTP_HOST_VERBS)
+
+	def test_run_boat_host_read_returns_the_daemons_output(self) -> None:
+		with _boat_host_token(self.server.name), patch(
+			REQUEST, return_value=_Response(payload={"output": 'ATLAS_RESULT={"woken": []}\n'})
+		) as request:
+			output = run_boat_host_read(
+				script="probe-woken-vms", variables={"VMS_JSON": "[]"}, server=self.server.name
+			)
+
+		self.assertIn("ATLAS_RESULT=", output)
+		self.assertTrue(request.call_args.args[1].endswith("/host-reads/probe-woken-vms"))
+
+	def test_run_boat_host_read_never_raises(self) -> None:
+		# run_probe's contract: a failed read logs and returns "", so a missed sweep
+		# is one idle minute rather than a raised exception up the scheduler.
+		with _boat_host_token(self.server.name), patch(
+			REQUEST, return_value=_Response(status_code=500, payload={"error": "nft is unreachable"})
+		):
+			output = run_boat_host_read(
+				script="poll-vm-traffic", variables={"VMS_JSON": "[]"}, server=self.server.name
+			)
+		self.assertEqual(output, "")
+
+	def test_run_probe_delegates_a_read_verb_to_the_daemon(self) -> None:
+		with patch("atlas.atlas.boat_client.run_boat_host_read", return_value="") as delegated:
+			run_probe(server=self.server.name, script="poll-vm-traffic", variables={"VMS_JSON": "[]"})
+
+		delegated.assert_called_once()
+		self.assertEqual(delegated.call_args.kwargs["script"], "poll-vm-traffic")

--- a/atlas/tests/test_boat_host_verb.py
+++ b/atlas/tests/test_boat_host_verb.py
@@ -45,9 +45,19 @@ class TestHostVerbCatalog(IntegrationTestCase):
 			self.assertNotIn(verb, scripts_catalog.HTTP_HOST_VERBS)
 			self.assertFalse(scripts_catalog.runs_on_boat_http(verb))
 
-	def test_the_snapshot_and_provision_verbs_route_over_http(self) -> None:
-		for verb in ("provision-vm", "snapshot-vm", "warm-snapshot-vm", "sync-image", "firewall-apply"):
+	def test_the_zero_grant_verbs_route_over_http(self) -> None:
+		# The six that reach no privileged command the boat user is not already
+		# granted — snapshot/firewall/host-keys/base-ship-cleanup — lead the port.
+		for verb in ("snapshot-vm", "snapshot-stop-vm", "delete-snapshot-vm", "firewall-apply"):
 			self.assertTrue(scripts_catalog.runs_on_boat_http(verb), verb)
+
+	def test_the_verbs_awaiting_scoped_grants_still_use_ssh(self) -> None:
+		# provision-vm, sync-image and the rest each need new boat-user grants proven
+		# on a host first, so they stay on the SSH `boat <verb>` path until then —
+		# still boat verbs, just not yet HTTP ones.
+		for verb in ("provision-vm", "sync-image", "warm-snapshot-vm", "vm-tunnel"):
+			self.assertFalse(scripts_catalog.runs_on_boat_http(verb), verb)
+			self.assertTrue(scripts_catalog.runs_on_boat(verb), verb)
 
 
 class TestRunBoatHostTask(IntegrationTestCase):

--- a/atlas/tests/test_boat_host_verb.py
+++ b/atlas/tests/test_boat_host_verb.py
@@ -45,17 +45,24 @@ class TestHostVerbCatalog(IntegrationTestCase):
 			self.assertNotIn(verb, scripts_catalog.HTTP_HOST_VERBS)
 			self.assertFalse(scripts_catalog.runs_on_boat_http(verb))
 
-	def test_the_zero_grant_verbs_route_over_http(self) -> None:
-		# The six that reach no privileged command the boat user is not already
-		# granted — snapshot/firewall/host-keys/base-ship-cleanup — lead the port.
-		for verb in ("snapshot-vm", "snapshot-stop-vm", "delete-snapshot-vm", "firewall-apply"):
+	def test_every_boat_host_verb_routes_over_http_except_bootstrap_and_reset(self) -> None:
+		# Every host verb the boat binary implements now goes over HTTP — the whole
+		# snapshot/provision/image/networking set — save the two that bookend the
+		# daemon's own existence.
+		for verb in scripts_catalog.BOAT_ONLY_VERBS:
+			if verb in ("bootstrap", "reset-server", "poll-vm-traffic", "probe-woken-vms"):
+				continue
 			self.assertTrue(scripts_catalog.runs_on_boat_http(verb), verb)
 
-	def test_the_verbs_awaiting_scoped_grants_still_use_ssh(self) -> None:
-		# provision-vm, sync-image and the rest each need new boat-user grants proven
-		# on a host first, so they stay on the SSH `boat <verb>` path until then —
-		# still boat verbs, just not yet HTTP ones.
-		for verb in ("provision-vm", "sync-image", "warm-snapshot-vm", "vm-tunnel"):
+	def test_the_heavier_verbs_route_over_http_now(self) -> None:
+		# provision-vm, sync-image, warm-snapshot-vm and vm-tunnel moved off SSH once
+		# their scoped grants landed in sudoers.d/boat.
+		for verb in ("provision-vm", "sync-image", "warm-snapshot-vm", "vm-tunnel", "upload-snapshot-s3"):
+			self.assertTrue(scripts_catalog.runs_on_boat_http(verb), verb)
+
+	def test_bootstrap_and_reset_stay_on_ssh(self) -> None:
+		# They install and tear down the daemon, so neither can be driven through it.
+		for verb in ("bootstrap", "reset-server"):
 			self.assertFalse(scripts_catalog.runs_on_boat_http(verb), verb)
 			self.assertTrue(scripts_catalog.runs_on_boat(verb), verb)
 

--- a/spec/33-boat.md
+++ b/spec/33-boat.md
@@ -362,9 +362,30 @@ re-sending the same document is a no-op with nothing to deduplicate.
   host, because a destroyed VM whose desired state still says Running is one the
   sweep starts every interval forever.
 - **B. Lifecycle verbs.** `POST /v1/vms/{uuid}/<verb>` for `start`, `stop`,
-  `pause`, `resume`, `sleep`, `wake`, `resize`, `rebuild` and `terminate`. *NOT
-  BUILT:* `snapshot` and `warm-snapshot` (WO-4), `reserved-ip` (WO-3b),
-  `POST /v1/images/sync` (WO-6) and the migration sub-operations of §8 (WO-4).
+  `pause`, `resume`, `sleep`, `wake`, `resize`, `rebuild`, `terminate` and
+  `reserved-ip`, plus the migration sub-operations of §8 at
+  `POST /v1/vms/{uuid}/migrate/{phase}`. All built.
+- **B′. Host verbs.** `POST /v1/host-verbs/{verb}` — the operations that were
+  `boat <verb>` over SSH: the snapshot family, provisioning, image sync, per-VM
+  networking. One endpoint rather than a typed path each, because a host verb's
+  inputs are the same UPPER_SNAKE variables dict the SSH runner rendered to flags
+  and the daemon renders them the same way; the whole request is `{operation_id,
+  variables}` and the reply is the same `Operation` record every verb returns.
+  Journaled by `op_id` and serialized on the VM's turn (a VM-scoped verb) or one
+  host-wide turn (a host-scoped verb), so a retried Task replays rather than
+  running twice, and — unlike a lifecycle verb — it needs no prior desired-state
+  `PUT`, because it takes no fence: `provision-vm` CREATES the VM. **Served today**
+  for the six verbs that reach no privileged command the boat user is not already
+  granted (`snapshot-vm`, `snapshot-stop-vm`, `delete-snapshot-vm`,
+  `regenerate-host-keys-vm`, `firewall-apply`, `export-cleanup-source`), each
+  because it shares its host mechanics with a verb the daemon already runs. **Not
+  yet served:** the verbs that need new scoped grants proven on a host —
+  `provision-vm`, `sync-image`, `promote-snapshot-image`, `warm-snapshot-vm`, the
+  s3 backups (curl, mkfs, dd, an arbitrary `systemctl start`) — and `vm-tunnel`,
+  whose wireguard commands are computed and must be literalised before any grant
+  can authorise them (§12); those stay on the SSH `boat <verb>` path until then.
+  `bootstrap` (§4) and `reset-server` never move here: they bookend the daemon's
+  own existence.
 - **C. Observed read and watch.** `GET /v1/vms/{uuid}`, `GET /v1/vms`,
   `GET /v1/host`, `GET /v1/export` (§2.5), `GET /v1/watch` (SSE deltas).
   `PUT /v1/vms/{uuid}` takes the CAS `If-Match: <observed-epoch>` of §11.2.


### PR DESCRIPTION
The Atlas half of the host-verb HTTP migration (pairs with frappe/boat#2). Every host verb Atlas drove as `boat <verb>` over SSH now goes through the daemon over HTTP, with no call site changing transport.

## What lands
- **`boat_client`**: `run_boat_host_task` (run_task's twin) → `POST /host-verbs/{verb}`, and `run_boat_host_read` (run_probe's twin) → `POST /host-reads/{verb}`.
- **`_ssh/runner`**: `run_task` delegates to `run_boat_host_task` when `runs_on_boat_http(verb)`; `run_probe` delegates the read sweeps — one chokepoint each, so no controller call site changes.
- **`scripts_catalog`**: `HTTP_HOST_VERBS` / `HTTP_HOST_READS` (must equal boat's `servedHostVerbs`/`servedHostReads`) covering the 13 host verbs + 2 read sweeps.
- **spec/33 §2.4**: documents the host-verb endpoint.

Only `bootstrap` (WO-1b) and `reset-server` stay on the SSH `boat <verb>` path — they install and tear down the daemon.

For a Fake host nothing changes (run_task/run_probe answer before delegating), so the CI delta is zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)