### PR TITLE
feat(boat): drive the standalone base-image ship over HTTP

### DIFF
--- a/atlas/atlas/doctype/virtual_machine_image_export/test_virtual_machine_image_export.py
+++ b/atlas/atlas/doctype/virtual_machine_image_export/test_virtual_machine_image_export.py
@@ -177,7 +177,10 @@ class TestExportPhaseMachine(IntegrationTestCase):
 		row = _export_row(_local_image(), source, target)
 		self._percent = 20  # hydration holds below 100
 
-		with patch.object(export_module, "run_task", side_effect=self._fake_run_task):
+		with (
+			patch.object(export_module, "run_task", side_effect=self._fake_run_task),
+			patch.object(export_module, "run_boat_migration_phase", side_effect=self._fake_run_task),
+		):
 			# Pending → Exporting → Hydrating each advance to a further non-terminal phase.
 			row.reload()
 			while row.status != "Hydrating":
@@ -197,7 +200,10 @@ class TestExportPhaseMachine(IntegrationTestCase):
 		row = _export_row(_local_image(), source, target)
 		self._percent = 100  # hydration completes immediately
 
-		with patch.object(export_module, "run_task", side_effect=self._fake_run_task):
+		with (
+			patch.object(export_module, "run_task", side_effect=self._fake_run_task),
+			patch.object(export_module, "run_boat_migration_phase", side_effect=self._fake_run_task),
+		):
 			# Walk every phase; advance_export returns False only at the terminal step.
 			for _ in range(len(export_module.PHASE_ORDER) + 2):
 				row.reload()
@@ -215,6 +221,7 @@ class TestExportPhaseMachine(IntegrationTestCase):
 
 		with (
 			patch.object(export_module, "run_task", side_effect=self._fake_run_task),
+			patch.object(export_module, "run_boat_migration_phase", side_effect=self._fake_run_task),
 			patch.object(export_module.frappe, "enqueue") as enqueue,
 		):
 			export_module.start_export(row.name)
@@ -236,7 +243,10 @@ class TestExportPhaseMachine(IntegrationTestCase):
 		)
 		self._percent = 20  # no progress → stall
 
-		with patch.object(export_module, "run_task", side_effect=self._fake_run_task):
+		with (
+			patch.object(export_module, "run_task", side_effect=self._fake_run_task),
+			patch.object(export_module, "run_boat_migration_phase", side_effect=self._fake_run_task),
+		):
 			row.reload()
 			with self.assertRaises(frappe.ValidationError):
 				export_module.advance_export(row)

--- a/atlas/atlas/export.py
+++ b/atlas/atlas/export.py
@@ -39,6 +39,7 @@ import uuid as _uuid
 
 import frappe
 
+from atlas.atlas.boat_client import run_boat_migration_phase
 from atlas.atlas.ssh import run_task
 from atlas.atlas.task_results import parse_result
 
@@ -425,14 +426,44 @@ PHASES = {
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+# The three base-ship phases boat serves as MIGRATION phases (spec/33 §8) — the same
+# export-base / receive-base / poll-hydration boat runs for a VM migration's disk
+# ship, driven over HTTP by `run_boat_migration_phase`. The fourth, export-cleanup-
+# source, is a host verb and goes through `run_task` (which delegates it to the
+# daemon over HTTP itself, spec/33 §2.4).
+_BASE_SHIP_PHASES: frozenset[str] = frozenset(
+	{"migration-export-base", "migration-receive-base", "migration-poll-hydration"}
+)
+
+
+def _base_ship_uuid(image: str) -> str:
+	"""A synthetic, stable UUID for a standalone base-image ship. A standalone export
+	belongs to no VM, but boat addresses a migration phase by UUID and DERIVES the nbd
+	port from it (NBDPort(uuid)+2). Deriving one UUID from the image name gives the
+	source (export-base) and the target (receive-base) the SAME port to bind and dial
+	without either carrying it on the wire — the same "two sides derive it from one
+	identity" trick the per-VM ship uses with the VM's UUID (spec/33 §8)."""
+	return str(_uuid.uuid5(_uuid.NAMESPACE_URL, "atlas-base-ship/" + image))
+
+
 def _run_phase_task(doc, *, server: str, script: str, variables: dict, timeout_seconds: int):
-	"""Run a phase's host script inline. run_task saves the Task row first and raises
-	on failure (→ caught by reconcile_image_exports → Failed). Lost-task detection
-	re-enters a prior Running/Pending Task of the same script that blew its timeout
-	(recorded, never a silent duplicate). An export has no VM, so the Task carries no
-	`virtual_machine` link — lost-task detection keys off the script + this image in the
-	Task variables instead."""
+	"""Run a phase's host work inline, over HTTP. The three base-ship migration phases
+	go through `run_boat_migration_phase` keyed on the image's synthetic UUID (boat
+	derives the port from it, and returns the port it bound in the export-base result,
+	which cleanup then reuses); export-cleanup-source rides `run_task`'s own host-verb
+	delegation. Both save the Task row first and raise on failure (→ caught by
+	reconcile_image_exports → Failed). Lost-task detection re-enters a prior
+	Running/Pending Task of the same script that blew its timeout; an export has no VM,
+	so it keys off the script + this image in the Task variables instead."""
 	_detect_lost_task(doc, script, timeout_seconds)
+	if script in _BASE_SHIP_PHASES:
+		return run_boat_migration_phase(
+			server=server,
+			script=script,
+			variables=variables,
+			virtual_machine=_base_ship_uuid(doc.image),
+			timeout_seconds=timeout_seconds,
+		)
 	return run_task(
 		server=server,
 		script=script,


### PR DESCRIPTION
Finishes the SSH→HTTP migration: `export.py`'s standalone base-image ship (the operator "Export Image" action) was the last thing driving boat work over SSH.

Its `export-base` / `receive-base` / `poll-hydration` phases are boat migration phases — the same ones a VM migration's disk ship already runs over HTTP — but a standalone export has no VM UUID to key them (and the nbd port boat derives from it) on, and its old `run_task` scripts no longer exist on disk. `_base_ship_uuid` derives a stable UUID from the image name so source and target agree on the port without carrying it on the wire, and `_run_phase_task` routes the three phases through `run_boat_migration_phase`. `export-cleanup-source` rides `run_task`'s host-verb HTTP delegation.

With this, every operation Atlas drives via boat is over HTTP except `bootstrap` (WO-1b) and `reset-server`. Export phase-machine tests green (19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)