### PR TITLE
feat(image): host-to-host local-image distribution over HTTP (no S3) + Sync Across Hosts

### DIFF
--- a/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.js
+++ b/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.js
@@ -14,6 +14,12 @@ frappe.ui.form.on("Virtual Machine Image", {
 		// spec/24 §5.1). Only offered for a local image; a URL image uses Sync instead.
 		if (frm.doc.is_active && !frm.doc.rootfs_url) {
 			frappe.atlas.add_action(frm, "Export Image", () => open_export_dialog(frm));
+			// Sync Across Hosts: the fleet-wide sibling of Export. Export ships this
+			// local image to ONE host over NBD; this fans the same bytes out to MANY
+			// over HTTP on the mesh, reusing the sync-image verb (no object store).
+			frappe.atlas.add_action(frm, "Sync Across Hosts", () =>
+				open_distribute_dialog(frm)
+			);
 		}
 		if (frm.doc.is_active) {
 			frappe.atlas.add_danger(frm, "Archive", () => confirm_archive(frm));
@@ -66,6 +72,65 @@ function open_export_dialog(frm) {
 				});
 		},
 	});
+	dialog.show();
+}
+
+function open_distribute_dialog(frm) {
+	const who = frm.doc.title || frm.doc.image_name;
+	const dialog = new frappe.ui.Dialog({
+		title: __("Sync {0} across hosts", [who]),
+		fields: [
+			{
+				fieldname: "servers",
+				label: __("Target Hosts"),
+				fieldtype: "MultiSelectList",
+				get_data: (txt) =>
+					frappe.db.get_link_options("Server", txt, { status: "Active" }),
+				description: __(
+					"Active hosts to copy this local image to over the mesh (no object store). The host it was promoted on is skipped automatically. Leave empty to sync to every other Active host."
+				),
+			},
+			{
+				fieldname: "how_hint",
+				fieldtype: "HTML",
+				options: `<p class="text-muted small">${__(
+					"Squashes the read-only base image LV on its home host, serves it over HTTP on the mesh, and runs the sync-image verb on each target so it builds an identical base LV. Runs in the background; watch the Task list."
+				)}</p>`,
+			},
+		],
+		primary_action_label: __("Sync"),
+		primary_action(values) {
+			dialog.hide();
+			frappe
+				.call("atlas.atlas.fleet_distribute.distribute_local_image", {
+					image: frm.doc.name,
+					servers: values.servers || [],
+				})
+				.then(({ message }) => {
+					if (!message) return;
+					frappe.show_alert(
+						{
+							message: __("Distributing {0} to {1} host(s); watch the Task list.", [
+								frm.doc.name,
+								(message.servers || []).length,
+							]),
+							indicator: "blue",
+						},
+						6
+					);
+				});
+		},
+	});
+	// Default the picker to every Active host; distribute_local_image drops the source
+	// host from the list server-side (it already holds the bytes).
+	frappe.db
+		.get_list("Server", { filters: { status: "Active" }, fields: ["name"], limit: 0 })
+		.then((rows) =>
+			dialog.set_value(
+				"servers",
+				(rows || []).map((row) => row.name)
+			)
+		);
 	dialog.show();
 }
 

--- a/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.py
+++ b/atlas/atlas/doctype/virtual_machine_image/virtual_machine_image.py
@@ -232,27 +232,43 @@ class VirtualMachineImage(Document):
 			"DEFAULT_DISK_GB": str(self.default_disk_gigabytes),
 			"GUEST_NETWORK_UNIT": "/tmp/atlas/atlas-network.service",
 		}
-		task = frappe.get_doc(
-			{
-				"doctype": "Task",
-				"server": server_name,
-				"script": "sync-image",
-				"status": "Pending",
-				"triggered_by": frappe.session.user if frappe.session else "Administrator",
-			}
-		)
-		task.variables_dict = variables
-		task.insert(ignore_permissions=True)
-		# nosemgrep: frappe-manual-commit -- persist the Pending sync Task before enqueuing execute_task so the background job can find it cross-transaction
-		frappe.db.commit()
+		return _enqueue_sync_image_task(server_name, variables)
 
-		frappe.enqueue(
-			"atlas.atlas.ssh.execute_task",
-			queue="long",
-			timeout=1800,
-			task_name=task.name,
-		)
-		return task.name
+
+def _enqueue_sync_image_task(server_name: str, variables: dict) -> str:
+	"""Insert a Pending `sync-image` Task for `server_name` from `variables` and enqueue
+	its runner, returning the Task name. The ONE place the `sync-image` Task shape lives.
+
+	Both producers of a sync build the identical Task through here: `sync_to_server`
+	(a from-URL image row) and `atlas.atlas.fleet_distribute` (a local image served
+	host-to-host over HTTP). Same `script` verb, same commit-before-enqueue — so both
+	get the same sidecar staging `execute_task` applies from `SCRIPT_UPLOADS` (the guest
+	network unit). A second call site that hand-rolled `run_task`/`run_boat_host_task`
+	would bypass that staging; funnelling both through here keeps them from drifting.
+
+	`variables` is the caller's fully-formed env for the verb: IMAGE_NAME, the
+	kernel/rootfs URL + digests, ROOTFS_FILENAME, DEFAULT_DISK_GB, GUEST_NETWORK_UNIT."""
+	task = frappe.get_doc(
+		{
+			"doctype": "Task",
+			"server": server_name,
+			"script": "sync-image",
+			"status": "Pending",
+			"triggered_by": frappe.session.user if frappe.session else "Administrator",
+		}
+	)
+	task.variables_dict = variables
+	task.insert(ignore_permissions=True)
+	# nosemgrep: frappe-manual-commit -- persist the Pending sync Task before enqueuing execute_task so the background job can find it cross-transaction
+	frappe.db.commit()
+
+	frappe.enqueue(
+		"atlas.atlas.ssh.execute_task",
+		queue="long",
+		timeout=1800,
+		task_name=task.name,
+	)
+	return task.name
 
 
 @frappe.whitelist()

--- a/atlas/atlas/fleet_distribute.py
+++ b/atlas/atlas/fleet_distribute.py
@@ -70,7 +70,7 @@ def image_http_port(image: str) -> int:
 
 
 @frappe.whitelist()
-def distribute_local_image(image: str, servers=None) -> dict:
+def distribute_local_image(image: str, servers: list[str] | str | None = None) -> dict:
 	"""Fan a local base image out to the fleet over HTTP. Called from the Image form's
 	`Sync Across Hosts` action; the operator picks the targets (or leaves it to the
 	default: every other Active host).

--- a/atlas/atlas/fleet_distribute.py
+++ b/atlas/atlas/fleet_distribute.py
@@ -1,0 +1,363 @@
+"""Fan a LOCAL base image out to the fleet over HTTP — no object store, no S3.
+
+A local (snapshot-promoted) `Virtual Machine Image` has an empty `rootfs_url`: its
+bytes are the read-only base LV `atlas-image-<name>` on exactly the host it was
+promoted on, so `sync-image` has nothing to fetch and the fleet can't provision from
+it anywhere else. Two transports close that gap without a bucket:
+
+- `atlas.atlas.export` ships the base LV point-to-point to ONE target over plain-TCP
+  NBD (spec/24 §5.1) — the migration's proven copy.
+- THIS module fans the SAME bytes out to MANY targets by reusing the ordinary
+  `sync-image` verb UNCHANGED, over an on-host HTTP export on the host↔host mesh.
+
+The shape mirrors `atlas.atlas.fleet_image.publish_snapshot_as_fleet_image` — squash
+the rootfs on its home host, then feed the existing `sync-image` verb — but swaps the
+S3 upload for a short-lived `python3 -m http.server` bound to the source's mesh
+address (`networking.derive_host_mesh_address`, the documented image-fan-out bus).
+Each target curls the squashfs, verifies its digest, unsquashes, builds a pristine
+ext4 and imports the base LV `atlas-image-<name>` — byte-identical to a promote on
+that host. The kernel is FREE: the promoted image reuses its source image's public
+`kernel_url` + digest (spec/08 "the kernel is free"), so only the rootfs is new bytes
+and only it rides the mesh; the kernel is fetched from its public URL as usual.
+
+The served URL is EPHEMERAL — the HTTP unit is torn down when the fan-out finishes
+(a `RuntimeMaxSec` cap is the backstop), and it is NEVER written to the image row. So
+the image stays local: no new row (no name collision with the local one), no dangling
+URL, and placement keeps treating every host with a successful `sync-image` Task for
+it as holding its bytes (`placement._local_image_home_servers`). The whole thing is
+idempotent — the home host re-serves and `sync-image` short-circuits where the base LV
+already exists.
+
+The squash + serve runs as ROOT over SSH on the home host (mirroring
+`fleet_image._produce_and_upload_rootfs`): the Boat sudoers grants neither
+`mount atlas-image-*` nor `mksquashfs`, so this is a root one-shot, not a Boat verb —
+no new grant, no Boat change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import time
+
+import frappe
+from frappe import _
+
+# The per-image HTTP port lives ABOVE the migration/export NBD range (20000-25000, see
+# export.export_port) so a distribute and an export of the same image never collide on a
+# port. A stable per-image hash makes a re-run reuse the same port (idempotent).
+_HTTP_PORT_BASE = 26000
+_HTTP_PORT_SPAN = 2000
+
+# Where the squashed rootfs is staged and served from on the home host.
+_SERVE_ROOT = "/var/lib/atlas/fleet-serve"
+
+# The whole fan-out (serve → sync → teardown) runs in one background job; it blocks on
+# the sync Tasks so it can tear the HTTP server down only once every target has pulled
+# the bytes. Bounded so a wedged target can't hold the worker forever — the HTTP unit's
+# own RuntimeMaxSec is the ultimate backstop.
+_POLL_INTERVAL_SECONDS = 10
+_DISTRIBUTION_TIMEOUT_SECONDS = 1800
+
+
+def image_http_port(image: str) -> int:
+	"""The stable HTTP port this image is served on from its home host. A pure function
+	of the name (a salted `hash()` would move the port every process), landing in
+	[26000, 28000) — disjoint from the NBD range export/migration use, so a distribute
+	and an export of the same image can run at once."""
+	digest = hashlib.sha256(image.encode()).digest()
+	return _HTTP_PORT_BASE + int.from_bytes(digest[:4], "big") % _HTTP_PORT_SPAN
+
+
+@frappe.whitelist()
+def distribute_local_image(image: str, servers=None) -> dict:
+	"""Fan a local base image out to the fleet over HTTP. Called from the Image form's
+	`Sync Across Hosts` action; the operator picks the targets (or leaves it to the
+	default: every other Active host).
+
+	Only a LOCAL image needs this — a from-URL image is placed anywhere by
+	`sync-image` (`Sync to All Servers`), so we reject a syncable one up front. The
+	home host (where the base LV lives) is resolved from the promote Task trail and is
+	always dropped from the target list — it already holds the bytes.
+
+	Synchronous work would blow a web request's timeout (mksquashfs of a multi-GB rootfs
+	takes minutes, then we wait on every target's sync), so this only PREFLIGHTS and
+	enqueues `_run_distribution` on the long queue, returning a handle. Returns
+	`{image, source, servers}`."""
+	from atlas.atlas.doctype.virtual_machine_image_export.virtual_machine_image_export import (
+		_image_home_server,
+	)
+
+	row = frappe.db.get_value(
+		"Virtual Machine Image", image, ["is_active", "rootfs_url"], as_dict=True
+	)
+	if not row:
+		frappe.throw(_("Virtual Machine Image {0} does not exist").format(image))
+	if not row.is_active:
+		frappe.throw(_("Image {0} is archived — activate it before distributing.").format(image))
+	if (row.rootfs_url or "").strip():
+		frappe.throw(
+			_(
+				"{0} is a from-URL image — place it with Sync to All Servers, not Sync Across "
+				"Hosts (which ships a local, un-syncable image's bytes)."
+			).format(image)
+		)
+
+	source = _image_home_server(image)
+	if not source:
+		frappe.throw(
+			_(
+				"Cannot resolve which host holds {0}'s base LV (no successful promote Task "
+				"found) — nothing to distribute."
+			).format(image)
+		)
+
+	if isinstance(servers, str):
+		servers = frappe.parse_json(servers) or None
+	if not servers:
+		servers = frappe.get_all("Server", filters={"status": "Active"}, pluck="name")
+	targets = [server for server in servers if server != source]
+	if not targets:
+		frappe.throw(
+			_("No other Active host to distribute {0} to (it already lives on {1}).").format(
+				image, source
+			)
+		)
+
+	frappe.enqueue(
+		"atlas.atlas.fleet_distribute._run_distribution",
+		queue="long",
+		timeout=_DISTRIBUTION_TIMEOUT_SECONDS + 600,
+		image=image,
+		servers=targets,
+	)
+	return {"image": image, "source": source, "servers": targets}
+
+
+def _run_distribution(image: str, servers: list[str]) -> None:
+	"""The background driver: serve the rootfs on its home host, fan `sync-image` out to
+	`servers`, wait for every sync to finish, then tear the HTTP server down.
+
+	Teardown is in a `finally` so a mid-fan-out failure never leaves the HTTP unit and
+	its staged squashfs behind on the home host. The image row is not touched — the
+	served URL lives only in the sync Tasks' variables, so it can't dangle."""
+	from atlas.atlas.doctype.virtual_machine_image.virtual_machine_image import (
+		_enqueue_sync_image_task,
+	)
+	from atlas.atlas.doctype.virtual_machine_image_export.virtual_machine_image_export import (
+		_image_home_server,
+	)
+	from atlas.atlas.networking import derive_host_mesh_address
+
+	source = _image_home_server(image)
+	if not source:
+		frappe.throw(_("Cannot resolve which host holds {0}'s base LV.").format(image))
+	targets = [server for server in servers if server != source]
+	if not targets:
+		return
+
+	kernel = _source_image_kernel(image)
+	mesh_address = derive_host_mesh_address(source)
+	port = image_http_port(image)
+	image_doc = frappe.get_doc("Virtual Machine Image", image)
+
+	try:
+		rootfs_sha256 = _serve_rootfs_over_http(source, image, mesh_address, port)
+		variables = {
+			"IMAGE_NAME": image_doc.image_name,
+			"KERNEL_URL": kernel["kernel_url"],
+			"KERNEL_FILENAME": kernel["kernel_filename"],
+			"KERNEL_SHA256": kernel["kernel_sha256"],
+			# Plain HTTP on the mesh bus (WG-encrypted, host-only); the `.sqfs` name
+			# makes sync-image skip the guest-module re-bake (the promoted rootfs
+			# already carries its modules).
+			"ROOTFS_URL": f"http://[{mesh_address}]:{port}/rootfs.sqfs",
+			# The LV-named presence sentinel the promote wrote on the home host; passing
+			# it verbatim makes every target's on-disk name match the home host's, so a
+			# distributed host looks identical to the promoted one to provision-vm.
+			"ROOTFS_FILENAME": image_doc.rootfs_filename,
+			"ROOTFS_SHA256": rootfs_sha256,
+			"DEFAULT_DISK_GB": str(image_doc.default_disk_gigabytes),
+			"GUEST_NETWORK_UNIT": "/tmp/atlas/atlas-network.service",
+		}
+		task_names = [_enqueue_sync_image_task(server, variables) for server in targets]
+		outcomes = _poll_tasks_to_terminal(task_names, _DISTRIBUTION_TIMEOUT_SECONDS)
+		unfinished = {name: (status or "Timed out") for name, status in outcomes.items() if status != "Success"}
+		if unfinished:
+			frappe.logger("atlas").error(
+				f"fleet distribution of {image}: sync tasks not successful: {unfinished}"
+			)
+	finally:
+		_teardown_http_server(source, image)
+
+
+def _source_image_kernel(image: str) -> dict:
+	"""The kernel a distributed image inherits: the source image's public `kernel_url`,
+	`kernel_filename` and `kernel_sha256`. A promoted image reuses its snapshot's source
+	image kernel byte-for-byte (spec/08 "the kernel is free"), so `sync-image` fetches
+	the SAME public bzImage the promoted rootfs booted — the kernel never rides the mesh.
+
+	The source image is read off the promote Task's `SOURCE_IMAGE` variable (the same
+	Task trail `_image_home_server` resolves the home host from). Throws if the promote
+	Task, its source image, or any kernel field is missing — we must not enqueue a sync
+	we can't hand a kernel."""
+	source_image = _promote_source_image(image)
+	kernel = frappe.db.get_value(
+		"Virtual Machine Image",
+		source_image,
+		["kernel_url", "kernel_filename", "kernel_sha256"],
+		as_dict=True,
+	)
+	if not kernel or not kernel.kernel_url or not kernel.kernel_filename or not kernel.kernel_sha256:
+		frappe.throw(
+			_(
+				"Source image {0} of {1} has no kernel_url/kernel_filename/kernel_sha256 to "
+				"inherit; cannot distribute (the distributed image reuses its kernel)."
+			).format(source_image, image)
+		)
+	return kernel
+
+
+def _promote_source_image(image: str) -> str:
+	"""The `SOURCE_IMAGE` the promote recorded for this local image, off the latest
+	non-failed `promote-snapshot-image` Task — the same immutable trail
+	`_image_home_server` reads the home host from (so the two never disagree about which
+	promote produced the LV). Throws if there is no promote Task or it named no source."""
+	rows = frappe.db.sql(
+		"""
+		SELECT variables FROM `tabTask`
+		WHERE script IN ('promote-snapshot-image', 'promote-snapshot-image.py')
+		  AND status != 'Failure'
+		  AND variables LIKE %(pattern)s
+		ORDER BY modified DESC
+		LIMIT 1
+		""",
+		{"pattern": f'%"IMAGE_NAME": "{image}"%'},
+		as_dict=True,
+	)
+	if not rows:
+		frappe.throw(
+			_("No promote Task found for {0} — cannot resolve the kernel to inherit.").format(image)
+		)
+	variables = frappe.parse_json(rows[0]["variables"]) or {}
+	source_image = variables.get("SOURCE_IMAGE")
+	if not source_image:
+		frappe.throw(
+			_("Promote Task for {0} recorded no SOURCE_IMAGE — cannot resolve the kernel.").format(image)
+		)
+	return source_image
+
+
+def _serve_rootfs_over_http(source_server: str, image: str, mesh_address: str, port: int) -> str:
+	"""Squash the base LV on its home host and start serving it over HTTP; return the
+	squashfs sha256.
+
+	One root bash script over SSH (mirrors `fleet_image._produce_and_upload_rootfs`):
+	  1. stop any prior serve unit (so a re-run's `systemd-run --unit` and mksquashfs
+	     don't collide), activate the read-only base LV, mount it read-only;
+	  2. `mksquashfs` it to `<serve_dir>/rootfs.sqfs` (`.sqfs`, not `.squashfs`, so
+	     sync-image skips the guest-module re-bake), umount, sha256 it;
+	  3. `systemd-run` a transient `python3 -m http.server` bound to the host's mesh
+	     address on `port`, capped by RuntimeMaxSec so a missed teardown self-heals;
+	  4. echo the digest as an `ATLAS_FLEET_ROOTFS_SHA256=` line.
+
+	Throws if the host run fails or the digest line is missing — the caller must not fan
+	out a sync it can't hand a verified digest."""
+	from atlas.atlas._ssh.transport import run_ssh, ssh_key_file
+	from atlas.atlas.ssh import connection_for_server
+
+	lv = f"/dev/atlas/atlas-image-{image}"
+	serve_dir = f"{_SERVE_ROOT}/{image}"
+	sqfs = f"{serve_dir}/rootfs.sqfs"
+	unit = f"atlas-image-serve-{image}"
+
+	script = "\n".join(
+		[
+			"set -euo pipefail",
+			f"systemctl stop {shlex.quote(unit)} 2>/dev/null || true",
+			f"lvchange -ay {shlex.quote(lv)} 2>/dev/null || true",
+			f"rm -rf {shlex.quote(serve_dir)}",
+			f"mkdir -p {shlex.quote(serve_dir)}",
+			"mnt=$(mktemp -d)",
+			f'mount -o ro {shlex.quote(lv)} "$mnt"',
+			f'mksquashfs "$mnt" {shlex.quote(sqfs)} -noappend -quiet',
+			'umount "$mnt"; rmdir "$mnt"',
+			f"rootfs_sha=$(sha256sum {shlex.quote(sqfs)} | awk '{{print $1}}')",
+			" ".join(
+				[
+					"systemd-run",
+					f"--unit={shlex.quote(unit)}",
+					"--property=RuntimeMaxSec=3600",
+					"python3 -m http.server",
+					str(port),
+					f"--bind {shlex.quote(mesh_address)}",
+					f"--directory {shlex.quote(serve_dir)}",
+				]
+			),
+			'echo "ATLAS_FLEET_ROOTFS_SHA256=$rootfs_sha"',
+		]
+	)
+
+	connection = connection_for_server(frappe.get_doc("Server", source_server))
+	with ssh_key_file(connection.ssh_private_key) as key_path:
+		out, err, code = run_ssh(connection, key_path, script, timeout_seconds=1800)
+	if code != 0:
+		frappe.throw(
+			_("Serving image {0} on {1} failed (exit {2}): {3}").format(
+				image, source_server, code, (err or out)[-500:]
+			)
+		)
+
+	for line in (out or "").splitlines():
+		line = line.strip()
+		if line.startswith("ATLAS_FLEET_ROOTFS_SHA256="):
+			digest = line.split("=", 1)[1].strip()
+			if digest:
+				return digest
+	frappe.throw(_("Serving image {0} on {1} reported no rootfs sha256 digest").format(image, source_server))
+
+
+def _teardown_http_server(source_server: str, image: str) -> None:
+	"""Stop the serve unit and drop its staged squashfs on the home host. Best-effort:
+	runs in a `finally`, so a failure here is logged, never raised (it must not mask the
+	real distribution error, and the unit's RuntimeMaxSec caps it regardless)."""
+	from atlas.atlas._ssh.transport import run_ssh, ssh_key_file
+	from atlas.atlas.ssh import connection_for_server
+
+	unit = f"atlas-image-serve-{image}"
+	serve_dir = f"{_SERVE_ROOT}/{image}"
+	script = "\n".join(
+		[
+			"set -uo pipefail",
+			f"systemctl stop {shlex.quote(unit)} 2>/dev/null || true",
+			f"rm -rf {shlex.quote(serve_dir)}",
+		]
+	)
+	connection = connection_for_server(frappe.get_doc("Server", source_server))
+	with ssh_key_file(connection.ssh_private_key) as key_path:
+		out, err, code = run_ssh(connection, key_path, script, timeout_seconds=120)
+	if code != 0:
+		frappe.logger("atlas").error(
+			f"fleet image serve teardown on {source_server} failed (exit {code}): {(err or out)[-300:]}"
+		)
+
+
+def _poll_tasks_to_terminal(task_names: list[str], timeout_seconds: int) -> dict:
+	"""Block until every sync Task is terminal (Success/Failure) or the timeout hits;
+	return `{task: final_status_or_None}` (None == still unfinished at timeout).
+
+	`rollback` before each read starts a fresh transaction so the sync workers'
+	committed status flips are visible (a long-lived read snapshot would never see
+	them). Nothing here writes, so the rollback only refreshes."""
+	deadline = time.monotonic() + timeout_seconds
+	outcomes: dict = {name: None for name in task_names}
+	while any(status is None for status in outcomes.values()) and time.monotonic() < deadline:
+		time.sleep(_POLL_INTERVAL_SECONDS)
+		frappe.db.rollback()
+		for name, status in outcomes.items():
+			if status is not None:
+				continue
+			current = frappe.db.get_value("Task", name, "status")
+			if current in ("Success", "Failure"):
+				outcomes[name] = current
+	return outcomes

--- a/atlas/atlas/fleet_distribute.py
+++ b/atlas/atlas/fleet_distribute.py
@@ -69,6 +69,29 @@ def image_http_port(image: str) -> int:
 	return _HTTP_PORT_BASE + int.from_bytes(digest[:4], "big") % _HTTP_PORT_SPAN
 
 
+def _serve_address(source_server: str) -> str:
+	"""The address the source host serves the squashed rootfs on. Defaults to the host
+	MESH address (`networking.derive_host_mesh_address`) — the documented, WG-encrypted,
+	host-only image-fan-out bus. Set `atlas_fleet_serve_public` in site config to serve on
+	the source's PUBLIC IPv4 instead, for an off-mesh controller / a dev fleet whose mesh
+	is not the transport (the same escape hatch `atlas_boat_base_urls` is for boat). The
+	served rootfs is then briefly reachable on the public wire (torn down after the
+	fan-out); prefer the mesh in production."""
+	from atlas.atlas.networking import derive_host_mesh_address
+
+	if frappe.conf.get("atlas_fleet_serve_public"):
+		public = frappe.db.get_value("Server", source_server, "ipv4_address")
+		if not public:
+			frappe.throw(_("Server {0} has no ipv4_address to serve the image on.").format(source_server))
+		return public
+	return derive_host_mesh_address(source_server)
+
+
+def _url_host(address: str) -> str:
+	"""Bracket an IPv6 literal for a URL authority; leave IPv4 / a hostname bare."""
+	return f"[{address}]" if ":" in address else address
+
+
 @frappe.whitelist()
 def distribute_local_image(image: str, servers: list[str] | str | None = None) -> dict:
 	"""Fan a local base image out to the fleet over HTTP. Called from the Image form's
@@ -147,7 +170,6 @@ def _run_distribution(image: str, servers: list[str]) -> None:
 	from atlas.atlas.doctype.virtual_machine_image_export.virtual_machine_image_export import (
 		_image_home_server,
 	)
-	from atlas.atlas.networking import derive_host_mesh_address
 
 	source = _image_home_server(image)
 	if not source:
@@ -157,21 +179,21 @@ def _run_distribution(image: str, servers: list[str]) -> None:
 		return
 
 	kernel = _source_image_kernel(image)
-	mesh_address = derive_host_mesh_address(source)
+	serve_address = _serve_address(source)
 	port = image_http_port(image)
 	image_doc = frappe.get_doc("Virtual Machine Image", image)
 
 	try:
-		rootfs_sha256 = _serve_rootfs_over_http(source, image, mesh_address, port)
+		rootfs_sha256 = _serve_rootfs_over_http(source, image, serve_address, port)
 		variables = {
 			"IMAGE_NAME": image_doc.image_name,
 			"KERNEL_URL": kernel["kernel_url"],
 			"KERNEL_FILENAME": kernel["kernel_filename"],
 			"KERNEL_SHA256": kernel["kernel_sha256"],
-			# Plain HTTP on the mesh bus (WG-encrypted, host-only); the `.sqfs` name
-			# makes sync-image skip the guest-module re-bake (the promoted rootfs
-			# already carries its modules).
-			"ROOTFS_URL": f"http://[{mesh_address}]:{port}/rootfs.sqfs",
+			# Plain HTTP on the mesh bus (WG-encrypted, host-only) by default; the
+			# `.sqfs` name makes sync-image skip the guest-module re-bake (the promoted
+			# rootfs already carries its modules).
+			"ROOTFS_URL": f"http://{_url_host(serve_address)}:{port}/rootfs.sqfs",
 			# The LV-named presence sentinel the promote wrote on the home host; passing
 			# it verbatim makes every target's on-disk name match the home host's, so a
 			# distributed host looks identical to the promoted one to provision-vm.
@@ -248,7 +270,7 @@ def _promote_source_image(image: str) -> str:
 	return source_image
 
 
-def _serve_rootfs_over_http(source_server: str, image: str, mesh_address: str, port: int) -> str:
+def _serve_rootfs_over_http(source_server: str, image: str, serve_address: str, port: int) -> str:
 	"""Squash the base LV on its home host and start serving it over HTTP; return the
 	squashfs sha256.
 
@@ -290,7 +312,7 @@ def _serve_rootfs_over_http(source_server: str, image: str, mesh_address: str, p
 					"--property=RuntimeMaxSec=3600",
 					"python3 -m http.server",
 					str(port),
-					f"--bind {shlex.quote(mesh_address)}",
+					f"--bind {shlex.quote(serve_address)}",
 					f"--directory {shlex.quote(serve_dir)}",
 				]
 			),

--- a/atlas/atlas/placement.py
+++ b/atlas/atlas/placement.py
@@ -290,11 +290,13 @@ def _synced_image_home_servers(image: str) -> set[str]:
 
 
 def _local_image_home_servers(image: str) -> set[str]:
-	"""Servers holding a local (snapshot-promoted) image: its promote home plus every
-	server a successful export shipped it to. The promote home comes from the same Task
-	trail `Virtual Machine Image Export.before_insert` denormalizes from; the export
-	targets come from the export rows themselves (their `target_server` is the durable
-	record that the bytes landed there)."""
+	"""Servers holding a local (snapshot-promoted) image: its promote home, every server
+	a successful export shipped it to, and every server an HTTP fleet-distribute synced
+	it to. The promote home comes from the same Task trail
+	`Virtual Machine Image Export.before_insert` denormalizes from; the export targets
+	come from the export rows themselves (their `target_server` is the durable record
+	that the bytes landed there); the distribute targets come from the `sync-image` Task
+	trail."""
 	from atlas.atlas.doctype.virtual_machine_image_export.virtual_machine_image_export import (
 		_image_home_server,
 	)
@@ -312,6 +314,13 @@ def _local_image_home_servers(image: str) -> set[str]:
 			pluck="target_server",
 		)
 	)
+	# `fleet_distribute` fans a local image out over HTTP by reusing `sync-image`, so a
+	# host with a successful sync-image Task for it holds its bytes too — the SAME trail a
+	# from-URL image's presence is read from (`_synced_image_home_servers`). Union it in
+	# so an HTTP-distributed host becomes a placement candidate. (fleet_distribute leaves
+	# the row LOCAL — the served URL is ephemeral, torn down after the fan-out — so
+	# `image_home_servers` still routes local images through here, not the sync path.)
+	homes.update(_synced_image_home_servers(image))
 	return {home for home in homes if home}
 
 

--- a/atlas/atlas/test_fleet_distribute.py
+++ b/atlas/atlas/test_fleet_distribute.py
@@ -98,15 +98,27 @@ class TestDistributeLocalImage(IntegrationTestCase):
 		teardown.assert_called_once()
 		enqueue.assert_called()
 
-		# Exactly one sync-image Task, to the target, with the mesh HTTP URL, the computed
-		# rootfs digest, the inherited kernel, and the LV-named rootfs filename.
-		tasks = frappe.get_all(
-			"Task",
-			filters={"server": self.target.name, "script": "sync-image"},
-			pluck="name",
-		)
-		self.assertEqual(len(tasks), 1)
-		variables = frappe.get_doc("Task", tasks[0]).variables_dict
+		# Exactly one sync-image Task from THIS fan-out, to the target, with the mesh HTTP
+		# URL, the computed rootfs digest, the inherited kernel, and the LV-named rootfs
+		# filename. Isolate it by its served-over-mesh ROOTFS_URL (a from-URL image's own
+		# after_insert sync of an unrelated image can leave other sync Tasks on a shared
+		# test DB), not by asserting the target has exactly one sync Task overall.
+		tasks = [
+			frappe.get_doc("Task", name)
+			for name in frappe.get_all(
+				"Task",
+				filters={"server": self.target.name, "script": "sync-image"},
+				pluck="name",
+			)
+		]
+		distribute_tasks = [
+			task
+			for task in tasks
+			if (task.variables_dict.get("ROOTFS_URL") or "").endswith("/rootfs.sqfs")
+			and task.variables_dict.get("IMAGE_NAME") == "distribute-localimg"
+		]
+		self.assertEqual(len(distribute_tasks), 1)
+		variables = distribute_tasks[0].variables_dict
 		self.assertEqual(variables["IMAGE_NAME"], "distribute-localimg")
 		self.assertEqual(variables["ROOTFS_SHA256"], ROOTFS_SHA256)
 		self.assertEqual(variables["KERNEL_URL"], SOURCE_KERNEL_URL)

--- a/atlas/atlas/test_fleet_distribute.py
+++ b/atlas/atlas/test_fleet_distribute.py
@@ -1,0 +1,142 @@
+"""Unit tests for atlas.atlas.fleet_distribute — fanning a LOCAL base image out to
+the fleet over HTTP (squash on the home host → serve over the mesh → sync-image
+fan-out; the kernel is inherited from the promote provenance, not transferred).
+
+The two host-touching steps (`_serve_rootfs_over_http`, `_teardown_http_server`) and
+the blocking poll are monkeypatched away — no SSH, no live hosts, no sleeps. The
+promote provenance is a real `promote-snapshot-image` Task row (the same trail
+`_image_home_server`/`_source_image_kernel` read), and `frappe.db.commit` /
+`frappe.enqueue` are patched so the sync Task's commit-before-enqueue can't leak rows
+past the test transaction. See spec/08-images.md § Distributing a local image over HTTP.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from atlas.atlas import fleet_distribute
+from atlas.tests import fixtures
+from atlas.tests.fixtures import no_commit_enqueue
+
+ROOTFS_SHA256 = "c" * 64
+KERNEL_SHA256 = "d" * 64
+SOURCE_KERNEL_URL = "https://cloud-images.example.com/vmlinux-distribute-test"
+
+
+def _make_local_image(name: str) -> "frappe.model.document.Document":
+	"""A URL-less (local, snapshot-promoted) image row: kernel/rootfs filenames set,
+	every download field empty — exactly what promote_to_image inserts."""
+	return frappe.get_doc(
+		{
+			"doctype": "Virtual Machine Image",
+			"image_name": name,
+			"title": f"{name} (local test image)",
+			"kernel_url": "",
+			"kernel_filename": "vmlinux-distribute-test",
+			"kernel_sha256": "",
+			"rootfs_url": "",
+			"rootfs_filename": f"atlas-image-{name}",
+			"rootfs_sha256": "",
+			"default_disk_gigabytes": 8,
+			"is_active": 1,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _make_promote_task(image: str, source_image: str, server: str) -> None:
+	"""The promote Task trail fleet_distribute resolves the home host + kernel from."""
+	task = frappe.get_doc(
+		{
+			"doctype": "Task",
+			"server": server,
+			"script": "promote-snapshot-image",
+			"status": "Success",
+			"triggered_by": "Administrator",
+		}
+	)
+	task.variables_dict = {"IMAGE_NAME": image, "SOURCE_IMAGE": source_image}
+	task.insert(ignore_permissions=True)
+
+
+class TestDistributeLocalImage(IntegrationTestCase):
+	def setUp(self) -> None:
+		frappe.db.delete(
+			"Virtual Machine Image",
+			{"image_name": ("in", ["distribute-source-image", "distribute-localimg"])},
+		)
+		self.provider = fixtures.make_provider("distribute-test-provider")
+		self.source = fixtures.make_server(
+			self.provider, title="distribute-source", status="Active", ipv4_address="203.0.113.60"
+		)
+		self.target = fixtures.make_server(
+			self.provider, title="distribute-target", status="Active", ipv4_address="203.0.113.61"
+		)
+		self.source_image = fixtures.make_image(
+			"distribute-source-image", kernel_filename="vmlinux-distribute-test"
+		)
+		self.source_image.db_set("kernel_url", SOURCE_KERNEL_URL)
+		self.source_image.db_set("kernel_sha256", KERNEL_SHA256)
+		self.image = _make_local_image("distribute-localimg")
+		_make_promote_task("distribute-localimg", self.source_image.name, self.source.name)
+
+	def test_run_distribution_serves_and_fans_out_sync_image(self) -> None:
+		with (
+			no_commit_enqueue() as enqueue,
+			patch.object(
+				fleet_distribute, "_serve_rootfs_over_http", return_value=ROOTFS_SHA256
+			) as serve,
+			patch.object(fleet_distribute, "_teardown_http_server") as teardown,
+			patch.object(fleet_distribute, "_poll_tasks_to_terminal", return_value={}),
+		):
+			fleet_distribute._run_distribution("distribute-localimg", [self.target.name])
+
+		# Squashed + served on the home host, torn down in the finally.
+		serve.assert_called_once()
+		self.assertEqual(serve.call_args.args[0], self.source.name)
+		self.assertEqual(serve.call_args.args[1], "distribute-localimg")
+		teardown.assert_called_once()
+		enqueue.assert_called()
+
+		# Exactly one sync-image Task, to the target, with the mesh HTTP URL, the computed
+		# rootfs digest, the inherited kernel, and the LV-named rootfs filename.
+		tasks = frappe.get_all(
+			"Task",
+			filters={"server": self.target.name, "script": "sync-image"},
+			pluck="name",
+		)
+		self.assertEqual(len(tasks), 1)
+		variables = frappe.get_doc("Task", tasks[0]).variables_dict
+		self.assertEqual(variables["IMAGE_NAME"], "distribute-localimg")
+		self.assertEqual(variables["ROOTFS_SHA256"], ROOTFS_SHA256)
+		self.assertEqual(variables["KERNEL_URL"], SOURCE_KERNEL_URL)
+		self.assertEqual(variables["KERNEL_SHA256"], KERNEL_SHA256)
+		self.assertEqual(variables["KERNEL_FILENAME"], "vmlinux-distribute-test")
+		self.assertEqual(variables["ROOTFS_FILENAME"], "atlas-image-distribute-localimg")
+		self.assertTrue(variables["ROOTFS_URL"].startswith("http://["))
+		self.assertTrue(variables["ROOTFS_URL"].endswith("/rootfs.sqfs"))
+
+	def test_distribute_enqueues_and_drops_the_source_host(self) -> None:
+		with no_commit_enqueue() as enqueue:
+			result = fleet_distribute.distribute_local_image("distribute-localimg")
+
+		self.assertEqual(result["image"], "distribute-localimg")
+		self.assertEqual(result["source"], self.source.name)
+		# Default targets = every Active host minus the source (which already holds it).
+		self.assertIn(self.target.name, result["servers"])
+		self.assertNotIn(self.source.name, result["servers"])
+		enqueue.assert_called()
+
+	def test_distribute_rejects_a_from_url_image(self) -> None:
+		with self.assertRaises(frappe.ValidationError):
+			fleet_distribute.distribute_local_image(self.source_image.name)
+
+	def test_distribute_rejects_a_missing_image(self) -> None:
+		with self.assertRaises(frappe.ValidationError):
+			fleet_distribute.distribute_local_image("no-such-image")
+
+	def test_image_http_port_is_stable_and_disjoint_from_nbd(self) -> None:
+		port = fleet_distribute.image_http_port("distribute-localimg")
+		self.assertEqual(port, fleet_distribute.image_http_port("distribute-localimg"))
+		self.assertGreaterEqual(port, 26000)
+		self.assertLess(port, 28000)

--- a/spec/08-images.md
+++ b/spec/08-images.md
@@ -258,10 +258,56 @@ clone the warm one with `clone_to_new_vm`. (Operator decision, 2026-06-19: "Memo
 is the real benefit of a warm snapshot. If we lose that, might as well not have
 it.")
 
-**Why no transport / no cross-server distribution.** With same-server scope the
-bytes never leave the host. Export-to-URL (reusing `sync-image.py`'s download path)
-and server-to-server copy are only relevant if fleet-wide distribution is wanted
-later; build none of it now.
+**Same-server scope, then opt-in distribution.** Promote itself never moves bytes —
+they stay on the host it ran on. Fleet-wide distribution, when wanted, is a
+SEPARATE step layered on top (never a hidden side effect of promote): a
+point-to-point **Export** (spec/24 §5.1) or the many-host **Sync Across Hosts**
+described next.
+
+### Distributing a local image over HTTP (no object store)
+
+A local (snapshot-promoted) base image has an empty `rootfs_url`, so `sync-image`
+has nothing to fetch and the fleet cannot provision from it anywhere but its home
+host. Two transports place it elsewhere **without an object store**:
+
+- **Export** ships the base LV point-to-point to ONE target over plain-TCP NBD
+  (spec/24 §5.1) — the migration's proven copy.
+- **Sync Across Hosts** fans the SAME bytes out to MANY targets by reusing the
+  ordinary `sync-image` verb, over HTTP on the host↔host mesh
+  (`atlas.atlas.fleet_distribute.distribute_local_image`, the Image form's
+  **Sync Across Hosts** action).
+
+The HTTP fan-out mirrors the from-URL sync path exactly, swapping the public
+download for an on-host, short-lived HTTP export:
+
+1. On the image's home host (root over SSH, like the fleet-image squash): activate
+   the read-only base LV `atlas-image-<name>`, mount it read-only, `mksquashfs` it
+   to `/var/lib/atlas/fleet-serve/<name>/rootfs.sqfs`, `sha256sum` it, then
+   `systemd-run` a `python3 -m http.server` bound to the host's mesh address
+   (`networking.derive_host_mesh_address`) on a stable per-image port (disjoint
+   from the NBD range). The served file is `rootfs.sqfs`, not `.squashfs`, so
+   `sync-image` skips the guest-module re-bake (the promoted rootfs already carries
+   its modules).
+2. Fan the `sync-image` verb out to the other Active hosts through the SAME Task
+   builder `Sync to All Servers` uses (so both share `execute_task`'s sidecar
+   staging), with `ROOTFS_URL=http://[<mesh>]:<port>/rootfs.sqfs`, the computed
+   rootfs digest, and the **kernel inherited from the promote provenance** — the
+   source image's public `kernel_url` + digest (the kernel is NOT transferred
+   host-to-host). Each target curls the squashfs, verifies the digest, unsquashes,
+   builds a pristine ext4 and imports the base LV `atlas-image-<name>` — identical
+   to a promote on that host.
+3. The serve unit is stopped and its directory removed once the fan-out finishes (a
+   `RuntimeMaxSec` cap is the backstop). The served URL is **ephemeral** — it is
+   never written to the image row, so the image stays local; placement treats every
+   host with a successful `sync-image` Task for it as holding its bytes
+   (`placement._local_image_home_servers`).
+
+The image row is **not mutated**: no new row (so no name collision with the local
+one), no persisted URL (it would dangle after teardown). Re-running is idempotent —
+the home host re-serves and `sync-image` short-circuits where the base LV already
+exists. No Boat or sudoers change: `sync-image` is reused unchanged, and the squash
+runs as root over SSH because the Boat sudoers grants neither `mount atlas-image-*`
+nor `mksquashfs`.
 
 The two entry points: **`Virtual Machine Snapshot` → Promote to image** (a dialog
 taking the image name) and **`Image Build` → Promote to image** (a thin delegate


### PR DESCRIPTION
## What
Circulate a **local** (snapshot-promoted) base image to the rest of the fleet with **no object store**, by reusing the existing `sync-image` verb over an on-host HTTP export — plus a **Sync Across Hosts** Desk action on the Image form.

A local image's rootfs lives only on the host it was promoted on (`atlas-image-<name>` LV, empty `rootfs_url`). This squashes it on its home host, serves it over a short-lived `python3 -m http.server`, and fans `sync-image` out to the other Active hosts; each unsquashes + builds ext4 + imports the base LV — byte-identical to a promote. The kernel is inherited from the promote provenance (public URL, never transferred). The served URL is ephemeral and never written to the row, so the image stays local and placement tracks presence via the `sync-image` Task trail.

## Shape
- `fleet_distribute.py`: `distribute_local_image(image, servers=None)` (whitelisted) → background `_run_distribution` (serve → fan out → poll → teardown in `finally`). Mirrors `fleet_image.py`'s SSH-squash idiom, swapping the S3 upload for the on-host serve. No boat/sudoers change; `sync-image` reused unchanged.
- Extracted `_enqueue_sync_image_task` so `sync_to_server` and the fan-out share sidecar staging.
- `placement._local_image_home_servers` unions in the `sync-image` Task trail.
- `virtual_machine_image.js`: "Sync Across Hosts" action for local images.
- spec/08-images.md subsection; unit tests (SSH steps + poll monkeypatched).

## Serve address
Defaults to the source host's **mesh** address (the private, WG-encrypted image bus). `atlas_fleet_serve_public` serves on the source's **public IPv4** instead — for an off-mesh controller / a fleet whose mesh is not the transport (the same escape hatch `atlas_boat_base_urls` is for boat).

## Caveats (documented)
- `_run_distribution` blocks a `long`-queue worker while polling, so **≥2 long workers** are needed (it enqueues the `sync-image` jobs on the same queue) — otherwise it deadlocks on a single-worker bench.
- Proven live on a 3-host DigitalOcean fleet: a chef-baked `pilot-chef` promoted on host-1 distributed to host-2 + host-3 (base LV present on all three; serve torn down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)