### PR TITLE
feat(bootstrap): run_self_serve(bake=False) for an external golden

### DIFF
--- a/atlas/bootstrap.py
+++ b/atlas/bootstrap.py
@@ -253,7 +253,7 @@ def run_with_proxy() -> None:
 	issue_certificate(tls_config["domain"])
 
 
-def run_self_serve(force_bake: bool = False) -> None:
+def run_self_serve(force_bake: bool = False, bake: bool = True) -> None:
 	"""From-scratch one-shot: stand up the ENTIRE signup flow and leave it running.
 
 	The durable sibling of the `self_serve_site` e2e (it drives the same proven
@@ -265,6 +265,13 @@ def run_self_serve(force_bake: bool = False) -> None:
 	`force_bake=True` re-bakes the golden image even if an Available one is already
 	configured (proves the from-scratch `build.sh` bake); the default reuses a
 	configured Available snapshot and skips the slow bake.
+
+	`bake=False` skips the built-in golden bake entirely — for the flow where an
+	EXTERNAL image service (chef) already baked the pilot golden and wired
+	`default_bench_snapshot` (via `service.register_bench_snapshot`). It then only
+	asserts that golden is registered + Available (fail loud before building the
+	proxy/cert on top of a signup path that can't clone anything), rather than
+	baking with the in-Atlas `bench_image` builder chef is replacing.
 
 	Billable, leaves infra up. Requires the TLS config keys + certbot/boto3 (it
 	throws via `_read_tls_config` / the bake / the cert if a prerequisite is
@@ -284,8 +291,15 @@ def run_self_serve(force_bake: bool = False) -> None:
 	server_name = run_compute()
 
 	# 2. Golden bench image — the snapshot site VMs clone from. Wires
-	#    Atlas Settings.default_bench_snapshot.
-	bake_golden_image(server_name, force=force_bake)
+	#    Atlas Settings.default_bench_snapshot. Skipped when an external image service
+	#    (chef) already baked + registered the golden — then just assert it is usable.
+	if bake:
+		bake_golden_image(server_name, force=force_bake)
+	else:
+		from atlas.atlas import placement
+
+		snapshot = placement.default_bench_snapshot()  # throws unless set + Available
+		print(f"[bootstrap] bake=False — using externally-registered golden snapshot {snapshot}")
 
 	# 3. TLS layer rows (Root Domain etc.) BEFORE the proxy: Site.before_insert and
 	#    build_proxy/cert-push all read the region off the Root Domain.


### PR DESCRIPTION
## Why

`run_self_serve` bakes the golden with the in-Atlas `bench_image` builder (`bake_golden_image` → step 2). When an external image service (**chef**) already bakes the pilot golden and registers it via `service.register_bench_snapshot` (frappe/atlas#156 + frappe/chef#9), that built-in bake is redundant — and it's exactly the `bench_image`/`image_recipes` path spec/30 moves out to the service.

## What

`run_self_serve(bake=False)` skips the built-in bake and instead asserts the externally-registered golden is present + Available (`placement.default_bench_snapshot()` throws otherwise) — failing loud *before* building the proxy VM + wildcard cert on top of a signup path that has nothing to clone. Default (`bake=True`) is unchanged.

## Test

Compiles; the `bake=False` branch is a guard + assert over the existing `placement.default_bench_snapshot()`. No change to the default path.