### PR TITLE
fix(server): a dangling default_user_image link must not block every Server op

### DIFF
--- a/atlas/atlas/doctype/server/server.py
+++ b/atlas/atlas/doctype/server/server.py
@@ -163,19 +163,23 @@ class Server(Document):
 		self.name = str(uuid.uuid4())
 
 	def validate(self) -> None:
-		atlas_settings = frappe.get_single("Atlas Settings")
-		atlas_settings._ensure_ancp_operator_keypair()
-		atlas_settings._ensure_ancp_wg_derivation_secret()
-		# ignore_mandatory: this save is incidental — we are only persisting the two
-		# lazily-generated ANCP secrets, not asking the operator to have finished
-		# configuring Atlas Settings. Without it, a Single with an empty `region`
-		# (any site that has not been through setup(), including every fresh test
-		# site) makes EVERY Server insert die with "Value missing for Atlas
-		# Settings: Region" — an error naming a field the caller never touched.
-		# The operator's required fields are still enforced when they save the
-		# Single themselves.
-		atlas_settings.flags.ignore_mandatory = True
-		atlas_settings.save(ignore_permissions=True)
+		# Materialize the two lazily-generated ANCP secrets (operator keypair + wg
+		# key-derivation secret) that `_denormalize_mesh_identity` / bootstrap read
+		# straight from the DB. Use the DB-level `ensure_*_in_db` helpers rather than
+		# a full `Atlas Settings` doc save: a `save()` here re-runs FULL link
+		# validation on the Single, so a dangling `default_user_image` /
+		# `default_bench_snapshot` Link (an image/snapshot deleted out from under the
+		# Single) would make EVERY Server op — bootstrap, provision, upgrade_boat,
+		# resync_networkd_keys — die with "Could not find Default User Image: <x>",
+		# an error naming a field the Server save never touched. The DB-level path is
+		# idempotent (no-op once the secrets exist) and validates nothing unrelated.
+		from atlas.atlas.doctype.atlas_settings.atlas_settings import (
+			ensure_ancp_operator_keypair_in_db,
+			ensure_ancp_wg_derivation_secret_in_db,
+		)
+
+		ensure_ancp_operator_keypair_in_db()
+		ensure_ancp_wg_derivation_secret_in_db()
 		self._validate_immutability()
 		self._denormalize_mesh_identity()
 

--- a/atlas/atlas/doctype/server/test_server.py
+++ b/atlas/atlas/doctype/server/test_server.py
@@ -640,6 +640,37 @@ class TestServerSigningKeyBackfill(IntegrationTestCase):
 		self.assertTrue(all(entry["signing_public_key"] for entry in seed))
 
 
+class TestServerValidateWithDanglingSettingsLink(IntegrationTestCase):
+	"""A Server save must succeed even when `Atlas Settings.default_user_image`
+	(or `default_bench_snapshot`) is a dangling Link — an image/snapshot deleted
+	out from under the Single. `validate()` materializes the ANCP secrets via the
+	DB-level `ensure_*_in_db` helpers, NOT a full `Atlas Settings` doc save, so it
+	never re-validates the unrelated Single Links that would otherwise block every
+	Server op (bootstrap, provision, upgrade_boat, resync_networkd_keys)."""
+
+	def test_server_saves_despite_dangling_default_user_image(self) -> None:
+		# Point the Single at an image that does not exist. `set_single_value`
+		# bypasses validation, reproducing the on-disk dangling-Link state.
+		frappe.db.set_single_value(
+			"Atlas Settings", "default_user_image", "no-such-image-deleted", update_modified=False
+		)
+		frappe.db.delete("Server", {"title": "test-server-dangling"})
+		# Insert AND re-save: both run validate(), and neither may raise
+		# LinkValidationError for the unrelated Atlas Settings Link.
+		server = make_server(
+			make_provider("test-provider-dangling"),
+			"test-server-dangling",
+			provider_resource_id="99",
+			status="Pending",
+		)
+		server.reload()
+		server.save(ignore_permissions=True)
+		# The Single's dangling link is untouched — we never rewrote it.
+		self.assertEqual(
+			frappe.db.get_single_value("Atlas Settings", "default_user_image"), "no-such-image-deleted"
+		)
+
+
 class TestServerUpgradeBoat(IntegrationTestCase):
 	"""`Server.upgrade_boat` — the boat-artifact + unit + durable-script subset of
 	bootstrap, made idempotent and re-runnable so a new binary, allow-list line or


### PR DESCRIPTION
## Problem (reproduced live during staging bring-up)

`Server.validate()` unconditionally called `atlas_settings.save(ignore_permissions=True)` on **every** Server save, purely to materialize the two lazily-generated ANCP secrets (operator keypair + wg key-derivation secret) into the DB.

That full doc save re-runs **complete link validation** on the `Atlas Settings` Single. So when `Atlas Settings.default_user_image` (or `default_bench_snapshot`) points at a since-deleted image/snapshot — a dangling Link — **every** Server operation (`bootstrap`, `provision`, `upgrade_boat`, `resync_networkd_keys`) died with:

```
frappe.exceptions.LinkValidationError: Could not find Default User Image: <x>
```

an error naming a field the Server save never touched.

## Fix

Replace the blind full `atlas_settings.save()` with the two idempotent **DB-level** helpers the module already provides for exactly this purpose:

- `ensure_ancp_operator_keypair_in_db()`
- `ensure_ancp_wg_derivation_secret_in_db()`

These persist exactly the two ANCP secrets (no-op once present, reading DB truth), and validate nothing unrelated. `_denormalize_mesh_identity()` still reads the wg secret straight from the DB afterward, so ordering is preserved. This is the same DB-level path `AtlasSettings.setup()` already uses on the validate-bypassing bootstrap flow.

**Invariant restored:** saving a Server succeeds even when `default_user_image` is a dangling link.

## Verification

Added `TestServerValidateWithDanglingSettingsLink`. Against the local `atlas.tests.local` site:

- **Before the fix:** the test fails with `LinkValidationError: Could not find Default User Image: no-such-image-deleted`.
- **After the fix:** passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)