### PR TITLE
fix(garage): terminate the gateway web_domain nginx directives

### DIFF
--- a/atlas/atlas/garage.py
+++ b/atlas/atlas/garage.py
@@ -59,9 +59,9 @@ def configure_garage(virtual_machine: str) -> str:
 	server {{
 		listen 80;
         listen [::]:80;
-		server_name {garage.web_domain}
+		server_name {garage.web_domain};
 		location / {{
-			proxy_pass http://127.0.0.1:3902
+			proxy_pass http://127.0.0.1:3902;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 		}}


### PR DESCRIPTION
The gateway nginx config generated by `configure_garage()` (atlas/atlas/garage.py) leaves the `web_domain` server block's `server_name` and `proxy_pass` directives **without trailing semicolons**, while the `api_domain` block has them. `nginx -t` rejects the missing semicolons, so **every gateway node's `configure_garage()` fails** when it writes /etc/nginx/conf.d/garage.conf and reloads nginx.

Found while standing up a real 3-node Garage cluster on staging — the gateway would not come up until these two semicolons were added. Two-character fix, no behavior change beyond producing valid nginx config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)