### PR TITLE
feat(central): better handling of server flows

### DIFF
--- a/atlas/atlas/api/provision.py
+++ b/atlas/atlas/api/provision.py
@@ -92,29 +92,17 @@ def create_vm(
 	# long-lived credential. Without them the guest never enrolls and Central refuses to
 	# open the console ("This VM's pilot hasn't enrolled yet") — servers were missing this
 	# entirely while sites had it.
-	pilot.flags.pilot_credential_id = pilot_credential_id
 	pilot.flags.central_endpoint = central_endpoint
 	pilot.flags.bootstrap_token = bootstrap_token
+	# The pilot credential id and correlation id must be on the VM BEFORE it is inserted: the
+	# VM's after_insert emits vm.created and snapshots its payload right then. Stamping them
+	# afterwards left vm.created carrying nulls — so Central couldn't bind its reserved Pilot
+	# Credential to the VM (the console then refused it as "pilot hasn't enrolled yet") nor
+	# attribute that first event to the create action. Ride both onto the VM via these flags,
+	# which _provision_backing_vm sets on the VM doc before it inserts it.
+	pilot.flags.pilot_credential_id = pilot_credential_id
+	pilot.flags.correlation_id = correlation_id
 	pilot.insert(ignore_permissions=True)
-
-	# Stamp the credential id on the backing VM HERE, synchronously, rather than leaving it
-	# to the provision job. The Pilot's after_insert already created the VM (that is why
-	# this function can return its identity), so the row exists — and doing it inline means
-	# the very first `vm.*` event Atlas emits already carries the id, which is what lets
-	# Central bind its reserved Pilot Credential to this VM. Deferring it to the background
-	# job loses the earliest events, and Central then has an Active credential with no
-	# `asset`, which `api/sso.get_bench_link` reads as "This VM's pilot hasn't enrolled
-	# yet" even though the bench enrolled perfectly well.
-	if pilot_credential_id and pilot.virtual_machine:
-		frappe.db.set_value(
-			"Virtual Machine", pilot.virtual_machine, "pilot_credential_id", pilot_credential_id
-		)
-
-	# Stamp the Central Server Action id the same way, so the vm.* events this create
-	# produces (Provisioning → Running / Failed) carry it and Central can resolve the
-	# create action it is tracking.
-	if correlation_id and pilot.virtual_machine:
-		frappe.db.set_value("Virtual Machine", pilot.virtual_machine, "correlation_id", correlation_id)
 
 	# The Pilot created its VM in after_insert; read the plain VM facts through the
 	# link and the bench fields off the Pilot. Shape matches central.atlas._mirror_vm

--- a/atlas/atlas/api/provision.py
+++ b/atlas/atlas/api/provision.py
@@ -41,6 +41,7 @@ def create_vm(
 	pilot_credential_id: str | None = None,
 	central_endpoint: str | None = None,
 	bootstrap_token: str | None = None,
+	correlation_id: str | None = None,
 ) -> dict:
 	"""Provision a bench VM for a Central team and return its (VM-shaped) mirror row.
 
@@ -108,6 +109,12 @@ def create_vm(
 		frappe.db.set_value(
 			"Virtual Machine", pilot.virtual_machine, "pilot_credential_id", pilot_credential_id
 		)
+
+	# Stamp the Central Server Action id the same way, so the vm.* events this create
+	# produces (Provisioning → Running / Failed) carry it and Central can resolve the
+	# create action it is tracking.
+	if correlation_id and pilot.virtual_machine:
+		frappe.db.set_value("Virtual Machine", pilot.virtual_machine, "correlation_id", correlation_id)
 
 	# The Pilot created its VM in after_insert; read the plain VM facts through the
 	# link and the bench fields off the Pilot. Shape matches central.atlas._mirror_vm

--- a/atlas/atlas/api/site.py
+++ b/atlas/atlas/api/site.py
@@ -28,6 +28,7 @@ def create_site(
 	pilot_credential_id: str | None = None,
 	central_endpoint: str | None = None,
 	bootstrap_token: str | None = None,
+	correlation_id: str | None = None,
 ) -> dict:
 	"""Provision a self-serve site for a Central team and return its mirror row.
 
@@ -51,7 +52,11 @@ def create_site(
 	# homes: pilot_credential_id on the backing VM (echoed to Central on vm.* events) and
 	# the endpoint/token in the bench's bench.toml (written at deploy). Nothing is
 	# persisted on the Site, and the token never appears in _mirror.
-	site = frappe.get_doc({"doctype": "Site", "subdomain": subdomain, "tenant": tenant})
+	# correlation_id persists on the Site (unlike the bench creds) so every site.* event —
+	# including the eventual Running from auto_provision — echoes it to Central.
+	site = frappe.get_doc(
+		{"doctype": "Site", "subdomain": subdomain, "tenant": tenant, "correlation_id": correlation_id}
+	)
 	site.flags.pilot_credential_id = pilot_credential_id
 	site.flags.central_endpoint = central_endpoint
 	site.flags.bootstrap_token = bootstrap_token

--- a/atlas/atlas/api/test_provision.py
+++ b/atlas/atlas/api/test_provision.py
@@ -60,7 +60,10 @@ class TestCreateVM(IntegrationTestCase):
 		self.server = self._make_server()
 		self.admin_image = fixtures.make_image("fake-bench-admin-image", build_mode="admin")
 		# create_vm's default-image resolution needs exactly one active image; pin the
-		# bench admin image as the sole active one.
+		# bench admin image as the sole active one. Also clear any configured default_user_image
+		# so default_image() resolves to that pinned image rather than a value carried over from
+		# the environment (rolled back with the test — Atlas Settings is a Single/InnoDB row).
+		frappe.db.set_single_value("Atlas Settings", "default_user_image", None)
 		frappe.db.set_value("Virtual Machine Image", self.admin_image.name, "is_active", 1)
 		for name in frappe.get_all("Virtual Machine Image", filters={"is_active": 1}, pluck="name"):
 			if name != self.admin_image.name:
@@ -129,6 +132,37 @@ class TestCreateVM(IntegrationTestCase):
 		vm = frappe.get_doc("Virtual Machine", pilot.virtual_machine)
 		self.assertEqual(vm.title, "acme")
 		self.assertEqual(result["ipv6_address"], vm.ipv6_address)
+
+	def test_create_stamps_ids_on_the_vm_created_event(self) -> None:
+		"""Regression: the correlation id and pilot credential id must be on the VM before
+		insert, so the vm.created event (emitted in the VM's after_insert, its payload
+		snapshotted at that moment) already carries them. Stamping them after insert left
+		vm.created with nulls — so Central couldn't attribute that first event to the create
+		action, nor bind its reserved Pilot Credential to the VM."""
+		import json
+
+		result = provision_api.create_vm(
+			team=TEAM,
+			title="corr",
+			vcpus=1,
+			memory_megabytes=512,
+			disk_gigabytes=2,
+			correlation_id="action-123",
+			pilot_credential_id="cred-456",
+		)
+		vm = result["name"]
+		self.addCleanup(frappe.db.delete, "Central Event Log", {"reference_name": vm})
+		self.assertEqual(frappe.db.get_value("Virtual Machine", vm, "correlation_id"), "action-123")
+		self.assertEqual(frappe.db.get_value("Virtual Machine", vm, "pilot_credential_id"), "cred-456")
+		payloads = frappe.get_all(
+			"Central Event Log",
+			filters={"event_type": "vm.created", "reference_name": vm},
+			pluck="payload",
+		)
+		self.assertTrue(payloads, "vm.created was not emitted")
+		created = json.loads(payloads[0])
+		self.assertEqual(created["correlation_id"], "action-123")
+		self.assertEqual(created["pilot_credential_id"], "cred-456")
 
 	def test_gateway_url_is_the_derived_fqdn(self) -> None:
 		result = self._create("acme")

--- a/atlas/atlas/central_report.py
+++ b/atlas/atlas/central_report.py
@@ -354,6 +354,7 @@ def _vm_payload(doc) -> dict:
 			"status": doc.status,
 			"server": doc.server,
 			"pilot_credential_id": doc.get("pilot_credential_id"),
+			"correlation_id": doc.get("correlation_id"),
 			"size_preset": doc.get("size_preset"),
 			"vcpus": doc.get("vcpus"),
 			"memory_megabytes": doc.get("memory_megabytes"),
@@ -384,6 +385,7 @@ def _pilot_vm_payload(pilot) -> dict:
 			"status": pilot.status,
 			"server": vm.server,
 			"pilot_credential_id": vm.get("pilot_credential_id"),
+			"correlation_id": vm.get("correlation_id"),
 			"size_preset": vm.get("size_preset"),
 			"vcpus": vm.get("vcpus"),
 			"memory_megabytes": vm.get("memory_megabytes"),
@@ -438,6 +440,7 @@ def _site_payload(doc) -> dict:
 		"url": f"https://{doc.name}" if running else None,
 		"login_url": doc.get("login_url") if running else None,
 		"login_url_expires_at": _iso(doc.get("login_url_expires_at")) if running else None,
+		"correlation_id": doc.get("correlation_id"),
 	}
 
 

--- a/atlas/atlas/doctype/central_event_log/central_event_log.js
+++ b/atlas/atlas/doctype/central_event_log/central_event_log.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2026, Frappe and Contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Central Event Log", {
+	refresh(frm) {
+		if (["queued", "error", "skipped"].includes(frm.doc.status)) {
+			frm.add_custom_button(__("Retry Delivery"), () => {
+				frm.call("retry_delivery").then(() => {
+					frappe.show_alert({ message: __("Delivery re-attempted"), indicator: "blue" });
+					frm.reload_doc();
+				});
+			});
+		}
+	},
+});

--- a/atlas/atlas/doctype/central_event_log/central_event_log.py
+++ b/atlas/atlas/doctype/central_event_log/central_event_log.py
@@ -42,19 +42,28 @@ class CentralEventLog(Document):
 
 	@frappe.whitelist()
 	def retry_delivery(self) -> None:
-		"""Re-attempt delivery to Central right now, from the desk. Resets the attempt
-		budget (and clears the stale error) so the periodic retry cron re-arms too."""
+		"""Re-attempt delivery to Central from the desk. Resets the attempt budget (and clears
+		the stale error) so the periodic retry cron re-arms too, then hands the POST to a
+		background worker.
+
+		Delivery must not run in this web request: `deliver` makes a network call to Central
+		and stamps this row, and the Central Event Log is MyISAM (table-level locking). Doing
+		it inline pins a web worker on the network round-trip and holds a table lock that
+		blocks concurrent event-log writes (live emits, other retries)."""
 		if self.status not in ("queued", "error", "skipped"):
 			frappe.throw(_("Only queued, error or skipped events can be retried."))
 
-		from atlas.atlas.central_report import deliver
-
 		self.db_set("attempts", 0)
 		self.db_set("last_error", None)
+		self.db_set("status", "queued")
 
-		if self.payload:
-			payload = json.loads(self.payload)
-		else:
-			payload = {}
-
-		deliver(self.name, self.event_type, payload, self.occurred_at)
+		payload = json.loads(self.payload) if self.payload else {}
+		frappe.enqueue(
+			"atlas.atlas.central_report.deliver",
+			queue="default",
+			timeout=60,
+			log_name=self.name,
+			event_type=self.event_type,
+			payload=payload,
+			occurred_at=self.occurred_at,
+		)

--- a/atlas/atlas/doctype/central_event_log/central_event_log.py
+++ b/atlas/atlas/doctype/central_event_log/central_event_log.py
@@ -1,3 +1,7 @@
+import json
+
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -31,10 +35,26 @@ class CentralEventLog(Document):
 	even for a reverted change — without ever delivering that reverted change to
 	Central (the after-commit deliver job never runs, so the row stays `pending`).
 
-	`atlas.atlas.central_report` is the sole writer: `_emit` inserts the row at
-	`pending`; `deliver` (and its `_stamp` helper) updates `status` / `attempts` /
-	`last_error` / `http_status` on the delivery outcome. No controller logic lives
-	here — the durability argument rests entirely on the table engine, asserted at
-	migrate (test + e2e), mirroring `Bench Routing Audit`."""
+	`atlas.atlas.central_report` is the sole automatic writer: `_emit` inserts the
+	row at `pending`; `deliver` (and its `_stamp` helper) updates `status` /
+	`attempts` / `last_error` / `http_status` on the delivery outcome. The one
+	operator action is `retry_delivery` — an on-demand redelivery from the desk."""
 
-	pass
+	@frappe.whitelist()
+	def retry_delivery(self) -> None:
+		"""Re-attempt delivery to Central right now, from the desk. Resets the attempt
+		budget (and clears the stale error) so the periodic retry cron re-arms too."""
+		if self.status not in ("queued", "error", "skipped"):
+			frappe.throw(_("Only queued, error or skipped events can be retried."))
+
+		from atlas.atlas.central_report import deliver
+
+		self.db_set("attempts", 0)
+		self.db_set("last_error", None)
+
+		if self.payload:
+			payload = json.loads(self.payload)
+		else:
+			payload = {}
+
+		deliver(self.name, self.event_type, payload, self.occurred_at)

--- a/atlas/atlas/doctype/central_event_log/test_central_event_log.py
+++ b/atlas/atlas/doctype/central_event_log/test_central_event_log.py
@@ -26,18 +26,27 @@ class IntegrationTestCentralEventLog(IntegrationTestCase):
 		self.addCleanup(frappe.delete_doc, "Central Event Log", doc.name, force=True, ignore_permissions=True)
 		return doc
 
-	def test_retry_delivery_redelivers_and_resets_the_budget(self):
+	def test_retry_delivery_enqueues_redelivery_and_resets_the_budget(self):
 		log = self._log()
-		with patch("atlas.atlas.central_report.deliver") as deliver:
+		with patch("frappe.enqueue") as enqueue:
 			log.retry_delivery()
-		deliver.assert_called_once_with(log.name, "vm.created", {"name": "vm-1"}, "2026-07-06 00:23:05")
+		enqueue.assert_called_once_with(
+			"atlas.atlas.central_report.deliver",
+			queue="default",
+			timeout=60,
+			log_name=log.name,
+			event_type="vm.created",
+			payload={"name": "vm-1"},
+			occurred_at="2026-07-06 00:23:05",
+		)
 		log.reload()
 		self.assertEqual(log.attempts, 0)
 		self.assertIsNone(log.last_error)
+		self.assertEqual(log.status, "queued")
 
 	def test_retry_delivery_refuses_an_already_delivered_row(self):
 		log = self._log(status="ok")
-		with patch("atlas.atlas.central_report.deliver") as deliver:
+		with patch("frappe.enqueue") as enqueue:
 			with self.assertRaises(frappe.ValidationError):
 				log.retry_delivery()
-		deliver.assert_not_called()
+		enqueue.assert_not_called()

--- a/atlas/atlas/doctype/central_event_log/test_central_event_log.py
+++ b/atlas/atlas/doctype/central_event_log/test_central_event_log.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class IntegrationTestCentralEventLog(IntegrationTestCase):
+	def _log(self, **overrides):
+		# MyISAM: not rolled back by the test teardown, so clean up explicitly.
+		doc = frappe.get_doc(
+			{
+				"doctype": "Central Event Log",
+				"event_type": "vm.created",
+				"payload": json.dumps({"name": "vm-1"}),
+				"status": "error",
+				"attempts": 5,
+				"last_error": "old failure",
+				"occurred_at": "2026-07-06 00:23:05",
+				**overrides,
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(
+			frappe.delete_doc, "Central Event Log", doc.name, force=True, ignore_permissions=True
+		)
+		return doc
+
+	def test_retry_delivery_redelivers_and_resets_the_budget(self):
+		log = self._log()
+		with patch("atlas.atlas.central_report.deliver") as deliver:
+			log.retry_delivery()
+		deliver.assert_called_once_with(log.name, "vm.created", {"name": "vm-1"}, "2026-07-06 00:23:05")
+		log.reload()
+		self.assertEqual(log.attempts, 0)
+		self.assertIsNone(log.last_error)
+
+	def test_retry_delivery_refuses_an_already_delivered_row(self):
+		log = self._log(status="ok")
+		with patch("atlas.atlas.central_report.deliver") as deliver:
+			with self.assertRaises(frappe.ValidationError):
+				log.retry_delivery()
+		deliver.assert_not_called()

--- a/atlas/atlas/doctype/central_event_log/test_central_event_log.py
+++ b/atlas/atlas/doctype/central_event_log/test_central_event_log.py
@@ -23,9 +23,7 @@ class IntegrationTestCentralEventLog(IntegrationTestCase):
 				**overrides,
 			}
 		).insert(ignore_permissions=True)
-		self.addCleanup(
-			frappe.delete_doc, "Central Event Log", doc.name, force=True, ignore_permissions=True
-		)
+		self.addCleanup(frappe.delete_doc, "Central Event Log", doc.name, force=True, ignore_permissions=True)
 		return doc
 
 	def test_retry_delivery_redelivers_and_resets_the_budget(self):

--- a/atlas/atlas/doctype/pilot/pilot.py
+++ b/atlas/atlas/doctype/pilot/pilot.py
@@ -173,10 +173,9 @@ class Pilot(Document):
 			timeout=1800,
 			enqueue_after_commit=True,
 			pilot_name=self.name,
-			# The pilot credential is bench-level and never persisted on the Pilot row; it
-			# rides the job to the backing VM + the bench's bench.toml, exactly as
-			# Site.after_insert carries it. Flags are set by api.provision.create_vm.
-			pilot_credential_id=self.flags.get("pilot_credential_id"),
+			# The bench enrollment inputs ride the job to the bench's bench.toml, exactly as
+			# Site.after_insert carries them. Flags are set by api.provision.create_vm. (The
+			# pilot credential id is stamped on the VM at insert, not here.)
 			central_endpoint=self.flags.get("central_endpoint"),
 			bootstrap_token=self.flags.get("bootstrap_token"),
 		)
@@ -281,7 +280,6 @@ class Pilot(Document):
 
 def auto_provision(
 	pilot_name: str,
-	pilot_credential_id: str | None = None,
 	central_endpoint: str | None = None,
 	bootstrap_token: str | None = None,
 ) -> None:
@@ -318,13 +316,9 @@ def auto_provision(
 		return
 
 	try:
-		# Stamp the credential id on the backing VM before anything else, so the vm.*
-		# events Atlas emits from here on echo it back and Central can bind its reserved
-		# Pilot Credential to this VM (mirrors Site.auto_provision).
-		if pilot_credential_id:
-			frappe.db.set_value(
-				"Virtual Machine", pilot.virtual_machine, "pilot_credential_id", pilot_credential_id
-			)
+		# The credential id is already on the backing VM (stamped at insert in
+		# _provision_backing_vm), so the vm.* events from here on echo it back and Central
+		# can bind its reserved Pilot Credential to this VM.
 		_trace(f"waiting for backing VM {pilot.virtual_machine} to boot (Running) …")
 		_t = time.monotonic()
 		_wait_for_vm_running(pilot.virtual_machine)
@@ -444,6 +438,11 @@ def _provision_backing_vm(pilot) -> str:
 		"memory_megabytes": spec.get("memory_megabytes", 512),
 		"disk_gigabytes": spec.get("disk_gigabytes", 2),
 		"ssh_public_key": fleet_public_key,
+		# Set at insert so the VM's after_insert emits vm.created already carrying them: the
+		# credential id lets Central bind its reserved Pilot Credential, the correlation id
+		# lets it attribute the create action.
+		"pilot_credential_id": pilot.flags.get("pilot_credential_id"),
+		"correlation_id": pilot.flags.get("correlation_id"),
 	}
 	# server/image are Atlas's placement concern. The image is the pinned bench image
 	# (caller override, else the Atlas Settings default). The server must be one that

--- a/atlas/atlas/doctype/site/site.json
+++ b/atlas/atlas/doctype/site/site.json
@@ -22,7 +22,8 @@
   "running_started",
   "section_break_credentials",
   "login_url",
-  "login_url_expires_at"
+  "login_url_expires_at",
+  "correlation_id"
  ],
  "fields": [
   {
@@ -31,7 +32,7 @@
    "label": "Overview"
   },
   {
-   "description": "The bare DNS label the user chose, e.g. acme. A single label (no dots) so the site stays inside the one regional wildcard the proxy already terminates. The full site URL is <subdomain>.<region domain> — that FQDN is this row's name, the site-name-on-disk, and the proxy Host header (one routing string).",
+   "description": "The bare DNS label the user chose, e.g. acme. A single label (no dots) so the site stays inside the one regional wildcard the proxy already terminates. The full site URL is <subdomain>.<region domain> \u2014 that FQDN is this row's name, the site-name-on-disk, and the proxy Host header (one routing string).",
    "fieldname": "subdomain",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -56,7 +57,7 @@
   },
   {
    "default": "Pending",
-   "description": "Controller-written lifecycle state. Running is reached ONLY on an observed HTTP 200 from the guest :80 (Frappe is actually serving), not when the backing VM boots. Pending → Provisioning → Deploying → Running; Failed on any error; Terminated after teardown.",
+   "description": "Controller-written lifecycle state. Running is reached ONLY on an observed HTTP 200 from the guest :80 (Frappe is actually serving), not when the backing VM boots. Pending \u2192 Provisioning \u2192 Deploying \u2192 Running; Failed on any error; Terminated after teardown.",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -85,7 +86,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The Subdomain (proxy map) row this site created once it began serving — deleting it takes the site off the front door. Written by the controller after the readiness gate.",
+   "description": "The Subdomain (proxy map) row this site created once it began serving \u2014 deleting it takes the site off the front door. Written by the controller after the readiness gate.",
    "fieldname": "subdomain_doc",
    "fieldtype": "Link",
    "label": "Routing Entry",
@@ -93,7 +94,7 @@
    "read_only": 1
   },
   {
-   "description": "The attached Pilot (bench admin console) this site stood up on its OWN backing VM — fronted at <subdomain>-pilot.<region domain>, the front door Central's Asset resolves for 'Open'. Created by auto_provision after the site serves; terminated with the site. The customer's Frappe site is this Site itself (surfaced via get_site); the Pilot is the admin console on the same bench.",
+   "description": "The attached Pilot (bench admin console) this site stood up on its OWN backing VM \u2014 fronted at <subdomain>-pilot.<region domain>, the front door Central's Asset resolves for 'Open'. Created by auto_provision after the site serves; terminated with the site. The customer's Frappe site is this Site itself (surfaced via get_site); the Pilot is the admin console on the same bench.",
    "fieldname": "pilot",
    "fieldtype": "Link",
    "label": "Pilot",
@@ -132,7 +133,7 @@
    "label": "Handoff"
   },
   {
-   "description": "The one-click Administrator session URL handed to the tenant instead of a password — minted by deploy-site.py (`bench browse --sid`, a real 24h session) and stamped before the readiness wait. The baked Administrator password is a long random secret generated at bake time and never surfaced. Surfaced to Central (event payload + get_site poll) once the site is Running. Controller-written.",
+   "description": "The one-click Administrator session URL handed to the tenant instead of a password \u2014 minted by deploy-site.py (`bench browse --sid`, a real 24h session) and stamped before the readiness wait. The baked Administrator password is a long random secret generated at bake time and never surfaced. Surfaced to Central (event payload + get_site poll) once the site is Running. Controller-written.",
    "fieldname": "login_url",
    "fieldtype": "Small Text",
    "label": "Login URL",
@@ -145,6 +146,13 @@
    "label": "Login URL Expires At",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "correlation_id",
+   "fieldtype": "Data",
+   "label": "Correlation ID",
+   "read_only": 1,
+   "description": "Central Resource Action id for the last lifecycle command. Echoed on site.* events so Central matches the outcome to the action that requested it."
   }
  ],
  "links": [],

--- a/atlas/atlas/doctype/site/site.py
+++ b/atlas/atlas/doctype/site/site.py
@@ -170,7 +170,7 @@ class Site(Document):
 	# ----- lifecycle methods (Contract B state machine) ------------------
 
 	@frappe.whitelist()
-	def terminate(self) -> None:
+	def terminate(self, correlation_id: str | None = None) -> None:
 		"""Take the site off the front door and tear down its backing VM.
 
 		Delete the Subdomain (the proxy stops routing on the next reconcile),
@@ -182,6 +182,7 @@ class Site(Document):
 		self._delete_subdomain()
 		self._terminate_pilot()
 		self._terminate_backing_vm()
+		self.correlation_id = correlation_id
 		self.status = "Terminated"
 		self.save(ignore_permissions=True)
 

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.json
@@ -15,6 +15,7 @@
   "status",
   "tenant",
   "pilot_credential_id",
+  "correlation_id",
   "section_break_resources",
   "size_preset",
   "column_break_resources_0",
@@ -479,6 +480,13 @@
    "label": "Pilot Credential ID",
    "read_only": 1,
    "description": "Central-minted per-pilot credential id, copied from the owning Site. Echoed to Central on vm.* events so Central links/revokes the credential."
+  },
+  {
+   "fieldname": "correlation_id",
+   "fieldtype": "Data",
+   "label": "Correlation ID",
+   "read_only": 1,
+   "description": "Central Server Action id for the last lifecycle command. Echoed on vm.* events so Central matches the outcome to the action that requested it."
   },
   {
    "collapsible": 1,

--- a/atlas/atlas/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/atlas/doctype/virtual_machine/virtual_machine.py
@@ -475,7 +475,7 @@ class VirtualMachine(Document):
 		return self._put_desired_state()
 
 	@frappe.whitelist()
-	def start(self) -> str:
+	def start(self, correlation_id: str | None = None) -> str:
 		"""Start a Stopped VM. When the last stop captured a memory snapshot
 		(has_memory_snapshot), the host resumes the guest from it in milliseconds
 		instead of cold-booting; the start Task is the same either way — the
@@ -506,6 +506,7 @@ class VirtualMachine(Document):
 		# than idle_timeout_seconds — and the next sleep_idle_vms tick puts it
 		# straight back to sleep, within a minute of the operator starting it.
 		self.last_traffic_at = self.last_started
+		self.correlation_id = correlation_id
 		self.save()
 		return task.name
 
@@ -515,6 +516,7 @@ class VirtualMachine(Document):
 		memory_snapshot: bool | None = None,
 		stop_timeout_seconds: int = 0,
 		graceful: bool = True,
+		correlation_id: str | None = None,
 	) -> str:
 		"""Stop a Running/Paused VM. The default is the plain unit stop. With
 		`memory_snapshot` (default: the VM's memory_snapshot_on_stop flag, off
@@ -602,6 +604,7 @@ class VirtualMachine(Document):
 		self.status = "Stopped"
 		self.has_memory_snapshot = 1 if snapshotted else 0
 		self.last_stopped = frappe.utils.now_datetime()
+		self.correlation_id = correlation_id
 		self.save()
 		return task.name
 
@@ -1224,7 +1227,7 @@ class VirtualMachine(Document):
 		return proxy.read_live_maps(self.name)
 
 	@frappe.whitelist()
-	def terminate(self) -> str:
+	def terminate(self, correlation_id: str | None = None) -> str:
 		if self.status == "Terminated":
 			frappe.throw(_("VM is already terminated"))
 		if self.termination_protection:
@@ -1242,6 +1245,7 @@ class VirtualMachine(Document):
 			timeout_seconds=60,
 		)
 		self.status = "Terminated"
+		self.correlation_id = correlation_id
 		self.save()
 		self._detach_reserved_ip()
 		self._revoke_tunnels()

--- a/atlas/tests/test_central.py
+++ b/atlas/tests/test_central.py
@@ -217,6 +217,38 @@ class TestCentralReport(IntegrationTestCase):
 	def test_vm_payload_pilot_credential_id_none_when_unset(self) -> None:
 		self.assertIsNone(central_report._vm_payload(self._vm())["pilot_credential_id"])
 
+	def test_vm_payload_echoes_correlation_id(self) -> None:
+		vm = self._vm()
+		vm.correlation_id = "sa-123"
+		self.assertEqual(central_report._vm_payload(vm)["correlation_id"], "sa-123")
+
+	def test_vm_payload_correlation_id_none_when_unset(self) -> None:
+		self.assertIsNone(central_report._vm_payload(self._vm())["correlation_id"])
+
+	def test_pilot_vm_payload_echoes_correlation_id(self) -> None:
+		# The pilot-backed path reads the id off the real VM doc, so Central still matches a
+		# create's outcome even when it reports through the Pilot front door.
+		server = fixtures.make_server(
+			fixtures.make_provider("corr-vm-provider"),
+			"corr-vm-server",
+			ipv6_address="2001:db8:d::1",
+			ipv6_prefix="2001:db8:d::/64",
+			ipv6_virtual_machine_range="2001:db8:d::/124",
+		)
+		vm = fixtures.make_virtual_machine(server, fixtures.make_image("corr-vm-image"), title="corr-vm")
+		vm.db_set("correlation_id", "sa-xyz")
+		pilot = SimpleNamespace(
+			name="acme.blr1.frappe.dev",
+			doctype="Pilot",
+			console_fqdn="acme.blr1.frappe.dev",
+			virtual_machine=vm.name,
+			tenant=None,
+			status="Running",
+			login_url_expires_at=None,
+		)
+		pilot.get = lambda key, default=None: getattr(pilot, key, default)
+		self.assertEqual(central_report._pilot_vm_payload(pilot)["correlation_id"], "sa-xyz")
+
 	def test_plain_vm_payload_has_no_bench_fields(self) -> None:
 		# A VM with no owning Pilot carries no front door.
 		payload = central_report._vm_payload(self._vm())
@@ -530,6 +562,14 @@ class TestCentralReportSite(IntegrationTestCase):
 		self.assertEqual(kwargs["event_type"], "site.created")
 		self.assertEqual(kwargs["payload"]["name"], "acme.blr1.frappe.dev")
 		self.assertEqual(kwargs["payload"]["subdomain"], "acme")
+
+	def test_site_payload_echoes_correlation_id(self) -> None:
+		site = self._site()
+		site.correlation_id = "ra-site-1"
+		self.assertEqual(central_report._site_payload(site)["correlation_id"], "ra-site-1")
+
+	def test_site_payload_correlation_id_none_when_unset(self) -> None:
+		self.assertIsNone(central_report._site_payload(self._site())["correlation_id"])
 
 	def test_status_change_emits_and_pending_hides_handoff(self) -> None:
 		with _patched_emit() as enqueue:


### PR DESCRIPTION
Stores the Central-supplied correlation_id on the VM/Site and includes it on every vm.* and site.* event, so Central can attribute each outcome to the action that requested it.