### PR TITLE
feat(central): add event IDs + retry webhook event delivery

### DIFF
--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -248,7 +248,11 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 	row with the outcome. Also updates the single's `status` breadcrumb so the
 	operator sees the last delivery at a glance. Runs only on commit
 	(enqueue_after_commit), so a rolled-back emit's row is never reached here and is
-	stamped `rolled_back` — logged, never delivered."""
+	stamped `rolled_back` — logged, never delivered.
+
+	Sends the Central Event Log row's own name as `event_id`: it's already the
+	stable identity of one emit (retry_pending redelivers the same log_name, never a
+	new one), so Central can dedup on it without Atlas inventing a second id."""
 	settings = frappe.get_single("Central Settings")
 	if not settings.enabled:
 		return
@@ -262,6 +266,7 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 	try:
 		settings.client().post_event(
 			{
+				"event_id": log_name,
 				"type": event_type,
 				"payload": payload,
 				"occurred_at": _iso(occurred_at) or frappe.utils.now(),

--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -35,11 +35,7 @@ from atlas.atlas.central import CentralError
 
 MAX_PENDING_RETRY_BATCH = 100
 
-# Total delivery attempts for one event before its Central Event Log row is given
-# up on and stamped "error" (the dead queue — spec/16-central.md). deliver() makes
-# one attempt per call; a failed-but-not-yet-exhausted attempt is stamped back to
-# "queued" so the once-a-minute retry_pending cron (scheduler_events in hooks.py)
-# redrives it — that cron tick, not an in-process sleep, is the retry delay.
+# Max attempts before an event is marked dead.
 MAX_RETRIES = 5
 
 
@@ -170,8 +166,6 @@ def _enqueue_delivery_after_commit(log_name: str, event_type: str, payload: dict
 	frappe.enqueue(
 		"atlas.atlas.central_report.deliver",
 		queue="default",
-		# deliver() makes a single attempt now — this only needs to cover one
-		# CentralClient request (its own DEFAULT_TIMEOUT=30s) plus margin.
 		timeout=60,
 		enqueue_after_commit=True,
 		log_name=log_name,
@@ -259,11 +253,7 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 	(enqueue_after_commit), so a rolled-back emit's row is never reached here and is
 	stamped `rolled_back` — logged, never delivered.
 
-	Makes exactly one send attempt. A failed attempt that hasn't yet used up
-	MAX_RETRIES is stamped back to "queued", so the once-a-minute retry_pending
-	cron (scheduler_events in hooks.py) redrives it — that cron cadence is the
-	retry delay, not an in-process sleep. Once MAX_RETRIES is reached the row is
-	stamped "error" and left dead.
+	One attempt per call; failures under MAX_RETRIES requeue for the cron.
 	"""
 	settings = frappe.get_single("Central Settings")
 	if not settings.enabled:

--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -35,6 +35,13 @@ from atlas.atlas.central import CentralError
 
 MAX_PENDING_RETRY_BATCH = 100
 
+# Total delivery attempts for one event before its Central Event Log row is given
+# up on and stamped "error" (the dead queue — spec/16-central.md). deliver() makes
+# one attempt per call; a failed-but-not-yet-exhausted attempt is stamped back to
+# "queued" so the once-a-minute retry_pending cron (scheduler_events in hooks.py)
+# redrives it — that cron tick, not an in-process sleep, is the retry delay.
+MAX_RETRIES = 5
+
 
 def _enabled() -> bool:
 	# get_single_value tolerates the single's row not existing yet (fresh site).
@@ -163,6 +170,8 @@ def _enqueue_delivery_after_commit(log_name: str, event_type: str, payload: dict
 	frappe.enqueue(
 		"atlas.atlas.central_report.deliver",
 		queue="default",
+		# deliver() makes a single attempt now — this only needs to cover one
+		# CentralClient request (its own DEFAULT_TIMEOUT=30s) plus margin.
 		timeout=60,
 		enqueue_after_commit=True,
 		log_name=log_name,
@@ -250,9 +259,12 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 	(enqueue_after_commit), so a rolled-back emit's row is never reached here and is
 	stamped `rolled_back` — logged, never delivered.
 
-	Sends the Central Event Log row's own name as `event_id`: it's already the
-	stable identity of one emit (retry_pending redelivers the same log_name, never a
-	new one), so Central can dedup on it without Atlas inventing a second id."""
+	Makes exactly one send attempt. A failed attempt that hasn't yet used up
+	MAX_RETRIES is stamped back to "queued", so the once-a-minute retry_pending
+	cron (scheduler_events in hooks.py) redrives it — that cron cadence is the
+	retry delay, not an in-process sleep. Once MAX_RETRIES is reached the row is
+	stamped "error" and left dead.
+	"""
 	settings = frappe.get_single("Central Settings")
 	if not settings.enabled:
 		return
@@ -263,21 +275,26 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 		_stamp(log_name, status="skipped")
 		settings.db_set("status", "skipped: register with Central first", commit=True)
 		return
+
+	event = {
+		"event_id": log_name,
+		"type": event_type,
+		"payload": payload,
+		"occurred_at": _iso(occurred_at) or frappe.utils.now(),
+	}
 	try:
-		settings.client().post_event(
-			{
-				"event_id": log_name,
-				"type": event_type,
-				"payload": payload,
-				"occurred_at": _iso(occurred_at) or frappe.utils.now(),
-			}
-		)
+		settings.client().post_event(event)
 		_stamp(log_name, status="ok", http_status=200)
 		settings.db_set("status", f"ok: {event_type}", commit=True)
-	except CentralError as exception:
-		frappe.log_error(f"Central event {event_type} failed: {exception}", "Central event")
-		_stamp(log_name, status="error", last_error=str(exception)[:140], http_status=exception.status_code)
-		settings.db_set("status", f"error: {exception}"[:140], commit=True)
+		return
+	except CentralError as exc:
+		attempts_so_far = frappe.db.get_value("Central Event Log", log_name, "attempts") or 0
+		dead = attempts_so_far + 1 >= MAX_RETRIES
+		status = "error" if dead else "queued"
+		if dead:
+			frappe.log_error(f"Central event {event_type} failed: {exc}", "Central event")
+		_stamp(log_name, status=status, last_error=str(exc)[:140], http_status=exc.status_code)
+		settings.db_set("status", f"error: {exc}"[:140], commit=True)
 
 
 def _set_log_status(log_name: str, status: str) -> None:

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -269,9 +269,7 @@ class TestCentralReport(IntegrationTestCase):
 		settings.client.return_value.post_event.side_effect = CentralError("still down", 503)
 		with (
 			patch.object(central_report.frappe, "get_single", return_value=settings),
-			patch.object(
-				central_report.frappe.db, "get_value", return_value=central_report.MAX_RETRIES - 1
-			),
+			patch.object(central_report.frappe.db, "get_value", return_value=central_report.MAX_RETRIES - 1),
 			patch.object(central_report, "_stamp") as stamp,
 			patch.object(central_report.frappe, "log_error") as log_error,
 		):

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -223,27 +223,28 @@ class TestCentralReport(IntegrationTestCase):
 			central_report.on_vm_after_insert(self._vm(before_status=None))
 		self.assertEqual(enqueue.call_args.kwargs["event_type"], "vm.created")
 
-	def test_deliver_records_error_and_does_not_raise(self) -> None:
+	def test_deliver_makes_a_single_attempt_and_requeues_on_failure(self) -> None:
+		"""Below MAX_RETRIES, a failed send is stamped back to "queued" -- not
+		retried in-process -- so the once-a-minute retry_pending cron picks it up
+		on its next tick. Only one HTTP call happens per deliver() invocation."""
 		settings = MagicMock()
 		settings.enabled = 1
 		settings.api_key = "svc_key"
 		settings.client.return_value.post_event.side_effect = CentralError("central down", 503)
 		with (
 			patch.object(central_report.frappe, "get_single", return_value=settings),
+			patch.object(central_report.frappe.db, "get_value", return_value=0),
 			patch.object(central_report, "_stamp") as stamp,
-			patch.object(central_report.frappe, "log_error"),
+			patch.object(central_report.frappe, "log_error") as log_error,
 		):
 			central_report.deliver("cel-1", "vm.created", {"name": "vm-1"})
-		# The single's breadcrumb still records the error...
-		settings.db_set.assert_called()
+		settings.client.return_value.post_event.assert_called_once()
+		stamp.assert_called_once_with("cel-1", status="queued", last_error="central down", http_status=503)
+		log_error.assert_not_called()
+		# The single's breadcrumb still records the error for at-a-glance visibility.
 		recorded = settings.db_set.call_args[0]
 		self.assertEqual(recorded[0], "status")
-		self.assertIn("error", recorded[1])
-		# ...and the audit row is stamped error with the HTTP status from Central.
-		stamp.assert_called_once()
-		self.assertEqual(stamp.call_args[0][0], "cel-1")
-		self.assertEqual(stamp.call_args.kwargs["status"], "error")
-		self.assertEqual(stamp.call_args.kwargs["http_status"], 503)
+		self.assertIn("central down", recorded[1])
 
 	def test_deliver_stamps_ok_on_success(self) -> None:
 		settings = MagicMock()
@@ -258,6 +259,25 @@ class TestCentralReport(IntegrationTestCase):
 		event = settings.client.return_value.post_event.call_args[0][0]
 		self.assertEqual(event["occurred_at"], "2026-07-06 00:23:05")
 		stamp.assert_called_once_with("cel-1", status="ok", http_status=200)
+
+	def test_deliver_marks_dead_once_max_retries_exhausted(self) -> None:
+		"""The MAX_RETRIES-th failed attempt is the last one -- no more cron
+		redrives after this, so the row is stamped error (dead) and logged."""
+		settings = MagicMock()
+		settings.enabled = 1
+		settings.api_key = "svc_key"
+		settings.client.return_value.post_event.side_effect = CentralError("still down", 503)
+		with (
+			patch.object(central_report.frappe, "get_single", return_value=settings),
+			patch.object(
+				central_report.frappe.db, "get_value", return_value=central_report.MAX_RETRIES - 1
+			),
+			patch.object(central_report, "_stamp") as stamp,
+			patch.object(central_report.frappe, "log_error") as log_error,
+		):
+			central_report.deliver("cel-1", "vm.created", {"name": "vm-1"})
+		stamp.assert_called_once_with("cel-1", status="error", last_error="still down", http_status=503)
+		log_error.assert_called_once()
 
 	def test_retry_pending_replays_queued_events_in_order(self) -> None:
 		rows = [

--- a/spec/16-central.md
+++ b/spec/16-central.md
@@ -169,6 +169,12 @@ per-Atlas service user** ([21-tunnel.md](./21-tunnel.md)). The methods Atlas exp
 | `ping` | `central.api.atlas.ping` | `{ label }` |
 | `post_event` | `central.api.atlas.event` | (ignored) |
 
+`post_event`'s body is `{ event_id, type, payload, occurred_at }`. `event_id` is
+the `Central Event Log` row's own name — the emit's stable delivery identity, not
+a separate id Atlas has to mint. A `retry_pending` redelivery of the same row
+sends the same `event_id`, so Central can use it to dedup a resend from a
+genuinely new event.
+
 `register` is gone (registration is Central-initiated). **Central → Atlas
 (inbound)** now travels over the tunnel (`tunnel_url`) authenticated as the **Atlas
 admin** token, and adds the `provision_tunnel` / `confirm_tunnel` / `tunnel_status`


### PR DESCRIPTION
ref: frappe/central#199.
Central webhooks now carry an event_id for dedup, and failed deliveries retry via the existing cron instead of dying after one try.