### PR TITLE
feat(images): fleet-distribute a promoted snapshot as a base image (chef → S3 → sync-image)

### DIFF
--- a/atlas/atlas/api/service.py
+++ b/atlas/atlas/api/service.py
@@ -225,3 +225,19 @@ def get_image(name: str) -> dict:
 		"is_active": bool(image.is_active),
 		"build_mode": image.build_mode or "",
 	}
+
+
+@frappe.whitelist()
+def publish_snapshot_as_fleet_image(
+	snapshot: str, image_name: str, servers=None, title: str | None = None
+) -> dict:
+	"""Distribute a cold snapshot to the fleet as a base image: squash its rootfs and
+	upload it public-read to S3, mint a NON-LOCAL Virtual Machine Image (a plain S3
+	rootfs url + the source image's inherited kernel), and fan out sync-image to
+	`servers` (a JSON list, or None = every Active server). The service (chef) polls
+	get_image(...).is_active for readiness.
+	Returns {image, rootfs_sha256, kernel_sha256, tasks}."""
+	frappe.only_for("System Manager")
+	from atlas.atlas import fleet_image
+
+	return fleet_image.publish_snapshot_as_fleet_image(snapshot, image_name, servers=servers, title=title)

--- a/atlas/atlas/api/service.py
+++ b/atlas/atlas/api/service.py
@@ -229,7 +229,7 @@ def get_image(name: str) -> dict:
 
 @frappe.whitelist()
 def publish_snapshot_as_fleet_image(
-	snapshot: str, image_name: str, servers=None, title: str | None = None
+	snapshot: str, image_name: str, servers: list | str | None = None, title: str | None = None
 ) -> dict:
 	"""Distribute a cold snapshot to the fleet as a base image: squash its rootfs and
 	upload it public-read to S3, mint a NON-LOCAL Virtual Machine Image (a plain S3

--- a/atlas/atlas/fleet_image.py
+++ b/atlas/atlas/fleet_image.py
@@ -1,0 +1,225 @@
+"""Fleet distribution of a promoted snapshot as a NON-LOCAL base image.
+
+`Virtual Machine Snapshot.promote_to_image` is same-server scope (spec/08): it dds
+the snapshot LV into a local `atlas-image-<name>` LV and registers a URL-less
+image row, so a baked golden can only be provisioned on the one host it was
+promoted on. That leaves a gap — a golden bake (spec/15) is exactly what the fleet
+wants everywhere, and no transport exists to get it there. This module fills the
+gap by turning a promoted snapshot into the input shape the existing `sync-image`
+verb already consumes: an HTTPS squashfs rootfs + an HTTPS kernel, each with a
+sha256. It squashes the snapshot's rootfs LV ON the snapshot's host, uploads it to
+S3 (public-read, so the plain non-expiring URL fits the image row's 140-char url
+field), mints a NON-LOCAL `Virtual Machine Image`, and fans out `sync-image` to an
+EXPLICIT list of servers — so each target host curls the squashfs, unsquashes,
+builds a pristine ext4 and imports the read-only base LV `atlas-image-<name>`,
+exactly as for any from-URL image.
+
+The snapshot's rootfs is itself an LV (`rootfs_path`); we mount it read-only and
+mksquashfs it — no dd, no host-side image dir. The kernel is free: the distributed
+image REUSES the source image's `kernel_url` + `kernel_sha256` verbatim (the same
+public bzImage the snapshot booted, which `sync-image` already knows how to unpack
+— exactly as `promote_to_image` reuses the source kernel), so only the rootfs is
+new bytes and only it goes to S3. The S3 bucket is the snapshot-backup bucket
+(spec/29); only the `fleet-images/` key layout is new. The image row is inserted
+INACTIVE so `after_insert` cannot blanket-fan-out to every Active server (the
+fleet carries junk Active rows that must not receive the image); the caller names
+the targets, and the row is activated only after those sync Tasks are enqueued.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+import frappe
+from frappe import _
+
+
+def publish_snapshot_as_fleet_image(
+	snapshot_name: str, image_name: str, *, servers=None, title: str | None = None
+) -> dict:
+	"""Publish `snapshot_name` (an Available cold snapshot) to the fleet as a base
+	image named `image_name`: squash its rootfs LV, upload it public-read to S3, mint
+	a NON-LOCAL `Virtual Machine Image` (a plain S3 rootfs URL + the source image's
+	inherited kernel), and fan out the existing `sync-image` verb to `servers` — the
+	EXPLICIT caller list (a JSON string or a Python list), never the implicit
+	every-Active-server sweep, because the fleet has junk Active rows that must not
+	receive the image.
+
+	The image is inserted INACTIVE (`is_active=0`), so `after_insert` does not
+	auto-sync it anywhere; `sync_to_all_servers(servers)` runs explicitly next, and
+	only then is the row flipped active. Placement ignores inactive rows, so there
+	is never a window where a host that was not asked to sync could provision from
+	it. The caller (the chef service) polls `api.service.get_image(...).is_active`
+	for readiness.
+
+	Returns {image, rootfs_sha256, kernel_sha256, tasks}."""
+	from atlas.atlas import s3
+
+	snapshot = frappe.get_doc("Virtual Machine Snapshot", snapshot_name)
+
+	if snapshot.status != "Available":
+		frappe.throw(f"Snapshot is not Available (status is {snapshot.status})")
+	if snapshot.kind == "Warm":
+		frappe.throw(
+			_(
+				"A warm snapshot cannot be published to the fleet — its value is the frozen memory pair clones resume, which a cold-booting base image discards. Publish a cold snapshot, or clone this one with Clone to new VM."
+			)
+		)
+	if snapshot.data_disk_gigabytes:
+		frappe.throw(
+			_(
+				"This snapshot has a data disk; a base image captures only the root disk (the image has no data-disk fields), so publishing would silently drop it. Clone this snapshot with Clone to new VM to keep the data disk, or publish a data-less snapshot."
+			)
+		)
+	if not snapshot.source_image:
+		frappe.throw(_("Snapshot has no source image to inherit a kernel from; cannot publish."))
+
+	image_name = (image_name or "").strip().lower()
+	from atlas.atlas.doctype.virtual_machine_snapshot.virtual_machine_snapshot import _IMAGE_NAME_RE
+
+	if not _IMAGE_NAME_RE.match(image_name):
+		frappe.throw(
+			f"Image name {image_name!r} is invalid — use lowercase letters, digits, "
+			"dots and dashes (it becomes both the image record name and the LVM LV name)."
+		)
+	if frappe.db.exists("Virtual Machine Image", image_name):
+		frappe.throw(f"A Virtual Machine Image named {image_name!r} already exists.")
+	if not s3.is_configured():
+		frappe.throw(_("S3 Settings is not configured — set the bucket and credentials first."))
+
+	# The distributed image reuses the source image's kernel VERBATIM: the same
+	# public bzImage the snapshot booted, which sync-image already unpacks. So only
+	# the rootfs is produced + uploaded; the kernel row fields are copied over.
+	source = frappe.db.get_value(
+		"Virtual Machine Image",
+		snapshot.source_image,
+		["kernel_url", "kernel_filename", "kernel_sha256", "build_mode"],
+		as_dict=True,
+	)
+	if not source or not source.kernel_url or not source.kernel_filename or not source.kernel_sha256:
+		frappe.throw(
+			f"Source image {snapshot.source_image} has no kernel_url/kernel_filename/kernel_sha256 "
+			"to inherit; cannot publish (the distributed image reuses its kernel)."
+		)
+
+	backup = s3.S3Backup()
+	# `.sqfs`, not `.squashfs`, ON PURPOSE: sync-image's installGuestModules swaps a
+	# `.squashfs` rootfs URL's suffix for `.manifest` to fetch the Ubuntu cloud
+	# image's package manifest and bake matching guest kernel modules into an
+	# otherwise-empty /lib/modules. Our rootfs is squashed from a PROVISIONED VM
+	# whose /lib/modules is already populated (baked by the source image's own
+	# sync-image, and the fleet image REUSES that same kernel), so that re-bake is
+	# redundant — and there is no sibling `.manifest` to fetch. A non-`.squashfs`
+	# URL makes manifestURLFor return "" so sync-image skips the module bake; the
+	# unsquashfs step reads the squashfs magic, not the extension.
+	rootfs_key = f"{backup.key_prefix}/fleet-images/{image_name}/rootfs.sqfs"
+
+	rootfs_sha256 = _produce_and_upload_rootfs(snapshot, image_name, backup, rootfs_key)
+	# Flip the uploaded object public-read so its plain, non-expiring URL (short
+	# enough for the 140-char url field) is what sync-image curls.
+	backup.make_public(rootfs_key)
+	rootfs_url = backup.public_url(rootfs_key)
+
+	# Mint the image row INACTIVE (is_active=0): `after_insert` skips the auto
+	# fan-out for an inactive row, so the only syncs that happen are the explicit
+	# ones below — and placement ignores inactive rows, so there is no window where
+	# an un-synced host could provision from it. A rootfs URL + digest + the
+	# inherited kernel make it NON-LOCAL, so the ordinary sync-image path (curl,
+	# unsquash, build ext4, import the base LV) applies. `rootfs_filename` is the
+	# per-server on-disk ext4 name sync-image writes under the image dir.
+	image = frappe.get_doc(
+		{
+			"doctype": "Virtual Machine Image",
+			"image_name": image_name,
+			"title": title or f"{image_name} (chef fleet image)",
+			"kernel_url": source.kernel_url,
+			"kernel_filename": source.kernel_filename,
+			"kernel_sha256": source.kernel_sha256,
+			"rootfs_url": rootfs_url,
+			"rootfs_filename": f"{image_name}.ext4",
+			"rootfs_sha256": rootfs_sha256,
+			"default_disk_gigabytes": snapshot.disk_gigabytes,
+			"build_mode": source.build_mode or None,
+			"is_active": 0,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	# Fan out sync-image to the caller's explicit list only. sync_to_all_servers
+	# accepts a JSON string or a Python list; with None it would default to every
+	# Active server, which is exactly the blanket sweep the explicit list exists to
+	# avoid (junk Active rows in the fleet must not receive the image).
+	tasks = image.sync_to_all_servers(servers)
+
+	# The sync Tasks are enqueued — now the image is provisionable. Flip active so
+	# placement can select it and `api.service.get_image(...).is_active` reads true
+	# for the chef service's readiness poll.
+	image.db_set("is_active", 1)
+	frappe.db.commit()
+
+	return {
+		"image": image.name,
+		"rootfs_sha256": rootfs_sha256,
+		"kernel_sha256": source.kernel_sha256,
+		"tasks": tasks,
+	}
+
+
+def _produce_and_upload_rootfs(snapshot, image_name, backup, rootfs_key) -> str:
+	"""Do the on-host half: squash the snapshot's rootfs LV into a squashfs, PUT it
+	to S3, and return its sha256 digest.
+
+	One root bash script over SSH on the snapshot's server (mirrors the
+	`ImageBuild._assert_host_has_capacity` run_ssh wiring):
+	  1. `lvchange -ay` the snapshot LV (a cold snapshot's LV may be deactivated
+	     once its build VM stopped — already-active is fine), mount it read-only,
+	     mksquashfs it to /tmp, umount + rmdir;
+	  2. sha256 the /tmp squashfs, PUT it with the presigned URL, rm it;
+	  3. echo the digest as an `ATLAS_FLEET_ROOTFS_SHA256=` line.
+
+	Throws if the host run fails (non-zero exit) or the digest line is missing —
+	the caller must not mint an image row it cannot vouch for."""
+	from atlas.atlas._ssh.transport import run_ssh, ssh_key_file
+	from atlas.atlas.ssh import connection_for_server
+
+	if not snapshot.rootfs_path:
+		frappe.throw(_("Snapshot has no rootfs_path to publish; nothing to squash."))
+
+	put_rootfs = backup.presign_put(rootfs_key)
+	lv = snapshot.rootfs_path
+	rootfs_tmp = f"/tmp/fleet-{image_name}.squashfs"
+
+	script = "\n".join(
+		[
+			"set -euo pipefail",
+			f"lvchange -ay {shlex.quote(lv)} 2>/dev/null || true",
+			"mnt=$(mktemp -d)",
+			f'mount -o ro {shlex.quote(lv)} "$mnt"',
+			f'mksquashfs "$mnt" {shlex.quote(rootfs_tmp)} -noappend -quiet',
+			'umount "$mnt"; rmdir "$mnt"',
+			f"rootfs_sha=$(sha256sum {shlex.quote(rootfs_tmp)} | awk '{{print $1}}')",
+			f"curl -fsS -X PUT --upload-file {shlex.quote(rootfs_tmp)} {shlex.quote(put_rootfs)}",
+			f"rm -f {shlex.quote(rootfs_tmp)}",
+			'echo "ATLAS_FLEET_ROOTFS_SHA256=$rootfs_sha"',
+		]
+	)
+
+	connection = connection_for_server(frappe.get_doc("Server", snapshot.server))
+	with ssh_key_file(connection.ssh_private_key) as key_path:
+		out, err, code = run_ssh(connection, key_path, script, timeout_seconds=1800)
+	if code != 0:
+		frappe.throw(
+			_("Fleet-image production failed on {0} (exit {1}): {2}").format(
+				snapshot.server, code, (err or out)[-500:]
+			)
+		)
+
+	for line in (out or "").splitlines():
+		line = line.strip()
+		if line.startswith("ATLAS_FLEET_ROOTFS_SHA256="):
+			digest = line.split("=", 1)[1].strip()
+			if digest:
+				return digest
+	frappe.throw(
+		_("Fleet-image production on {0} did not report the rootfs sha256 digest").format(snapshot.server)
+	)

--- a/atlas/atlas/s3.py
+++ b/atlas/atlas/s3.py
@@ -116,6 +116,20 @@ class S3Backup:
 	def presign_get(self, key: str) -> str:
 		return self._presign("get_object", key)
 
+	def make_public(self, key: str) -> None:
+		"""Set an object's ACL to public-read. A base-image artifact (a squashfs
+		rootfs) carries no secret, and a plain unsigned URL is both short enough for
+		the image row's 140-char url field — where a presigned url is not — and
+		non-expiring, so a host that re-syncs the image months later still fetches it."""
+		self._client().put_object_acl(Bucket=self.bucket, Key=key, ACL="public-read")
+
+	def public_url(self, key: str) -> str:
+		"""The plain (unsigned) URL of a public-read object — short and non-expiring,
+		unlike a presigned url. Path-style against the configured endpoint (DO Spaces,
+		MinIO); standard virtual-host S3 when no endpoint is set."""
+		base = (self.endpoint_url or f"https://s3.{self.region}.amazonaws.com").rstrip("/")
+		return f"{base}/{self.bucket}/{key}"
+
 	def delete_prefix(self, snapshot_name: str) -> int:
 		"""Delete every object under a snapshot's prefix; return how many. Used by
 		the snapshot row's on_trash so a deleted backup leaves no paid orphan."""

--- a/atlas/atlas/test_fleet_image.py
+++ b/atlas/atlas/test_fleet_image.py
@@ -1,0 +1,118 @@
+"""Unit tests for atlas.atlas.fleet_image — fleet distribution of a promoted
+snapshot as a NON-LOCAL base image (rootfs squashfs → S3 → sync-image fan-out;
+the kernel is inherited from the source image, not re-uploaded).
+
+`_produce_and_upload_rootfs` (the only host-touching step) is monkeypatched away —
+no SSH, no live hosts. S3 is a stub (fixed key prefix + a public-url stub + no-op
+make_public, so the minted image row passes VirtualMachineImage.validate), and
+`frappe.db.commit` / `frappe.enqueue` are patched so the sync Tasks'
+commit-before-enqueue pattern cannot leak rows past the test transaction or pile
+jobs onto the `long` queue. See spec/08-images.md, spec/29-snapshot-backup.md.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas import fleet_image
+from atlas.tests import fixtures
+from atlas.tests.fixtures import no_commit_enqueue
+
+ROOTFS_SHA256 = "a" * 64
+KERNEL_SHA256 = "b" * 64
+SOURCE_KERNEL_URL = "https://cloud-images.example.com/vmlinux-chef-test"
+
+
+class _StubS3Backup:
+	"""Stand-in for s3.S3Backup: a fixed key prefix, a presign-put stub, a no-op
+	make_public and a short plain public-url (so the row's 140-char url fits)."""
+
+	key_prefix = "atlas/snapshots"
+
+	def presign_put(self, key: str) -> str:
+		return "https://example.com/put/" + key
+
+	def make_public(self, key: str) -> None:
+		return None
+
+	def public_url(self, key: str) -> str:
+		return "https://nyc3.example.com/bucket/" + key
+
+
+class TestPublishSnapshotAsFleetImage(IntegrationTestCase):
+	def test_publish_mints_non_local_image_and_fans_out(self) -> None:
+		# image_name is the VMI docname (autoname field:image_name), so a row leaked
+		# by a crashed run would collide with the mint — clear any first. Plain
+		# db.delete (no hooks): VirtualMachineImage has no on_trash to worry about.
+		frappe.db.delete(
+			"Virtual Machine Image", {"image_name": ("in", ["chef-source-image", "chef-testimg"])}
+		)
+
+		provider = fixtures.make_provider("fleet-test-provider")
+		server = fixtures.make_server(
+			provider,
+			title="fleet-test-server",
+			status="Active",
+			ipv4_address="203.0.113.50",
+			ipv6_address="2001:db8:abcd::1",
+			ipv6_prefix="2001:db8:abcd::/64",
+			ipv6_virtual_machine_range="2001:db8:abcd::/124",
+		)
+		source_image = fixtures.make_image(
+			"chef-source-image",
+			kernel_filename="vmlinux-chef-test",
+			build_mode="site",
+		)
+		# The distributed image reuses the source's kernel url + digest verbatim.
+		source_image.db_set("kernel_url", SOURCE_KERNEL_URL)
+		source_image.db_set("kernel_sha256", KERNEL_SHA256)
+
+		with (
+			no_commit_enqueue() as enqueue,
+			patch.object(fleet_image, "_produce_and_upload_rootfs", return_value=ROOTFS_SHA256),
+			patch("atlas.atlas.s3.is_configured", return_value=True),
+			patch("atlas.atlas.s3.S3Backup", _StubS3Backup),
+		):
+			vm = fixtures.make_virtual_machine(server, source_image, title="fleet-test-vm")
+			snapshot = frappe.get_doc(
+				{
+					"doctype": "Virtual Machine Snapshot",
+					"title": "fleet test snapshot",
+					"virtual_machine": vm.name,
+					"server": server.name,
+					"source_image": source_image.name,
+					"status": "Available",
+					"kind": "Cold",
+					"disk_gigabytes": 8,
+					"rootfs_path": "/dev/atlas/atlas-snap-fleet-test",
+				}
+			).insert(ignore_permissions=True)
+
+			result = fleet_image.publish_snapshot_as_fleet_image(
+				snapshot.name, "chef-testimg", servers=[server.name]
+			)
+
+		image = frappe.get_doc("Virtual Machine Image", "chef-testimg")
+		self.assertEqual(image.is_active, 1)
+		self.assertFalse(image.is_local)  # rootfs_url set -> non-local, syncable
+		self.assertEqual(image.rootfs_sha256, ROOTFS_SHA256)
+		# kernel is inherited verbatim from the source image
+		self.assertEqual(image.kernel_sha256, KERNEL_SHA256)
+		self.assertEqual(image.kernel_url, SOURCE_KERNEL_URL)
+		self.assertEqual(image.kernel_filename, "vmlinux-chef-test")
+		self.assertEqual(image.rootfs_filename, "chef-testimg.ext4")
+		self.assertEqual(image.default_disk_gigabytes, 8)
+		self.assertEqual(image.build_mode, "site")
+		# the rootfs is a plain (public) https url carrying the fleet-images key layout
+		self.assertTrue(image.rootfs_url.startswith("https://"))
+		self.assertIn("fleet-images/chef-testimg/rootfs.sqfs", image.rootfs_url)
+
+		self.assertEqual(result["image"], "chef-testimg")
+		self.assertTrue(result["tasks"])
+		# the explicit fan-out went to exactly the requested server, via sync-image
+		self.assertEqual(len(result["tasks"]), 1)
+		task = frappe.get_doc("Task", result["tasks"][0])
+		self.assertEqual(task.server, server.name)
+		self.assertEqual(task.script, "sync-image")
+		enqueue.assert_called()


### PR DESCRIPTION
## What

Adds the missing capability to **fleet-distribute a built (promoted-snapshot) base image to every host**. Today `Virtual Machine Snapshot.promote_to_image` is same-server scope (spec/08): a baked golden lives only on the host it was promoted on, and no transport puts it on the rest of the fleet — only from-URL seed images (the Ubuntu cloud squashfs) fan out via `sync-image`.

This turns a snapshot into that same from-URL shape:

1. `fleet_image.publish_snapshot_as_fleet_image(snapshot, image_name, servers=...)` — mounts the snapshot's rootfs LV on its host, `mksquashfs` it, uploads it **public-read** to the S3 backup bucket, and mints a **non-local** `Virtual Machine Image` whose `rootfs_url` is the plain S3 URL and whose **kernel is inherited verbatim from the source image** (same bzImage the snapshot booted — `sync-image` already unpacks it). It then fans `sync-image` out to an **explicit** server list (never the blanket every-Active sweep — the row is inserted INACTIVE so `after_insert` can't auto-fan to junk Active rows), and flips it active.
2. `api/service.py`: `publish_snapshot_as_fleet_image` — the service (chef) entry point; poll `get_image(...).is_active`.
3. `s3.py`: `make_public` / `public_url` — a base-image rootfs carries no secret, and a plain unsigned URL is short enough for the 140-char image url field (a presigned URL is not) and non-expiring.

The matching chef `atlas-distribute` publisher is on frappe/chef main.

## Design notes
- **Kernel reuse, not re-upload**: the fleet image reuses the source image's `kernel_url`/`kernel_sha256` — `sync-image`'s `downloadKernel` expects the Ubuntu bzImage, and the snapshot booted that exact kernel. Only the rootfs is new bytes.
- **`.sqfs`, not `.squashfs`**: `sync-image`'s `installGuestModules` swaps `.squashfs`→`.manifest` to bake guest kernel modules into an empty `/lib/modules`. Our rootfs comes from a *provisioned* VM whose `/lib/modules` is already populated (same kernel), so that re-bake is redundant and there's no sibling manifest — a non-`.squashfs` URL makes `sync-image` skip it. `unsquashfs` reads the magic, not the extension.

## Proven live (2-host DO fleet)
- Atlas provisioned + snapshotted a VM, `publish_snapshot_as_fleet_image` squashed it → S3 (public, HTTP 200, 337 MB) → non-local VMI → `sync_to_all_servers` → `sync-image`.
- `atlas-image-chef-base-1` (4 G read-only base LV) imported on **both** hosts.
- A VM provisioned from it on the **non-bake** host booted (firecracker active, disk LV `origin=atlas-image-chef-base-1`, guest pings 0% loss).

## Tests
`atlas.atlas.test_fleet_image` (mint non-local image + explicit fan-out) — green. No boat change required (`sync-image` already curls any URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)