### PR TITLE
feat(datum): make the single fleet token the default install shape

### DIFF
--- a/atlas/atlas/datum_token.py
+++ b/atlas/atlas/datum_token.py
@@ -74,6 +74,41 @@ def build_bundle(
 	}
 
 
+# The fleet-wide resource_id every host and VM reports under in single-token mode.
+# datum stamps each sample with the token's resource_id, so with one token the host and
+# all VMs share it; per-VM samples are told apart by a vm=<uuid> label, and host samples
+# by a server=<name> label — not by resource_id (see boat internal/metricspush).
+FLEET_RESOURCE_ID = "boat"
+
+
+def fleet_token(ttl_seconds: int = DEFAULT_TTL_SECONDS) -> str:
+	"""The single fleet-wide datum token for single-token (primary) mode. Prefer a static
+	token from site config (`atlas_datum_token`) — required when datum verifies against a key
+	Atlas does not hold, e.g. a remote datum — otherwise mint one for resource_id="boat" with
+	the configured fleet signing key."""
+	import frappe
+
+	static = frappe.conf.get("atlas_datum_token")
+	if static:
+		return static
+	return mint(FLEET_RESOURCE_ID, ttl_seconds)
+
+
+def single_token_bundle(token: str) -> dict:
+	"""The single-token file shape: one fleet token and an empty VM map. Every sample lands
+	under the token's resource_id; per-VM samples are distinguished by a vm=<uuid> label.
+	Pure — no frappe — so it is unit-tested."""
+	return {"host": token, "vms": {}}
+
+
+def single_token_file_json() -> str:
+	"""The exact bytes written to /etc/boat/datum-tokens.json in single-token (primary) mode:
+	the fleet token (static from site config if provided, else minted)."""
+	import json
+
+	return json.dumps(single_token_bundle(fleet_token()))
+
+
 def token_file_json(server_name: str, vm_names: list[str]) -> str:
 	"""The exact bytes written to /etc/boat/datum-tokens.json for one host, signed with the
 	configured fleet key."""
@@ -84,8 +119,9 @@ def token_file_json(server_name: str, vm_names: list[str]) -> str:
 
 
 def refresh_all() -> None:
-	"""Scheduler entry: re-mint and re-ship every Active host's datum token bundle, so token
-	expiry and VM churn are both covered. A no-op when metrics export is not configured."""
+	"""Scheduler entry: re-ship every Active host's single fleet datum token, covering token
+	expiry (a minted token is re-minted each sweep; a static token is simply re-installed). A
+	no-op when metrics export is not configured."""
 	import frappe
 
 	if not frappe.conf.get("atlas_datum_url"):

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -825,14 +825,15 @@ class Server(Document):
 	def _install_datum_tokens(self, connection, key_path) -> None:
 		"""Ship this host's datum token bundle and the drop-in that points boat at datum.
 		A no-op when metrics export is not configured (no atlas_datum_url), so a fleet that
-		has not turned datum on installs nothing. The bundle carries a token per VM this host
-		holds; the secret travels on stdin, never argv, like the bearer token."""
+		has not turned datum on installs nothing. The bundle is a single fleet token (resource_id="boat")
+		with an empty VM map — host and VMs both report under it, told apart by server=/vm= labels; a
+		static `atlas_datum_token` from site config is used when present, else a token is minted. The
+		secret travels on stdin, never argv."""
 		if not frappe.conf.get("atlas_datum_url"):
 			return
 		from atlas.atlas import datum_token
 
-		vm_names = frappe.get_all("Virtual Machine", filters={"server": self.name}, pluck="name")
-		payload = datum_token.token_file_json(self.name, vm_names)
+		payload = datum_token.single_token_file_json()
 		self._boat_ssh(
 			connection,
 			key_path,
@@ -852,7 +853,7 @@ class Server(Document):
 	@frappe.whitelist()
 	def refresh_datum_tokens(self) -> None:
 		"""Re-mint and re-ship this host's datum bundle, then SIGHUP boat so it picks up the
-		new tokens without a restart. This is the rotation + VM-churn path; bootstrap already
+		new tokens without a restart. This is the token-rotation path; bootstrap already
 		installs the first bundle. A no-op on a Fake server or when datum is not configured."""
 		if is_fake_server(self.name) or not frappe.conf.get("atlas_datum_url"):
 			return

--- a/atlas/tests/test_datum_token.py
+++ b/atlas/tests/test_datum_token.py
@@ -53,6 +53,16 @@ class TestDatumToken(unittest.TestCase):
 		self.assertEqual(set(bundle["vms"]), {"vm-a", "vm-b"})
 		self.assertEqual(jwt.decode(bundle["vms"]["vm-a"], public_pem, algorithms=["RS256"])["resource_id"], "vm-a")
 
+	def test_single_token_bundle_has_empty_vms(self):
+		module = _load_module()
+		private_pem, public_pem = _keypair()
+		token = module.encode_token("boat", private_pem, key_id="k1")
+		bundle = module.single_token_bundle(token)
+		self.assertEqual(bundle["vms"], {})
+		self.assertEqual(
+			jwt.decode(bundle["host"], public_pem, algorithms=["RS256"])["resource_id"], "boat"
+		)
+
 	def test_wrong_key_is_rejected(self):
 		module = _load_module()
 		private_pem, _ = _keypair()


### PR DESCRIPTION
Builds on #141 (host + per-VM metrics to datum). datum stamps every sample with the token's `resource_id`, and boat now labels host samples `server=<name>` and per-VM samples `vm=<uuid>` (frappe/boat `645bb6e`, `87cb631`). So a host no longer needs a token per resource — one fleet token suffices.

**Change:** `_install_datum_tokens` now ships `{"host":<fleet token>,"vms":{}}` (no per-VM enumeration) as the default. The fleet token is:
- a **static** `atlas_datum_token` from site config when set — required when datum verifies against a signing key Atlas does not hold (e.g. a remote datum);
- otherwise a freshly **minted** token with `resource_id="boat"`.

The per-resource `build_bundle` path stays for a datum that trusts Atlas's key. `refresh_all`/`refresh_datum_tokens` keep rotating for expiry; their wording drops the VM-churn justification (a single token doesn't change with the host's VM set). New unit test covers the single-token bundle shape.

## Proven live (frappe/boat side, atlas-host-1 → remote datum)
Deploying this exact shape by hand — `{"host":"<static boat token>","vms":{}}` + `--datum-url` — gives one push/tick, host + both VMs under the one `resource_id="boat"` token, `server=`/`vm=` labels present:
```
INFO datum: pushed metrics samples=22 accepted=22
host_up{server="atlas-host-1"} 1
vm_up{server="atlas-host-1",status="Running",vm="cb0bda6a-..."} 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)