### PR TITLE
feat(central): sign outbound event webhooks with an HMAC signature

### DIFF
--- a/atlas/atlas/api/central_link.py
+++ b/atlas/atlas/api/central_link.py
@@ -101,11 +101,16 @@ def _store_provisioning(payload: dict, result: dict) -> None:
 	"""Write the pushed Central service-user creds + tunnel parameters into the Central
 	Settings single. url/api_key/api_secret now hold the per-Atlas Central service-user
 	creds (no longer hand-entered) — Central rotates them by re-provisioning, so we
-	overwrite them every time. The Password (api_secret) is encrypted on save."""
+	overwrite them every time. The Password (api_secret) is encrypted on save.
+
+	service_webhook_secret is optional, and absent means "unchanged": assigning None
+	would wipe it, since _save_passwords() clears Password fields reading empty."""
 	settings = frappe.get_single("Central Settings")
 	settings.url = payload["central_url"]
 	settings.api_key = payload["service_api_key"]
 	settings.api_secret = payload["service_api_secret"]
+	if payload.get("service_webhook_secret"):
+		settings.webhook_secret = payload["service_webhook_secret"]
 	settings.tunnel_ip = payload["tunnel_ip"]
 	settings.tunnel_cidr = payload["tunnel_cidr"]
 	settings.hub_public_key = payload["hub_public_key"]
@@ -124,6 +129,9 @@ def _store_local(payload: dict) -> None:
 	settings.url = payload["central_url"]
 	settings.api_key = payload["service_api_key"]
 	settings.api_secret = payload["service_api_secret"]
+	# Absent means "unchanged" — see _store_provisioning.
+	if payload.get("service_webhook_secret"):
+		settings.webhook_secret = payload["service_webhook_secret"]
 	settings.enabled = 1
 	settings.tunnel_status = "Inactive"
 	settings.save(ignore_permissions=True)

--- a/atlas/atlas/api/test_central_link.py
+++ b/atlas/atlas/api/test_central_link.py
@@ -26,6 +26,7 @@ PAYLOAD = {
 	"central_url": "https://central.example",
 	"service_api_key": "svc_key",
 	"service_api_secret": "svc_secret",
+	"service_webhook_secret": "whs_secret",
 }
 
 TUNNEL_UP_RESULT = {
@@ -67,6 +68,11 @@ def _make_plain_user() -> str:
 class IntegrationTestCentralLink(IntegrationTestCase):
 	def setUp(self) -> None:
 		self.addCleanup(frappe.set_user, "Administrator")
+		# webhook_secret is a Password field: db_set can't reliably clear it and residue
+		# survives rollback, so force a clean slate independent of run order.
+		from frappe.utils.password import remove_encrypted_password
+
+		remove_encrypted_password("Central Settings", "Central Settings", "webhook_secret")
 
 	# ----- provision_tunnel ------------------------------------------------
 
@@ -99,6 +105,22 @@ class IntegrationTestCentralLink(IntegrationTestCase):
 		self.assertEqual(settings.tunnel_status, "Provisioning")
 		# The pushed service-user secret is stored encrypted, readable back.
 		self.assertEqual(get_secret("Central Settings", "Central Settings", "api_secret"), "svc_secret")
+		# Same for the webhook signing secret.
+		self.assertEqual(get_secret("Central Settings", "Central Settings", "webhook_secret"), "whs_secret")
+
+	@patch.object(central_link, "run_local_task")
+	def test_provision_tunnel_without_webhook_secret_still_succeeds(self, run_local_task) -> None:
+		# An old Central that doesn't send service_webhook_secret yet (rollout
+		# window) must not break provisioning — the field stays optional.
+		run_local_task.side_effect = [_task(TUNNEL_UP_RESULT), _task()]
+		payload = {k: v for k, v in PAYLOAD.items() if k != "service_webhook_secret"}
+
+		out = central_link.provision_tunnel(**payload)
+
+		self.assertEqual(out["tunnel_ip"], "10.88.0.2")
+		self.assertFalse(
+			get_secret("Central Settings", "Central Settings", "webhook_secret", raise_exception=False)
+		)
 
 	@patch.object(central_link, "run_local_task")
 	def test_provision_tunnel_passes_keypath_and_tunnel_params(self, run_local_task) -> None:
@@ -135,11 +157,13 @@ class IntegrationTestCentralLink(IntegrationTestCase):
 			central_url="https://central.example",
 			service_api_key="svc_key",
 			service_api_secret="svc_secret",
+			service_webhook_secret="whs_secret",
 			skip_tunnel=1,
 		)
 
 		self.assertEqual(out, {"skip_tunnel": True, "tunnel_status": "Inactive"})
 		run_local_task.assert_not_called()
+		self.assertEqual(get_secret("Central Settings", "Central Settings", "webhook_secret"), "whs_secret")
 
 		settings = frappe.get_single("Central Settings")
 		self.assertEqual(settings.url, "https://central.example")

--- a/atlas/atlas/central.py
+++ b/atlas/atlas/central.py
@@ -13,10 +13,10 @@ via `provision_tunnel`. Atlas no longer calls
 `register`; it only reports outward:
 
 - **ping** — `central.api.atlas.ping` returns `{label}`; a credential + reachability
-  check for the Test Connection toast.
+  check for the Test Connection toast. Stays on the plain admin token.
 - **event** — `central.api.atlas.event` (via `post_event`) carries VM lifecycle
-  events, authenticated as the pushed per-Atlas service user. Atlas's outbound is
-  unrestricted, so this works regardless of the management-plane firewall.
+  events, signed with HMAC-SHA256 over `X-Atlas-Timestamp + raw body` keyed on the
+  per-region `webhook_secret`, and carrying no `Authorization` header at all.
 
 The route names and payloads are the single external dependency; the whole
 contract is absorbed here, so a change on Central's side is a one-file edit.
@@ -25,6 +25,9 @@ contract is absorbed here, so a change on Central's side is a one-file edit.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import hmac
+import json
 
 import frappe
 import requests
@@ -57,15 +60,23 @@ class CentralAuthResult:
 class CentralClient:
 	"""Talks to a single Central instance. Constructed from Central Settings."""
 
-	def __init__(self, url: str, api_key: str, api_secret: str, timeout: int = DEFAULT_TIMEOUT):
+	def __init__(
+		self,
+		url: str,
+		api_key: str,
+		api_secret: str,
+		webhook_secret: str | None = None,
+		timeout: int = DEFAULT_TIMEOUT,
+	):
 		self.url = url.rstrip("/")
 		self.api_key = api_key
 		self.api_secret = api_secret
+		self.webhook_secret = webhook_secret
 		self.timeout = timeout
 
 	def ping(self) -> CentralAuthResult:
-		"""Credential check. Never raises — returns ok=False so the Test
-		Connection toast can render a red indicator."""
+		"""Credential check. Never raises — returns ok=False for the Test Connection
+		toast. Plain token auth, out of scope for the webhook HMAC scheme."""
 		try:
 			body = self._request("GET", "ping")
 		except CentralError as exception:
@@ -73,17 +84,42 @@ class CentralClient:
 		return CentralAuthResult(ok=True, label=body.get("label"))
 
 	def post_event(self, event: dict) -> dict:
-		return self._request("POST", "event", json=event)
+		return self._request("POST", "event", json=event, sign=True)
 
-	def _request(self, method: str, route_key: str, json: dict | None = None) -> dict:
+	def _sign(self, headers: dict, json_payload: dict | None) -> bytes:
+		"""Sign the exact bytes sent, adding the X-Atlas-* headers in place. Returns the
+		body so the caller passes `data=`, not `json=` — requests' own serialization
+		isn't guaranteed byte-identical to what was signed."""
+		from atlas.atlas.placement import atlas_region
+
+		body_bytes = json.dumps(json_payload or {}).encode()
+		timestamp = frappe.utils.now()
+		signature = hmac.new(
+			self.webhook_secret.encode(), f"{timestamp}.".encode() + body_bytes, hashlib.sha256
+		).hexdigest()
+		headers["X-Atlas-Region"] = atlas_region()
+		headers["X-Atlas-Timestamp"] = timestamp
+		headers["X-Atlas-Signature"] = signature
+		return body_bytes
+
+	def _request(self, method: str, route_key: str, json: dict | None = None, sign: bool = False) -> dict:
 		url = f"{self.url}/api/method/{_ROUTES[route_key]}"
 		headers = {
-			"Authorization": f"token {self.api_key}:{self.api_secret}",
 			"Content-Type": "application/json",
 			"Accept": "application/json",
 		}
+		data = None
+		if sign:
+			if not self.webhook_secret:
+				raise CentralError(f"cannot sign {route_key}: no webhook_secret configured")
+			data = self._sign(headers, json_payload=json)
+			json = None
+		else:
+			headers["Authorization"] = f"token {self.api_key}:{self.api_secret}"
 		try:
-			response = requests.request(method, url, json=json, headers=headers, timeout=self.timeout)
+			response = requests.request(
+				method, url, json=json, data=data, headers=headers, timeout=self.timeout
+			)
 		except requests.RequestException as exception:
 			raise CentralError(f"{method} {route_key}: {exception}") from exception
 		if response.status_code >= 400:

--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -207,7 +207,11 @@ def retry_pending(limit: int = 50, include_legacy_pending: bool = False) -> int:
 
 def _delivery_ready() -> bool:
 	settings = frappe.get_single("Central Settings")
-	return bool(settings.enabled and settings.api_key)
+	return bool(
+		settings.enabled
+		and settings.api_key
+		and settings.get_password("webhook_secret", raise_exception=False)
+	)
 
 
 def _retry_limit(limit: int) -> int:
@@ -258,10 +262,9 @@ def deliver(log_name: str, event_type: str, payload: dict, occurred_at: str | No
 	settings = frappe.get_single("Central Settings")
 	if not settings.enabled:
 		return
-	if not settings.api_key:
-		# Enabled but not yet registered: without the scoped service-user creds we
-		# can't authenticate to Central (and the sender is resolved from that identity),
-		# so skip rather than POST unauthenticated. Register first.
+	if not (settings.api_key and settings.get_password("webhook_secret", raise_exception=False)):
+		# Rollout-safety gate: signing code deployed but not yet re-registered just
+		# skips (durable outbox, nothing lost) rather than POSTing unsigned.
 		_stamp(log_name, status="skipped")
 		settings.db_set("status", "skipped: register with Central first", commit=True)
 		return

--- a/atlas/atlas/doctype/central_settings/central_settings.json
+++ b/atlas/atlas/doctype/central_settings/central_settings.json
@@ -8,6 +8,7 @@
   "url",
   "api_key",
   "api_secret",
+  "webhook_secret",
   "column_break_connection",
   "enabled",
   "section_break_registration",
@@ -54,6 +55,12 @@
    "in_list_view": 1,
    "label": "API Secret",
    "reqd": 1
+  },
+  {
+   "description": "HMAC signing secret for Atlas's webhook auth to Central. Set by Central via provision_tunnel; rotated by re-provisioning (same event as api_key/api_secret). Optional so a fresh/not-yet-registered Atlas doesn't fail validation.",
+   "fieldname": "webhook_secret",
+   "fieldtype": "Password",
+   "label": "Webhook Secret"
   },
   {
    "fieldname": "column_break_connection",

--- a/atlas/atlas/doctype/central_settings/central_settings.py
+++ b/atlas/atlas/doctype/central_settings/central_settings.py
@@ -28,6 +28,7 @@ class CentralSettings(Document):
 		tunnel_status: DF.Literal["Inactive", "Provisioning", "Active", "Reverting"]
 		url: DF.Data
 		version_image_map: DF.JSON | None
+		webhook_secret: DF.Password | None
 		wg_listen_port: DF.Int
 		wg_public_key: DF.Data | None
 	# end: auto-generated types
@@ -52,4 +53,8 @@ class CentralSettings(Document):
 		if not self.url or not self.api_key:
 			frappe.throw(_("Set Central URL and API Key first"))
 		secret = get_secret("Central Settings", "Central Settings", "api_secret")
-		return CentralClient(self.url, self.api_key, secret)
+		# raise_exception=False: a fresh Atlas has none, and client() must still build.
+		webhook_secret = get_secret(
+			"Central Settings", "Central Settings", "webhook_secret", raise_exception=False
+		)
+		return CentralClient(self.url, self.api_key, secret, webhook_secret=webhook_secret)

--- a/atlas/atlas/doctype/central_settings/test_central_settings.py
+++ b/atlas/atlas/doctype/central_settings/test_central_settings.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -17,4 +17,20 @@ class IntegrationTestCentralSettings(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def _settings(self, webhook_secret=None):
+		settings = frappe.get_single("Central Settings")
+		settings.url = "https://central.example"
+		settings.api_key = "ak"
+		settings.api_secret = "as"
+		settings.webhook_secret = webhook_secret
+		settings.save(ignore_permissions=True)
+		return frappe.get_single("Central Settings")
+
+	def test_client_passes_webhook_secret_when_set(self) -> None:
+		settings = self._settings(webhook_secret="whs")
+		self.assertEqual(settings.client().webhook_secret, "whs")
+
+	def test_client_passes_none_when_webhook_secret_unset(self) -> None:
+		# A not-yet-rotated instance: client() must not crash decrypting an unset field.
+		settings = self._settings(webhook_secret=None)
+		self.assertIsNone(settings.client().webhook_secret)

--- a/atlas/atlas/secrets.py
+++ b/atlas/atlas/secrets.py
@@ -4,10 +4,10 @@ import frappe
 from frappe.utils.password import get_decrypted_password
 
 
-def get_secret(doctype: str, name: str, fieldname: str) -> str:
+def get_secret(doctype: str, name: str, fieldname: str, raise_exception: bool = True) -> str:
 	"""Read a Password-type field, decrypted. Single chokepoint so the
 	storage backend can be swapped later."""
-	return get_decrypted_password(doctype, name, fieldname, raise_exception=True)
+	return get_decrypted_password(doctype, name, fieldname, raise_exception=raise_exception)
 
 
 def get_ssh_key_from_disk(path: str) -> str:

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -31,9 +31,55 @@ def _response(status_code=200, body=None, content=True):
 	return resp
 
 
+# --- Golden vector: pinned wire contract, mirrored in Central's
+# central/tests/test_atlas_webhook_signature.py ---------------------------------
+# Nothing binds the two repos: a format change made on ONE side leaves both suites green
+# while every real delivery fails. Do not regenerate the digest to make a test pass.
+GOLDEN_SECRET = "atlas-golden-secret"
+GOLDEN_TIMESTAMP = "2026-06-18 10:00:00.000000"
+GOLDEN_PAYLOAD = {
+	"event_id": "evt-golden-1",
+	"type": "vm.created",
+	"payload": {"name": "vm-golden"},
+	"occurred_at": "2026-06-18 10:00:00",
+}
+GOLDEN_BODY = (
+	b'{"event_id": "evt-golden-1", "type": "vm.created", '
+	b'"payload": {"name": "vm-golden"}, "occurred_at": "2026-06-18 10:00:00"}'
+)
+GOLDEN_SIGNATURE = "918bd05acd9cb434d5e2b78bb7ebc977d6c8abefa979687d6575c375ea9370c5"
+
+
+class TestGoldenVector(IntegrationTestCase):
+	"""Pin the signer to the wire contract Central verifies against."""
+
+	def test_serialization_is_byte_stable(self) -> None:
+		# json.dumps' default separators and key order are part of the contract.
+		client = CentralClient("https://central.example/", "ak", "s", webhook_secret=GOLDEN_SECRET)
+		with patch("atlas.atlas.placement.atlas_region", return_value="blr"):
+			body = client._sign({}, json_payload=GOLDEN_PAYLOAD)
+		self.assertEqual(body, GOLDEN_BODY)
+
+	def test_signer_produces_the_golden_signature(self) -> None:
+		client = CentralClient("https://central.example/", "ak", "s", webhook_secret=GOLDEN_SECRET)
+		headers: dict = {}
+		with (
+			patch("atlas.atlas.central.frappe.utils.now", return_value=GOLDEN_TIMESTAMP),
+			patch("atlas.atlas.placement.atlas_region", return_value="blr"),
+		):
+			client._sign(headers, json_payload=GOLDEN_PAYLOAD)
+		self.assertEqual(headers["X-Atlas-Timestamp"], GOLDEN_TIMESTAMP)
+		self.assertEqual(headers["X-Atlas-Signature"], GOLDEN_SIGNATURE)
+
+
 class TestCentralClient(IntegrationTestCase):
 	def setUp(self) -> None:
 		self.client = CentralClient("https://central.example/", "ak", "secret")
+		self.signing_client = CentralClient("https://central.example/", "ak", "secret", webhook_secret="whs")
+		# atlas_region() throws when Atlas Settings.region is unset, true on a fresh site.
+		region = patch("atlas.atlas.placement.atlas_region", return_value="blr")
+		region.start()
+		self.addCleanup(region.stop)
 
 	def test_request_builds_url_and_auth_header(self) -> None:
 		with patch("atlas.atlas.central.requests.request") as request:
@@ -66,11 +112,65 @@ class TestCentralClient(IntegrationTestCase):
 		self.assertFalse(result.ok)
 		self.assertIn("down", result.error)
 
+	def test_ping_stays_unsigned(self) -> None:
+		# ping is plain token auth even on a client that HAS a webhook_secret.
+		with patch("atlas.atlas.central.requests.request") as request:
+			request.return_value = _response(body={"message": {"label": "Central"}})
+			self.signing_client.ping()
+		kwargs = request.call_args.kwargs
+		self.assertNotIn("X-Atlas-Signature", kwargs["headers"])
+		self.assertIn("Authorization", kwargs["headers"])
+		self.assertIsNone(kwargs.get("data"))
+
+	def test_post_event_sends_no_authorization_header(self) -> None:
+		# Frappe validates any Authorization header it sees, so sending the token would
+		# put a stale api_secret in the path of a correctly signed event.
+		with patch("atlas.atlas.central.requests.request") as request:
+			request.return_value = _response(body={})
+			self.signing_client.post_event({"type": "vm.created"})
+		self.assertNotIn("Authorization", request.call_args.kwargs["headers"])
+
 	def test_post_event_raises_on_error(self) -> None:
 		with patch("atlas.atlas.central.requests.request") as request:
 			request.return_value = _response(status_code=500, body={"exc": "boom"})
 			with self.assertRaises(CentralError):
+				self.signing_client.post_event({"type": "vm.created"})
+
+	def test_post_event_raises_without_webhook_secret(self) -> None:
+		# No webhook_secret — post_event must refuse before the network call.
+		with patch("atlas.atlas.central.requests.request") as request:
+			with self.assertRaises(CentralError):
 				self.client.post_event({"type": "vm.created"})
+		request.assert_not_called()
+
+	def test_post_event_sends_data_not_json_kwarg(self) -> None:
+		# Signed bytes and sent bytes must be the same object.
+		with patch("atlas.atlas.central.requests.request") as request:
+			request.return_value = _response(body={})
+			self.signing_client.post_event({"type": "vm.created"})
+		kwargs = request.call_args.kwargs
+		self.assertIsNone(kwargs["json"])
+		self.assertIsInstance(kwargs["data"], bytes)
+		self.assertEqual(json.loads(kwargs["data"]), {"type": "vm.created"})
+
+	def test_post_event_signs_with_hmac_headers(self) -> None:
+		import hashlib
+		import hmac
+
+		with (
+			patch("atlas.atlas.central.requests.request") as request,
+			patch("atlas.atlas.placement.atlas_region", return_value="blr"),
+		):
+			request.return_value = _response(body={})
+			self.signing_client.post_event({"type": "vm.created"})
+		headers = request.call_args.kwargs["headers"]
+		body = request.call_args.kwargs["data"]
+		self.assertEqual(headers["X-Atlas-Region"], "blr")
+		self.assertTrue(headers["X-Atlas-Timestamp"])
+		expected = hmac.new(
+			b"whs", f"{headers['X-Atlas-Timestamp']}.".encode() + body, hashlib.sha256
+		).hexdigest()
+		self.assertEqual(headers["X-Atlas-Signature"], expected)
 
 
 @contextlib.contextmanager
@@ -353,6 +453,20 @@ class TestCentralReport(IntegrationTestCase):
 		settings = MagicMock()
 		settings.enabled = 1
 		settings.api_key = None  # enabled but no service-user creds yet
+		with (
+			patch.object(central_report.frappe, "get_single", return_value=settings),
+			patch.object(central_report, "_stamp") as stamp,
+		):
+			central_report.deliver("cel-1", "vm.created", {"name": "vm-1"})
+		settings.client.assert_not_called()
+		stamp.assert_called_once_with("cel-1", status="skipped")
+
+	def test_deliver_skips_when_webhook_secret_missing(self) -> None:
+		# api_key set but webhook_secret not yet: skip rather than send unsigned.
+		settings = MagicMock()
+		settings.enabled = 1
+		settings.api_key = "svc_key"
+		settings.get_password.return_value = None
 		with (
 			patch.object(central_report.frappe, "get_single", return_value=settings),
 			patch.object(central_report, "_stamp") as stamp,

--- a/spec/16-central.md
+++ b/spec/16-central.md
@@ -89,16 +89,18 @@ the fleet state the commands above produce.
 
 - **Central Settings** (single) — the credentials and this Atlas's tunnel identity.
   Mirrors `DigitalOcean Settings`. Fields: `url`, `api_key`, `api_secret` (Password),
-  `enabled` (master switch — event reporting is skipped when off), and a read-only
+  `webhook_secret` (Password, optional) — the HMAC signing secret for outbound
+  `event` webhooks, see *The wire contract* below — `enabled` (master switch —
+  event reporting is skipped when off), and a read-only
   `status` breadcrumb (the last register / event-delivery
   outcome — a glance-only convenience; the event *history* belongs to the planned
   `Central Event` log, not the Single). The region is read from `Atlas Settings.region`
   (`placement.atlas_region()`), not a Central Settings field. **Plus a Tunnel section**
   (`tunnel_ip`, `tunnel_cidr`, `hub_public_key`, `hub_endpoint`, `wg_public_key`,
-  `wg_listen_port`, `tunnel_status`); `url` / `api_key` / `api_secret` now hold the
-  **pushed per-Atlas Central service-user** creds — all written by Central's
-  `provision_tunnel`, no longer hand-entered (registration is **Central-initiated**;
-  see [21-tunnel.md](./21-tunnel.md)).
+  `wg_listen_port`, `tunnel_status`); `url` / `api_key` / `api_secret` /
+  `webhook_secret` now hold the **pushed per-Atlas Central service-user** creds —
+  all written by Central's `provision_tunnel`, no longer hand-entered (registration
+  is **Central-initiated**; see [21-tunnel.md](./21-tunnel.md)).
 
 Atlas keeps **no local catalog of Central's sizes or expected images**: Central
 sends a VM's resource values and `image` per provision call (`create_vm`), so
@@ -174,6 +176,30 @@ the `Central Event Log` row's own name — the emit's stable delivery identity, 
 a separate id Atlas has to mint. A `retry_pending` redelivery of the same row
 sends the same `event_id`, so Central can use it to dedup a resend from a
 genuinely new event.
+
+**`event` is HMAC-signed, not token-authenticated.** `ping` stays on the plain
+`Authorization` token above, but `post_event` authenticates with three headers
+instead — `X-Atlas-Region` (this Atlas's `Atlas Settings.region`, selecting which
+`webhook_secret` Central checks), `X-Atlas-Timestamp` (unix seconds), and
+`X-Atlas-Signature` — an `HMAC-SHA256(webhook_secret, "<timestamp>." + raw_body)`
+hex digest, computed over the exact bytes sent (`CentralClient` signs then sends
+`data=`, never `json=`, since `requests`' own JSON serialization isn't guaranteed
+byte-identical to what was signed). A signed request carries **no `Authorization`
+header at all**: Frappe authenticates any token it is given regardless of
+`allow_guest`, so sending one would put a stale `api_secret` back in the path of a
+correctly signed event — the signature is the whole authentication. Central rejects
+a request whose signature doesn't `hmac.compare_digest`-match — the header only
+*selects* the secret to check, it is never trusted on its own. A replayed request is
+caught by the unique `event_id`, not by a timestamp window. `webhook_secret` is
+optional on `Central Settings` specifically so a build with the signing code
+deployed but not yet re-registered skips delivery (durable outbox) instead of
+sending an unsigned request Central would reject anyway.
+
+Central stores the raw signed bytes and the signature on its `Atlas Event` row, so
+the stored row stays **re-verifiable**: the HMAC can be recomputed over the exact
+bytes long after the request is gone (`AtlasEvent.verify_signature`). The parsed
+payload is not a substitute — reserialized JSON is not byte-identical, so a
+signature never verifies against it.
 
 `register` is gone (registration is Central-initiated). **Central → Atlas
 (inbound)** now travels over the tunnel (`tunnel_url`) authenticated as the **Atlas


### PR DESCRIPTION
ref: frappe/central#199
Atlas now signs every event it sends to Central with a secret handed to it during registration. Holds events in the queue rather than sending unsigned ones while a region is still being set up, picks up the new secret automatically on re-registration, and locks the message in before signing so what gets signed and what gets delivered can't drift apart.
Pairs with frappe/central#278.