### PR TITLE
fix(server): boat token minting — timezone-aware expiry + survive save

### DIFF
--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -797,7 +797,7 @@ class Server(Document):
 		payload = json.dumps(
 			{
 				"token": token,
-				"hard_expires_at": frappe.utils.get_datetime(self.boat_token_expires_at).isoformat(),
+				"hard_expires_at": frappe.utils.get_datetime(self.boat_token_expires_at).astimezone().isoformat(),
 			}
 		)
 		self._boat_ssh(

--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -768,6 +768,14 @@ class Server(Document):
 
 		token = secrets.token_urlsafe(32)
 		set_encrypted_password(self.doctype, self.name, token, "boat_token")
+		# Carry the token on the in-memory doc too: `Document._save_passwords`
+		# REMOVES any Password field that is empty at save time, and bootstrap /
+		# upgrade_boat both end with `self.save()` — so a mint that only wrote
+		# __Auth was silently deleted by the very save that closed the operation,
+		# leaving the host's /etc/boat/token the only copy (and the row tokenless
+		# on the next read). Setting the attribute makes the trailing save re-write
+		# the same value (then mask it), keeping row and host in agreement.
+		self.boat_token = token
 		self.db_set(
 			"boat_token_expires_at",
 			frappe.utils.add_to_date(frappe.utils.now_datetime(), days=BOAT_TOKEN_TTL_DAYS),


### PR DESCRIPTION
Two small fixes found live during the fleet stand-up on atlas.localhost:

1. **743a100** — `hard_expires_at` written naive; boat (RFC3339) crash-looped on every daemon start after bootstrap.
2. **64ada7f** — `_save_passwords` deletes an empty Password field at save; the token minted into __Auth was wiped by the trailing `self.save()` in bootstrap/upgrade_boat, so `token_for_server` fell back to the config token → 401 on every verb. Now carried on the in-memory doc.

Verified live: all three hosts answer /export with the row token, mirror sync applies with zero drift.