### PR TITLE
fix(deploy-site): drive the golden CLI as pilot (post rename)

### DIFF
--- a/bench/deploy-site.py
+++ b/bench/deploy-site.py
@@ -72,7 +72,19 @@ BENCH_HOME = f"/home/{BENCH_USER}"
 BENCH_CLI_DIR = f"{BENCH_HOME}/pilot"
 BENCH_NAME = "atlas"
 BENCH_DIR = f"{BENCH_CLI_DIR}/benches/{BENCH_NAME}"
-BENCH = f"{BENCH_CLI_DIR}/bench"
+
+
+def _resolve_bench_cli() -> str:
+	"""The baked CLI executable. frappe/bench-cli was renamed frappe/pilot: the tool is
+	now `pilot` at `bin/pilot`, not a top-level `bench` (the rename moved the executable,
+	not just the ~/bench-cli → ~/pilot directory). Prefer it; fall back to a legacy
+	top-level `bench` for older goldens. Both take `<cli> -b <bench> <cmd>` identically,
+	so every `_bench(...)` call below is unchanged."""
+	pilot = f"{BENCH_CLI_DIR}/bin/pilot"
+	return pilot if os.path.exists(pilot) else f"{BENCH_CLI_DIR}/bench"
+
+
+BENCH = _resolve_bench_cli()
 # The bench DB's UNIX socket — the readiness contract `_await_db_ready` probes, and
 # what the baked site_config.json's `db_socket` points at. pilot v0.0.9 runs MariaDB
 # as a user-owned `pilot-mariadb.service` with its datadir + socket under the pilot
@@ -307,7 +319,10 @@ def _preflight() -> None:
 	The site-vs-admin baked-content check is mode-specific and lives in the rename
 	path (`_rename_site_to_fqdn`) / admin path, not here."""
 	if not os.path.exists(BENCH):
-		sys.exit(f"bench-cli not found at {BENCH}; this VM was not baked from the golden image")
+		sys.exit(
+			f"pilot CLI not found at {BENCH_CLI_DIR}/bin/pilot or {BENCH_CLI_DIR}/bench; "
+			"this VM was not baked from the golden image"
+		)
 	if not os.path.isdir(BENCH_DIR):
 		sys.exit(f"baked bench {BENCH_DIR} missing; this VM was not baked from the golden image")
 


### PR DESCRIPTION
## Why

`frappe/bench-cli` was renamed **`frappe/pilot`**, and the rename moved the *executable* too — it's now `pilot` at `~/pilot/bin/pilot`, not a top-level `~/pilot/bench`. Atlas's in-guest `deploy-site.py` already tracked the `~/bench-cli → ~/pilot` **directory** rename but still hard-required the `~/pilot/bench` executable, so a self-serve **Site** deploy onto a modern (chef-baked) pilot golden failed at the pre-flight:

```
bench-cli not found at /home/frappe/pilot/bench; this VM was not baked from the golden image
```

## What

Resolve the CLI to `bin/pilot` when present, falling back to a legacy top-level `bench` for older goldens. Both accept `<cli> -b <bench> <cmd>` identically, so every `_bench(...)` call (rename-site / setup production / `frappe browse`) is unchanged. Keeps deploy-site's "runs on goldens of either vintage" property true across the executable rename.

Complements frappe/chef#10 (which has the golden also expose a `bench→bin/pilot` symlink) — together, a Site deploys onto a pilot golden whether the Atlas side or the golden side carries the compat.

## Test

The existing `test_deploy_site.py` mocks `_bench`, not the path; on a non-golden machine `BENCH` resolves to the same legacy value as before. Verified live: with `bin/pilot`, `rename-site` / `frappe browse` / `setup production` all resolve on a cloned golden guest.