### PR TITLE
feat: export host and per-VM metrics to datum (spec ch.34)

### DIFF
--- a/atlas/atlas/datum_token.py
+++ b/atlas/atlas/datum_token.py
@@ -1,0 +1,59 @@
+"""Mint RS256 JWTs that datum accepts, one per resource_id (a host or a VM).
+
+datum stamps every sample with the token's resource_id and cannot be told otherwise, so a
+producer that reports for many resources holds many tokens. Atlas mints them here (signed with
+the fleet RSA key in site config `atlas_datum_signing_key`) and ships them to the host's boat
+daemon. Keep frappe imports lazy so `encode_token` is testable without a site.
+"""
+
+import time
+
+import jwt
+
+# One day. Tokens are re-minted every refresh sweep, so a day comfortably covers a missed one.
+DEFAULT_TTL_SECONDS = 24 * 60 * 60
+
+
+def encode_token(resource_id: str, private_key_pem: str, ttl_seconds: int = DEFAULT_TTL_SECONDS, key_id: str | None = None) -> str:
+	"""The pure crypto: an RS256 write-scoped JWT for one resource_id. No frappe."""
+	issued_at = int(time.time())
+	claims = {
+		"resource_id": resource_id,
+		"access": ["write"],
+		"iat": issued_at,
+		"exp": issued_at + ttl_seconds,
+	}
+	headers = {"kid": key_id} if key_id else None
+	return jwt.encode(claims, private_key_pem, algorithm="RS256", headers=headers)
+
+
+def _signing_config() -> tuple[str, str | None]:
+	import frappe
+
+	private_key = frappe.conf.get("atlas_datum_signing_key")
+	if not private_key:
+		raise RuntimeError("atlas_datum_signing_key is not set in site config; cannot mint a datum token")
+	return private_key, frappe.conf.get("atlas_datum_key_id")
+
+
+def mint(resource_id: str, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
+	"""Mint a token for an arbitrary resource_id using the configured fleet key."""
+	private_key, key_id = _signing_config()
+	return encode_token(resource_id, private_key, ttl_seconds, key_id)
+
+
+def mint_for_server(server_name: str, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
+	"""Host token: resource_id is the Server name."""
+	return mint(server_name, ttl_seconds)
+
+
+def mint_for_vm(vm_name: str, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
+	"""VM token: resource_id is the Virtual Machine name (== its UUID)."""
+	return mint(vm_name, ttl_seconds)
+
+
+def datum_url() -> str | None:
+	"""The configured datum base URL, or None if metrics export is not wired."""
+	import frappe
+
+	return frappe.conf.get("atlas_datum_url")

--- a/atlas/atlas/datum_token.py
+++ b/atlas/atlas/datum_token.py
@@ -57,3 +57,44 @@ def datum_url() -> str | None:
 	import frappe
 
 	return frappe.conf.get("atlas_datum_url")
+
+
+def build_bundle(
+	server_name: str,
+	vm_names: list[str],
+	private_key_pem: str,
+	key_id: str | None = None,
+	ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> dict:
+	"""The token file's JSON structure: one host token (resource_id = the Server name)
+	and one token per VM (resource_id = the VM name). Pure — no frappe — so it is unit-tested."""
+	return {
+		"host": encode_token(server_name, private_key_pem, ttl_seconds, key_id),
+		"vms": {name: encode_token(name, private_key_pem, ttl_seconds, key_id) for name in vm_names},
+	}
+
+
+def token_file_json(server_name: str, vm_names: list[str]) -> str:
+	"""The exact bytes written to /etc/boat/datum-tokens.json for one host, signed with the
+	configured fleet key."""
+	import json
+
+	private_key, key_id = _signing_config()
+	return json.dumps(build_bundle(server_name, vm_names, private_key, key_id))
+
+
+def refresh_all() -> None:
+	"""Scheduler entry: re-mint and re-ship every Active host's datum token bundle, so token
+	expiry and VM churn are both covered. A no-op when metrics export is not configured."""
+	import frappe
+
+	if not frappe.conf.get("atlas_datum_url"):
+		return
+	for name in frappe.get_all("Server", filters={"status": "Active"}, pluck="name"):
+		frappe.enqueue(
+			"atlas.atlas.doctype.server.server.refresh_datum_tokens_for_server",
+			queue="long",
+			job_id=f"datum-tokens-{name}",
+			deduplicate=True,
+			server_name=name,
+		)

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -82,6 +82,8 @@ BOAT_ARTIFACTS: list[tuple[str, str]] = [
 # of that on every bootstrap/upgrade, so a reachable host is always handed a fresh
 # token well before the hard expiry — and a leaked-but-unrotated one is still bounded.
 BOAT_TOKEN_PATH = "/etc/boat/token"
+DATUM_TOKENS_PATH = "/etc/boat/datum-tokens.json"
+DATUM_DROPIN_PATH = "/etc/systemd/system/boat.service.d/10-datum.conf"
 BOAT_TOKEN_TTL_DAYS = 30
 BOAT_TOKEN_REMINT_WITHIN_DAYS = 7
 
@@ -715,6 +717,9 @@ class Server(Document):
 			# to /etc/boat/token, not one of the four static artifacts the tar stream
 			# carried. _start_boat's restart reads it.
 			self._install_boat_token(connection, key_path)
+			# The datum token bundle + its drop-in, when metrics export is configured. A
+			# no-op otherwise, so a fleet without datum installs nothing extra.
+			self._install_datum_tokens(connection, key_path)
 
 	def _staged_boat_digest(self) -> str:
 		"""SHA-256 of the boat binary this bootstrap is shipping, read on the
@@ -802,6 +807,61 @@ class Server(Document):
 			f"sudo install -D -m 0640 -o root -g boat /dev/stdin {BOAT_TOKEN_PATH}",
 			stdin=payload,
 		)
+
+	def _datum_dropin_contents(self) -> str:
+		"""The systemd drop-in that turns metrics export on: it resets ExecStart and re-adds
+		the daemon command with --server-name and the datum flags. NOTE: this fully owns
+		ExecStart, so a host that also needs --listen must fold it in here too."""
+		url = frappe.conf.get("atlas_datum_url")
+		return (
+			"[Service]\n"
+			"ExecStart=\n"
+			"ExecStart=/usr/local/bin/boat daemon --socket /run/boat/boat.sock "
+			"--store /var/lib/boat/boat.db --token-file /etc/boat/token "
+			f"--server-name {self.name} --datum-url {url} "
+			"--datum-token-file /etc/boat/datum-tokens.json\n"
+		)
+
+	def _install_datum_tokens(self, connection, key_path) -> None:
+		"""Ship this host's datum token bundle and the drop-in that points boat at datum.
+		A no-op when metrics export is not configured (no atlas_datum_url), so a fleet that
+		has not turned datum on installs nothing. The bundle carries a token per VM this host
+		holds; the secret travels on stdin, never argv, like the bearer token."""
+		if not frappe.conf.get("atlas_datum_url"):
+			return
+		from atlas.atlas import datum_token
+
+		vm_names = frappe.get_all("Virtual Machine", filters={"server": self.name}, pluck="name")
+		payload = datum_token.token_file_json(self.name, vm_names)
+		self._boat_ssh(
+			connection,
+			key_path,
+			"installing the datum tokens",
+			f"sudo install -D -m 0640 -o root -g boat /dev/stdin {DATUM_TOKENS_PATH}",
+			stdin=payload,
+		)
+		self._boat_ssh(
+			connection,
+			key_path,
+			"installing the datum systemd drop-in",
+			f"sudo install -D -m 0644 -o root -g root /dev/stdin {DATUM_DROPIN_PATH}",
+			stdin=self._datum_dropin_contents(),
+		)
+		self._boat_ssh(connection, key_path, "reloading systemd for datum", "sudo systemctl daemon-reload")
+
+	@frappe.whitelist()
+	def refresh_datum_tokens(self) -> None:
+		"""Re-mint and re-ship this host's datum bundle, then SIGHUP boat so it picks up the
+		new tokens without a restart. This is the rotation + VM-churn path; bootstrap already
+		installs the first bundle. A no-op on a Fake server or when datum is not configured."""
+		if is_fake_server(self.name) or not frappe.conf.get("atlas_datum_url"):
+			return
+		connection = connection_for_server(self)
+		with ssh_key_file(connection.ssh_private_key) as key_path:
+			self._install_datum_tokens(connection, key_path)
+			self._boat_ssh(
+				connection, key_path, "reloading boat for datum rotation", "sudo systemctl reload boat.service"
+			)
 
 	def _start_boat(self, connection) -> None:
 		"""Enable and (re)start boat.service — after the `boat bootstrap` Task.
@@ -1429,3 +1489,8 @@ def frappe_thread_context(site: str):
 		yield
 	finally:
 		frappe.destroy()
+
+
+def refresh_datum_tokens_for_server(server_name: str) -> None:
+	"""Enqueue target for datum_token.refresh_all: load the Server and re-ship its bundle."""
+	frappe.get_doc("Server", server_name).refresh_datum_tokens()

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -251,6 +251,7 @@ scheduler_events = {
 		],
 		"*/10 * * * *": [
 			"atlas.atlas.providers.worker.reconcile_pending_servers",
+			"atlas.atlas.datum_token.refresh_all",
 		],
 		"*/2 * * * *": [
 			"atlas.atlas.migration.reconcile_migrations",

--- a/atlas/tests/test_datum_token.py
+++ b/atlas/tests/test_datum_token.py
@@ -1,0 +1,56 @@
+import importlib.util
+import time
+import unittest
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+_MODULE_PATH = "/home/qwerty/worktrees/atlas-datum-metrics/atlas/atlas/datum_token.py"
+
+
+def _load_module():
+	spec = importlib.util.spec_from_file_location("datum_token_under_test", _MODULE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _keypair():
+	key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+	private_pem = key.private_bytes(
+		serialization.Encoding.PEM,
+		serialization.PrivateFormat.PKCS8,
+		serialization.NoEncryption(),
+	).decode()
+	public_pem = key.public_key().public_bytes(
+		serialization.Encoding.PEM,
+		serialization.PublicFormat.SubjectPublicKeyInfo,
+	).decode()
+	return private_pem, public_pem
+
+
+class TestDatumToken(unittest.TestCase):
+	def test_encode_token_verifies_and_carries_claims(self):
+		module = _load_module()
+		private_pem, public_pem = _keypair()
+		token = module.encode_token("vm-abc123", private_pem, ttl_seconds=3600, key_id="k1")
+
+		claims = jwt.decode(token, public_pem, algorithms=["RS256"])
+		self.assertEqual(claims["resource_id"], "vm-abc123")
+		self.assertIn("write", claims["access"])
+		self.assertGreater(claims["exp"], int(time.time()))
+		header = jwt.get_unverified_header(token)
+		self.assertEqual(header["kid"], "k1")
+
+	def test_wrong_key_is_rejected(self):
+		module = _load_module()
+		private_pem, _ = _keypair()
+		_, other_public = _keypair()
+		token = module.encode_token("server-1", private_pem)
+		with self.assertRaises(jwt.InvalidSignatureError):
+			jwt.decode(token, other_public, algorithms=["RS256"])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/atlas/tests/test_datum_token.py
+++ b/atlas/tests/test_datum_token.py
@@ -43,6 +43,16 @@ class TestDatumToken(unittest.TestCase):
 		header = jwt.get_unverified_header(token)
 		self.assertEqual(header["kid"], "k1")
 
+	def test_build_bundle_has_host_and_vm_tokens(self):
+		module = _load_module()
+		private_pem, public_pem = _keypair()
+		bundle = module.build_bundle("atlas-host-1", ["vm-a", "vm-b"], private_pem, key_id="k1")
+		import jwt
+
+		self.assertEqual(jwt.decode(bundle["host"], public_pem, algorithms=["RS256"])["resource_id"], "atlas-host-1")
+		self.assertEqual(set(bundle["vms"]), {"vm-a", "vm-b"})
+		self.assertEqual(jwt.decode(bundle["vms"]["vm-a"], public_pem, algorithms=["RS256"])["resource_id"], "vm-a")
+
 	def test_wrong_key_is_rejected(self):
 		module = _load_module()
 		private_pem, _ = _keypair()

--- a/spec/34-metrics.md
+++ b/spec/34-metrics.md
@@ -1,0 +1,215 @@
+# Metrics — host and per-VM telemetry shipped to datum
+
+The README's oldest non-goal — "No metrics or alerting. `journalctl` is enough."
+([README](./README.md#non-goals-this-iteration)) — was scoped exactly as far as
+[22-observability.md](./22-observability.md) drew it: observability stops at
+making long-running *tasks* legible to a human, and spec/22 explicitly disclaimed
+metrics, alerting, and time-series. This chapter retires the **metrics half** of
+that disclaimer. It ships what spec/22 declined to specify: machine telemetry —
+host and per-VM time-series — pushed to an external store, so the fleet's
+questions ("is this host low on RAM? which tenants are burning CPU? is a VM's
+disk filling?") are answered by numbers a chart can hold, not by grepping a
+journal.
+
+It does not supersede spec/22; the two are different layers and both stay. The
+Task row ([22](./22-observability.md)) answers "what is the thing I clicked doing
+right now" — live, human, ephemeral. The metric answers "what have the machines
+done, over time, across the fleet" — historical, aggregate, queryable. One is
+liveness for an operator watching; the other is a time-series for a fleet an
+operator is not watching. Nothing in spec/22 is retracted; this chapter adds the
+layer it explicitly left out.
+
+## The store: frappe/datum
+
+`datum` is a ClickHouse-backed telemetry service. Producers POST JSON samples to
+`/v1/ingest` under a bearer JWT; readers query SQL at `/v1/query`. A sample is
+one point in one series:
+
+```
+{metric, value, ts, labels}   # ts is ISO-8601 Z
+```
+
+datum stamps every sample with the `resource_id` carried in the producer's JWT,
+and it cannot be overridden per sample. That is the tenant boundary, and it is
+deliberately out of the producer's hands: a producer *is* a resource — its token
+says which one — so a buggy or malicious sample cannot claim another tenant's
+series, no matter what it puts in `labels`. The same property makes read grants
+safe in the other direction: a query credential scoped to one `resource_id`
+leaks exactly that resource's series and nothing else.
+
+## The producer: boat
+
+The push lives in `boat`, the per-host Go daemon ([33-boat.md](./33-boat.md)),
+on a resident ticker defaulting to 30 seconds. The choice is attachment, not
+invention: boat already runs on every host, already gathers host facts for its
+export, and already runs a 30s reconcile loop
+([33-boat.md § 3.2](./33-boat.md#32-reconciler-and-forward-only-state-machines))
+— so the metric tick rides machinery that exists instead of a new agent, in the
+spirit of [README principle 5](./README.md#operating-principles) (no agent runs
+on the server). A separate collector would duplicate boat's host probes, its VM
+inventory, and its failure handling for no gain.
+
+The push is strictly best-effort, by construction. Each tick runs in an isolated
+background worker with a 2-second HTTP timeout, no retry, and bounded per-VM
+concurrency. There is no retry queue, no backpressure into the reconciler, no
+shared lock with anything that touches a VM. datum being slow or down is
+therefore a gap in a chart — the worst case is a missing data point — never a
+slow or failed VM operation. Best-effort is a deliberate trade, not a shortcut:
+telemetry is the one output where losing a sample is strictly cheaper than any
+mechanism that could guarantee delivery, and a guarantee would put the VM
+lifecycle on the critical path of a third-party service Atlas does not control.
+
+The tick is also strictly opt-in. It is wired only when `--datum-url` is set
+(from the `atlas_datum_url` site-config key); an un-wired host reads no token
+file, starts no tick, opens no connection — it behaves exactly as it did before
+this feature existed. Metrics export is invisible until it is configured.
+
+## Tenancy is per-VM
+
+`resource_id` is the Frappe **Server** name for host samples and the **Virtual
+Machine** name — which is the VM's UUID — for a VM's samples. Because datum
+stamps one `resource_id` per batch and a token names one resource, boat holds
+**N+1 tokens** — one host token plus one token per VM — and pushes one batch per
+`resource_id` on each tick.
+
+The cost is token churn: a VM's token is minted when the VM appears and dropped
+when it leaves, and each tick pays N+1 HTTP round trips instead of one. The cost
+is deliberate. A single host-scoped `resource_id` would have made the host the
+tenant — cheaper, but it is the wrong boundary: a tenant's VM is exactly the unit
+a hosting platform must be able to talk about alone. With per-VM ids, a single
+VM's series can be read — or a read grant handed out for it — in isolation,
+without exposing the rest of the host's fleet, and the series follows the VM
+wherever it runs, because its identity is the resource, not the machine. That is
+the property the host-scoped alternative cannot give, and it is the one that
+matters.
+
+## Token lifecycle
+
+Atlas mints the tokens ([datum_token.py](../atlas/atlas/datum_token.py)): RS256,
+signed with the fleet key in site config `atlas_datum_signing_key`; datum
+verifies with the matching public key, and `atlas_datum_key_id` rides the JWT
+`kid` header so the fleet key can rotate without touching datum. Each token
+carries `resource_id`, `access: ["write"]`, `iat`, and `exp`; the default TTL is
+24 hours, and tokens are re-minted on a refresh sweep, so a day comfortably
+covers a missed sweep. Minting is pure crypto — the module imports and tests
+without a Frappe site.
+
+Atlas ships the batch to the host as `/etc/boat/datum-tokens.json`, one JSON
+document:
+
+```json
+{"host": "<jwt>", "vms": {"<uuid>": "<jwt>"}}
+```
+
+installed `0640 root:boat`, and the secret travels over **stdin, never argv** —
+argv is world-readable and would leak a tenant's write credential into the
+process list. boat reads the file at startup and **reloads it on SIGHUP**, which
+is the whole rotation story: Atlas rotates the fleet key or reflects VM churn by
+rewriting the file and `systemctl reload boat`. No restart, no dropped ticks, no
+window where a token is half-valid. The three config keys, all of them:
+`atlas_datum_url`, `atlas_datum_signing_key`, `atlas_datum_key_id`.
+
+## Collection needs no new privilege
+
+Host gauges come from the same host probes boat already runs for its export —
+CPU count, memory, pool fullness are facts it already gathers, now sampled on
+the tick instead of only on the export sweep.
+
+Per-VM values are read **in-process from world-readable files**, needing no sudo
+and no guest access. Two sources, both on the host:
+
+- The VM's **cgroup v2 tree** at `/sys/fs/cgroup/firecracker/<uuid>/` —
+  `memory.current` and `memory.max` for the memory gauges, `cpu.stat`'s
+  `usage_usec` for CPU, `io.stat`'s `rbytes`/`wbytes` for IO.
+- The host-side **veth** `atlas-h<first-7-hex-of-uuid>` under
+  `/sys/class/net/<veth>/statistics/` — `rx_bytes`/`tx_bytes` for network. The
+  veth faces the host, so its rx is the guest's tx and its tx is the guest's rx:
+  `vm_network_receive_bytes_total` reads the veth's `tx_bytes`,
+  `vm_network_transmit_bytes_total` its `rx_bytes`.
+
+A missing file — a VM not running, or torn down between ticks — drops **that one
+sample, never the batch**; the tick moves on and the rest of the VMs report. A
+non-Running VM reports only `vm_up=0`: the cgroup and veth are gone, and the
+status label is the only signal left.
+
+## Counters stay cumulative
+
+CPU, IO, and network metrics are **cumulative counters** — the names end
+`_total` — and the rate is derived downstream by datum/Grafana. That division of
+labor is why boat keeps **no cross-tick state**: it never stores a previous
+value, so there is nothing to persist, nothing to recover after a crash, and
+nothing to get wrong when a counter resets. A VM restart zeroes its counters;
+the derived rate dips to zero and resumes, which is exactly the shape a restart
+deserves, and because the reset is visible downstream rather than "handled" by a
+producer that keeps history, the chart stays honest.
+
+## The metric set
+
+Host — `resource_id` is the Server name; no identifying labels:
+
+| Metric | Meaning |
+| --- | --- |
+| `host_up` | 1 while the host's push succeeds |
+| `host_cpu_cores` | host CPU core count |
+| `host_memory_bytes` | total host memory |
+| `host_disk_free_bytes` | free disk on the host's storage pool |
+| `host_pool_data_percent` | thin-pool data fullness — the number placement's capacity accounting reads |
+| `host_pool_metadata_percent` | thin-pool metadata fullness |
+| `host_virtual_machines` | VMs on the host |
+| `host_firecracker_running` | running firecracker processes |
+
+Per-VM — `resource_id` is the VM name; every sample carries the `server` label,
+and `vm_up` additionally carries `status`:
+
+| Metric | Meaning |
+| --- | --- |
+| `vm_up` | 1 while the VM is Running, 0 otherwise (labeled with `status`) |
+| `vm_memory_current_bytes` | cgroup `memory.current` |
+| `vm_memory_max_bytes` | cgroup `memory.max` |
+| `vm_cpu_usage_seconds_total` | counter — cgroup `cpu.stat` `usage_usec` |
+| `vm_io_read_bytes_total` | counter — cgroup `io.stat` `rbytes` |
+| `vm_io_write_bytes_total` | counter — cgroup `io.stat` `wbytes` |
+| `vm_network_receive_bytes_total` | counter — veth `tx_bytes` (the guest's rx) |
+| `vm_network_transmit_bytes_total` | counter — veth `rx_bytes` (the guest's tx) |
+
+Names are lowercase `^[a-z_][a-z0-9_]*$`, the identifier grammar datum ingests.
+One label key is off the table: **`uuid` is forbidden by datum**, so per-VM
+identity rides the `resource_id`, not a label — which is consistent with the
+tenancy model. The resource is the tenant, and a VM's series is named by the
+resource it belongs to, not by a label any producer could mistype.
+
+## What this is not
+
+- **Not a supersession of spec/22.** Task liveness and fleet numbers are
+  different layers; both stay
+  ([22-observability.md](./22-observability.md),
+  [33-boat.md § 10](./33-boat.md#10-observability-and-audit)).
+- **Not alerting.** This chapter ships numbers, not pages. Alerting on the
+  series is a consumer's job and stays out of scope — the non-goal's alerting
+  half stands.
+- **Not a new agent, and not on the VM lifecycle path.** The tick is a
+  best-effort reader inside boat: it can lose samples, but it can never hold a
+  lock, delay a verb, or fail a VM operation.
+- **Not a per-sample tenancy override.** `resource_id` comes from the token;
+  samples cannot assert it.
+
+## Testing
+
+The split mirrors the rest of the spec. The token mint is pure crypto with no
+Frappe dependency: [test_datum_token.py](../atlas/tests/test_datum_token.py)
+verifies the claims (`resource_id`, `access`, `exp`), the `kid` header, and that
+a token signed by the wrong key is rejected — milliseconds, no site, no host.
+
+The pipeline is a host fact: a live host pushing into a real datum store,
+asserted end-to-end — the tick fires, samples land under the right
+`resource_id`, and the failure shapes are the honest ones: datum down is a gap
+in the series, not a failed tick; a VM torn down between ticks loses one sample
+with the batch intact; a non-Running VM yields `vm_up=0` and nothing else. The
+2-second timeout and no-retry behavior make these shapes cheap to provoke and
+assert.
+
+## Files
+
+Controller: [datum_token.py](../atlas/atlas/datum_token.py) (mint, refresh,
+ship) and [test_datum_token.py](../atlas/tests/test_datum_token.py). Host: the
+metric tick inside boat ([33-boat.md](./33-boat.md)).

--- a/spec/README.md
+++ b/spec/README.md
@@ -164,6 +164,7 @@ keep it the source of truth.
 30. [Distributed network control plane (ANCP)](./31-ancp-network-control-plane.md) — *shipped: the decentralized `atlas-networkd` control plane (gossip + anti-entropy) that replaced the controller-driven WireGuard host mesh of [25](./25-private-networking.md)*
 31. [Sleepy VMs — auto-sleep idle VMs, wake on demand](./32-sleepy-vms.md) — *free host RAM by sleeping idle VMs; wake on operator Start or the first inbound TCP connection (fast resume from a memory snapshot)*
 32. [Boat — the per-host daemon, and what Atlas keeps](./33-boat.md) — *design: the split that makes Atlas authoritative for **desired** state and a per-host Go daemon authoritative for **observed** state; every host-side service becomes one unit off one `boat` binary, driven over an OpenAPI-typed HTTP contract on the [management tunnel](./21-tunnel.md)*
+33. [Metrics — host and per-VM telemetry shipped to datum](./34-metrics.md) — *the metrics half of the old "no metrics or alerting" non-goal, retired: the resident `boat` daemon pushes host and per-VM time-series to the frappe/datum telemetry store on a 30s best-effort tick — per-VM tenancy via one RS256 token per resource_id, no new privilege, and a slow or down datum can never touch a VM's lifecycle*
 
 ## First run on a fresh site
 


### PR DESCRIPTION
Atlas side of host + per-VM metrics export to [frappe/datum](https://github.com/frappe/datum) — the control-plane half of the boat change.

**What**
- `atlas/atlas/datum_token.py`: mints RS256 JWTs per resource_id (host = Server name, VM = Virtual Machine name), signed with a fleet key in site config `atlas_datum_signing_key`; `build_bundle` assembles the `{host, vms}` token file and `refresh_all` re-ships every Active host's bundle on a schedule.
- `Server`: bootstrap installs `/etc/boat/datum-tokens.json` + a systemd drop-in pointing boat at datum (no-op unless `atlas_datum_url` is set); a whitelisted `refresh_datum_tokens` re-ships and SIGHUPs boat. Secrets travel on stdin, never argv.
- `hooks.py`: a 10-minute sweep covers token expiry and VM churn.
- `spec/34-metrics.md`: documents the pipeline, per-VM tenancy, the taxonomy, and retires the metrics half of the old "no metrics or alerting" non-goal (without superseding spec/22).

**Proven live**: driven from real DB state, the bundle Atlas builds shipped to a real host and boat pushed per-VM samples under the matching resource_ids.

Companion: the boat PR (frappe/boat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
