### PR TITLE
feat(server): mint, store, install and read the per-host Boat token (WO-1b, Atlas half)

### DIFF
--- a/atlas/atlas/boat_client.py
+++ b/atlas/atlas/boat_client.py
@@ -643,17 +643,26 @@ def base_url_for_server(server_name: str) -> str:
 def token_for_server(server_name: str) -> str:
 	"""This host's bearer token.
 
-	Per-host and short-lived by design (spec/33 §12): Atlas mints it, Boat serves
-	the last valid one under partition. WO-0 has no minting yet, so it is
-	configured like every other Atlas credential and read through this one
-	chokepoint — `atlas_boat_tokens` maps a Server name to its token, and
-	`atlas_boat_token` is the single-host dev fallback. The value is never
-	logged and never appears in an error message."""
+	Per-host and short-lived (spec/33 §12): Atlas mints it (Server.mint_boat_token),
+	stores it encrypted on the Server row, and installs it to /etc/boat/token on the
+	host; the daemon serves the last valid one until its hard expiry. Read through
+	this one chokepoint, and never logged or put in an error message.
+
+	A host with no minted token yet — SSH-only, or one not bootstrapped/upgraded
+	since minting shipped — falls back to the static site config: `atlas_boat_tokens`
+	maps a Server name to its token, and `atlas_boat_token` is the single-host dev
+	fallback. Keeping the fallback is what lets minting roll out host by host without
+	stranding one whose token still lives in config."""
+	minted = frappe.get_cached_doc("Server", server_name).get_password("boat_token", raise_exception=False)
+	if minted:
+		return minted
 	tokens = frappe.conf.get("atlas_boat_tokens") or {}
 	token = tokens.get(server_name) or frappe.conf.get("atlas_boat_token")
 	if not token:
 		frappe.throw(
-			_("Server {0} has no Boat token; set atlas_boat_tokens in site config").format(server_name)
+			_(
+				"Server {0} has no Boat token; bootstrap/upgrade it to mint one, or set atlas_boat_tokens"
+			).format(server_name)
 		)
 	return token
 

--- a/atlas/atlas/doctype/server/server.json
+++ b/atlas/atlas/doctype/server/server.json
@@ -27,6 +27,8 @@
    "signing_public_key",
    "signing_private_key",
    "mesh_address",
+   "boat_token",
+   "boat_token_expires_at",
   "section_break_host_info",
   "architecture",
   "column_break_host_info",
@@ -183,6 +185,21 @@
    "fieldname": "mesh_address",
    "fieldtype": "Data",
    "label": "Mesh Address",
+   "read_only": 1
+  },
+  {
+   "description": "The bearer token Atlas minted for this host's Boat tunnel listener (spec/33 §12). Short-lived and per-host: Atlas re-mints it before its hard expiry and installs it to /etc/boat/token on the host; the daemon serves the last valid one until then. Stored encrypted; never logged. Empty on an SSH-only or not-yet-bootstrapped host, where token_for_server falls back to atlas_boat_tokens in site config.",
+   "fieldname": "boat_token",
+   "fieldtype": "Password",
+   "label": "Boat Token",
+   "read_only": 1,
+   "no_copy": 1
+  },
+  {
+   "description": "When boat_token stops being valid if Atlas never re-mints it — the hard expiry the daemon enforces (fail-closed past it). Atlas re-mints well before this on every bootstrap/upgrade, so a reachable host never reaches it; it bounds how long a leaked-but-unrotated token stays good.",
+   "fieldname": "boat_token_expires_at",
+   "fieldtype": "Datetime",
+   "label": "Boat Token Expires At",
    "read_only": 1
   },
   {

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import secrets
 import shlex
 import uuid
 from contextlib import contextmanager
@@ -75,6 +76,15 @@ BOAT_ARTIFACTS: list[tuple[str, str]] = [
 	("systemd/boat-networkd.service", f"{BOAT_STAGING_DIRECTORY}/boat-networkd.service"),
 ]
 
+# Where the daemon reads its bearer token, and the token's lifetimes (spec/33 §12).
+# The daemon serves a minted token until BOAT_TOKEN_TTL_DAYS past minting and
+# refuses it after (fail-closed); Atlas re-mints within BOAT_TOKEN_REMINT_WITHIN_DAYS
+# of that on every bootstrap/upgrade, so a reachable host is always handed a fresh
+# token well before the hard expiry — and a leaked-but-unrotated one is still bounded.
+BOAT_TOKEN_PATH = "/etc/boat/token"
+BOAT_TOKEN_TTL_DAYS = 30
+BOAT_TOKEN_REMINT_WITHIN_DAYS = 7
+
 
 def boat_distribution() -> Path:
 	"""The boat checkout (or unpacked release) on the CONTROLLER that bootstrap
@@ -105,6 +115,8 @@ class Server(Document):
 		from frappe.types import DF
 
 		architecture: DF.Data | None
+		boat_token: DF.Password | None
+		boat_token_expires_at: DF.Datetime | None
 		cli_ready: DF.Check
 		firecracker_version: DF.Data | None
 		image: DF.Link | None
@@ -699,6 +711,10 @@ class Server(Document):
 			for description, command in steps:
 				self._boat_ssh(connection, key_path, description, command)
 			self._verify_boat_binary(connection, key_path, digest)
+			# The bearer token last: it is a per-host secret, minted here and written
+			# to /etc/boat/token, not one of the four static artifacts the tar stream
+			# carried. _start_boat's restart reads it.
+			self._install_boat_token(connection, key_path)
 
 	def _staged_boat_digest(self) -> str:
 		"""SHA-256 of the boat binary this bootstrap is shipping, read on the
@@ -730,6 +746,62 @@ class Server(Document):
 		if not version:
 			frappe.throw(f"`boat version` on {self.name} printed nothing; the binary is not usable")
 		self.observed_boat_version = version
+
+	def mint_boat_token(self) -> str:
+		"""Mint this host's bearer token and stamp its hard expiry (spec/33 §12).
+
+		Short-lived and per-host. The token is stored ENCRYPTED — a Password field, so
+		it lives in __Auth and never in the row or a log — and returned so the caller
+		installs the exact value without re-reading it. The expiry is the hard one the
+		daemon enforces; the re-mint window (below) means a reachable host is handed a
+		fresh token well before it and never reaches it.
+
+		Written with set_encrypted_password + db_set rather than a full self.save():
+		this runs mid-bootstrap/upgrade, and re-running every validate/before_save hook
+		to stamp one credential is both needless and a way to trip a half-built doc."""
+		from frappe.utils.password import set_encrypted_password
+
+		token = secrets.token_urlsafe(32)
+		set_encrypted_password(self.doctype, self.name, token, "boat_token")
+		self.db_set(
+			"boat_token_expires_at",
+			frappe.utils.add_to_date(frappe.utils.now_datetime(), days=BOAT_TOKEN_TTL_DAYS),
+		)
+		return token
+
+	def _current_or_minted_boat_token(self) -> str:
+		"""The stored token if it is present and not yet within the re-mint window of
+		its hard expiry, else a freshly minted one. Re-minting early is what keeps a
+		reachable host from ever reaching the hard expiry the daemon fails closed on."""
+		token = self.get_password("boat_token", raise_exception=False)
+		expires = self.boat_token_expires_at
+		if token and expires:
+			remaining = frappe.utils.get_datetime(expires) - frappe.utils.now_datetime()
+			if remaining.days > BOAT_TOKEN_REMINT_WITHIN_DAYS:
+				return token
+		return self.mint_boat_token()
+
+	def _install_boat_token(self, connection, key_path) -> None:
+		"""Write this host's bearer token to /etc/boat/token, minting or rotating it
+		first. The file is the JSON form Boat reads — the token and the hard expiry it
+		enforces — installed 0640 root:boat so the daemon user reads it and nobody
+		else. The secret is piped on stdin, never argv (§12). _start_boat's restart
+		reads it fresh; a rotation with no restart is this same write followed by
+		`systemctl reload boat` (the daemon reloads the token on SIGHUP)."""
+		token = self._current_or_minted_boat_token()
+		payload = json.dumps(
+			{
+				"token": token,
+				"hard_expires_at": frappe.utils.get_datetime(self.boat_token_expires_at).isoformat(),
+			}
+		)
+		self._boat_ssh(
+			connection,
+			key_path,
+			"installing the boat token",
+			f"sudo install -D -m 0640 -o root -g boat /dev/stdin {BOAT_TOKEN_PATH}",
+			stdin=payload,
+		)
 
 	def _start_boat(self, connection) -> None:
 		"""Enable and (re)start boat.service — after the `boat bootstrap` Task.
@@ -764,10 +836,17 @@ class Server(Document):
 				connection, key_path, "boat.service did not stay up", "sudo systemctl is-active boat.service"
 			)
 
-	def _boat_ssh(self, connection, key_path, description: str, command: str) -> str:
+	def _boat_ssh(
+		self, connection, key_path, description: str, command: str, stdin: str | None = None
+	) -> str:
 		"""One step of the boat install, failing loud and naming which step. Every
-		step is a precondition of the ones after it, so none may be logged past."""
-		stdout, stderr, exit_code = run_ssh(connection, key_path, command, timeout_seconds=120)
+		step is a precondition of the ones after it, so none may be logged past.
+
+		`stdin`, when given, is piped to the remote command instead of placed in its
+		argv — the token install uses it so the secret never appears in a process
+		list, in the command string, or in this method's error text (§12; `install`
+		reads /dev/stdin and echoes nothing, so stderr/stdout stay secret-free)."""
+		stdout, stderr, exit_code = run_ssh(connection, key_path, command, timeout_seconds=120, stdin=stdin)
 		if exit_code != 0:
 			frappe.throw(
 				f"boat install on {self.name}: {description} failed "

--- a/atlas/atlas/doctype/server/test_server.py
+++ b/atlas/atlas/doctype/server/test_server.py
@@ -731,3 +731,68 @@ class TestServerUpgradeBoat(IntegrationTestCase):
 		self.assertEqual(len(mine), 1)
 		self.assertEqual(mine[0].args[0], "atlas.atlas.doctype.server.server.upgrade_host_to_current_boat")
 		self.assertEqual(mine[0].kwargs.get("job_id"), f"upgrade-boat-{self.server.name}")
+
+
+class TestServerBoatToken(IntegrationTestCase):
+	"""WO-1b (spec/33 §12): Atlas mints the per-host bearer token, stores it
+	encrypted, re-mints it before its hard expiry, and reads it through
+	token_for_server. The install-to-host + daemon reload is the live half."""
+
+	def setUp(self) -> None:
+		frappe.db.delete("Server", {"title": "test-server-token"})
+		self.provider = make_provider("test-provider-token")
+
+	def _server(self) -> Document:
+		return make_server(self.provider, "test-server-token", provider_resource_id="77", status="Active")
+
+	def test_mint_stores_the_token_encrypted_and_stamps_a_future_expiry(self) -> None:
+		from atlas.atlas.doctype.server import server as server_module
+
+		server = self._server()
+		token = server.mint_boat_token()
+
+		self.assertTrue(token)
+		# Read back decrypted from __Auth — and NOT sitting in the row column, which
+		# is the whole point of a Password field for a bearer secret.
+		self.assertEqual(server.get_password("boat_token", raise_exception=False), token)
+		self.assertNotEqual(frappe.db.get_value("Server", server.name, "boat_token"), token)
+		remaining = frappe.utils.get_datetime(server.boat_token_expires_at) - frappe.utils.now_datetime()
+		self.assertGreater(remaining.days, server_module.BOAT_TOKEN_TTL_DAYS - 2)
+
+	def test_current_or_minted_reuses_a_fresh_token(self) -> None:
+		server = self._server()
+		first = server.mint_boat_token()
+		# Still far from expiry, so no new secret is handed out.
+		self.assertEqual(server._current_or_minted_boat_token(), first)
+
+	def test_current_or_minted_remints_inside_the_expiry_window(self) -> None:
+		from atlas.atlas.doctype.server import server as server_module
+
+		server = self._server()
+		first = server.mint_boat_token()
+		# Push the expiry inside the re-mint window: the next call must mint anew, so a
+		# reachable host never carries a token to its hard expiry.
+		near = frappe.utils.add_to_date(
+			frappe.utils.now_datetime(), days=server_module.BOAT_TOKEN_REMINT_WITHIN_DAYS - 1
+		)
+		server.db_set("boat_token_expires_at", near)
+
+		second = server._current_or_minted_boat_token()
+
+		self.assertNotEqual(second, first)
+		self.assertEqual(server.get_password("boat_token", raise_exception=False), second)
+
+	def test_token_for_server_prefers_the_minted_row_over_config(self) -> None:
+		from atlas.atlas.boat_client import token_for_server
+
+		server = self._server()
+		token = server.mint_boat_token()
+		with patch.dict(frappe.conf, {"atlas_boat_token": "the-config-fallback"}):
+			self.assertEqual(token_for_server(server.name), token)
+
+	def test_token_for_server_falls_back_to_config_when_unminted(self) -> None:
+		from atlas.atlas.boat_client import token_for_server
+
+		server = self._server()  # never minted
+		with patch.dict(frappe.conf, {"atlas_boat_token": "the-config-fallback"}):
+			self.assertEqual(token_for_server(server.name), "the-config-fallback")


### PR DESCRIPTION
The Atlas half of WO-1b (spec/33 §12). The boat **daemon** half already merged (frappe/boat: `internal/token` — rotation, hard-expiry, SIGHUP reload). This is the controller side, so `token_for_server` no longer depends on an operator placing a token in site config — Atlas mints one.

## Changes

- **Schema** — `Server` gains `boat_token` (Password, stored encrypted in `__Auth`, never in the row) and `boat_token_expires_at` (Datetime).
- **`mint_boat_token`** stamps a fresh `secrets.token_urlsafe(32)` and a hard expiry; **`_current_or_minted_boat_token`** re-mints inside a window (`BOAT_TOKEN_REMINT_WITHIN_DAYS`) so a reachable host is always handed a fresh token well before the expiry the daemon fails closed on.
- **`_install_boat`** writes the JSON token (`{token, hard_expires_at}`) to `/etc/boat/token` at `0640 root:boat`, piped on **stdin** so the secret never appears in argv, a process list, or an error text (§12; `install` reads `/dev/stdin` and echoes nothing). `_start_boat`'s restart reads it; a restart-free rotation is this same write followed by `systemctl reload boat`.
- **`token_for_server`** reads the encrypted row first and keeps the `atlas_boat_tokens` / `atlas_boat_token` config fallback, so minting rolls out host by host without stranding one whose token still lives in config.

## Tests

`TestServerBoatToken` — mint stores encrypted and stamps a future expiry; re-mint inside the window; `token_for_server` prefers the row and falls back to config. Green. `TestServerBootstrap` stays green with the extra install step (its ordering assertions don't collide with the token command).

## Not in this PR (still WO-1b, needs live proof)

Install-to-host + daemon reload proven end to end, and the **registration handshake** (a freshly bootstrapped host announcing its address). No tunnel/mesh in the dev env to validate against. Plan: `frappe/boat` `llm/wo-1b-atlas-half.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
