### PR TITLE
feat(wg-mesh): Add unicast discovery relay

### DIFF
--- a/services/wg-mesh/README.md
+++ b/services/wg-mesh/README.md
@@ -14,6 +14,7 @@ Atlas WG Mesh does not provide inter-region VM connectivity yet.
 
 - [Operations guide](docs/operations.md): requirements, build, installation, VM lifecycle, debugging, and upgrades.
 - [Design guide](docs/design.md): addressing, [trust model](docs/design.md#trust-model), BPF maps and hooks, packet paths, and recovery behavior.
+- [Unicast network guide](docs/unicast-network.md): use the discovery relay when multicast is unavailable.
 - [Benchmark results](docs/benchmark.md): throughput, packet rate, debug cost, and rate-limiter impact.
 - [Debug in production](docs/debug-in-production.md): inspect routes and packet decisions.
 

--- a/services/wg-mesh/bpf/control.h
+++ b/services/wg-mesh/bpf/control.h
@@ -13,7 +13,7 @@ static __always_inline int send_discovery_message(
 	struct __sk_buff *packet, struct config *local_config,
 	const __u8 *recipient_mac, __be32 recipient_ipv4,
 	__u8 message_operation, const struct in6_addr *virtual_machine,
-	const struct in6_addr *virtual_machine_host, __u32 uplink_ifindex)
+	const struct in6_addr *virtual_machine_host, __u32 egress_ifindex)
 {
 	struct atlas_msg msg = {};
 	struct ethhdr eth = {};
@@ -27,7 +27,7 @@ static __always_inline int send_discovery_message(
 	ip.version = 4;
 	ip.ihl = 5;
 	ip.tot_len = bpf_htons((__u16)(DISCOVERY_PACKET_LENGTH - ETH_HLEN));
-	ip.ttl = ATLAS_TTL;
+	ip.ttl = recipient_ipv4 == bpf_htonl(ATLAS_MCAST4) ? ATLAS_MULTICAST_TTL : ATLAS_UNICAST_TTL;
 	ip.protocol = IPPROTO_UDP;
 	ip.saddr = local_config->underlay_ip4;
 	ip.daddr = recipient_ipv4;
@@ -59,7 +59,7 @@ static __always_inline int send_discovery_message(
 		bpf_skb_store_bytes(packet, DISCOVERY_MESSAGE_OFFSET, &msg, sizeof(msg), 0))
 		return TC_ACT_SHOT;
 
-	return bpf_redirect(uplink_ifindex, 0);
+	return bpf_redirect(egress_ifindex, 0);
 }
 
 /* Send a host discovery request for a virtual machine. */
@@ -79,7 +79,7 @@ static __always_inline int ask_for_virtual_machine_host(
 
 	return send_discovery_message(packet, local_config, multicast_mac,
 								  bpf_htonl(ATLAS_MCAST4), MESSAGE_OPERATION_WHO_HAS,
-								  virtual_machine, NULL, local_config->uplink_ifindex);
+								  virtual_machine, NULL, local_config->discovery_ifindex);
 }
 
 /* Tell the requesting host that its VM location is stale. */

--- a/services/wg-mesh/bpf/protocol.h
+++ b/services/wg-mesh/bpf/protocol.h
@@ -29,7 +29,10 @@
 /* Discovery uses IPv4 multicast on the local physical network. */
 #define ATLAS_MCAST4 0xef010101u /* 239.1.1.1 */
 #define ATLAS_PORT 7373
-#define ATLAS_TTL 1
+#define ATLAS_MULTICAST_TTL 1
+
+/* A unicast reply has no multicast scope to keep and must survive routers. */
+#define ATLAS_UNICAST_TTL 64
 
 /* Recovery travels inside WireGuard as an experimental IPv6 next header. */
 #define ATLAS_CONTROL_NEXT_HEADER 253

--- a/services/wg-mesh/bpf/state.h
+++ b/services/wg-mesh/bpf/state.h
@@ -27,7 +27,8 @@ struct
 /* Host configuration. */
 struct config
 {
-	__u32 uplink_ifindex;
+	/* Destination for locally generated WHO_HAS frames. */
+	__u32 discovery_ifindex;
 	__be32 underlay_ip4;
 	__u8 uplink_mac[ETH_ALEN];
 	__u8 pad[2];

--- a/services/wg-mesh/cli/bpf.go
+++ b/services/wg-mesh/cli/bpf.go
@@ -26,13 +26,36 @@ var bpfObject []byte
 
 // Must match struct config in bpf/state.h.
 type hostConfig struct {
-	UplinkIndex   uint32
-	UplinkIPv4    [4]byte
-	UplinkMAC     [6]byte
-	Padding       [2]byte
-	WireGuardIPv6 [16]byte
-	WhoHasRate    uint32
-	WhoHasBurst   uint32
+	DiscoveryIndex uint32
+	UplinkIPv4     [4]byte
+	UplinkMAC      [6]byte
+	Padding        [2]byte
+	WireGuardIPv6  [16]byte
+	WhoHasRate     uint32
+	WhoHasBurst    uint32
+}
+
+// setDiscoveryInterface rewrites one field of the shared host config, so it
+// takes the same lock as the other commands that replace it wholesale.
+func setDiscoveryInterface(index uint32) error {
+	unlock, err := lockVMState()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	configMap, err := openMap("config")
+	if err != nil {
+		return err
+	}
+	defer configMap.Close()
+
+	var config hostConfig
+	if err := configMap.Lookup(uint32(0), &config); err != nil {
+		return err
+	}
+	config.DiscoveryIndex = index
+	return configMap.Put(uint32(0), config)
 }
 
 // programPath returns the pin for a program. A fresh install pins at the top

--- a/services/wg-mesh/cli/commands.go
+++ b/services/wg-mesh/cli/commands.go
@@ -288,11 +288,25 @@ func showStatus() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("uplink index: %d\nlocal VMs: %d\nremote locations: %d/%d\nWireGuard address: %s\n", config.UplinkIndex, count, remoteCount, remoteCapacity, netip.AddrFrom16(config.WireGuardIPv6))
+	fmt.Printf("discovery interface: %s\nlocal VMs: %d\nremote locations: %d/%d\nWireGuard address: %s\n", discoveryInterfaceName(config), count, remoteCount, remoteCapacity, netip.AddrFrom16(config.WireGuardIPv6))
 	if config.WhoHasRate == 0 {
 		fmt.Println("WHO_HAS rate limit: disabled")
 	} else {
 		fmt.Printf("WHO_HAS rate limit: %d/s burst %d\n", config.WhoHasRate, config.WhoHasBurst)
 	}
 	return nil
+}
+
+// discoveryInterfaceName names where WHO_HAS is sent. A relay killed without
+// its cleanup leaves an index no interface owns, which drops every WHO_HAS, so
+// report that rather than a bare number.
+func discoveryInterfaceName(config hostConfig) string {
+	device, err := net.InterfaceByIndex(int(config.DiscoveryIndex))
+	if err != nil {
+		return fmt.Sprintf("ifindex:%d (missing; rerun the discovery relay or configure)", config.DiscoveryIndex)
+	}
+	if device.Name == interfaceWithIPv4(config.UplinkIPv4) {
+		return device.Name + " (multicast)"
+	}
+	return device.Name + " (relay)"
 }

--- a/services/wg-mesh/cli/discovery_relay.go
+++ b/services/wg-mesh/cli/discovery_relay.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultDiscoveryTap    = "atlas-wg-relay"
+	discoveryRelayLockPath = "/run/lock/atlas-wg-mesh-discovery-relay.lock"
+	discoveryFrameSize     = 14 + 20 + 8 + meshAnnouncementSize
+	discoveryMessageOffset = discoveryFrameSize - meshAnnouncementSize
+
+	// Read past a discovery frame so an oversized one fails the length check
+	// rather than arriving truncated to exactly the expected size.
+	discoveryReadSize = 2048
+)
+
+var discoveryVerbose bool
+
+var discoveryRelayCommand = &cobra.Command{
+	Use:   "discovery-relay PEERS_FILE",
+	Short: "relay multicast discovery messages to configured hosts",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, arguments []string) error {
+		return runDiscoveryRelay(arguments[0], discoveryVerbose)
+	},
+}
+
+// runDiscoveryRelay directs multicast-style discovery through a local relay.
+func runDiscoveryRelay(peersFile string, verbose bool) error {
+	config, err := readPinnedConfig()
+	if err != nil {
+		return err
+	}
+	uplinkName := interfaceWithIPv4(config.UplinkIPv4)
+	if uplinkName == "" {
+		return errors.New("cannot find the configured uplink")
+	}
+	uplink, err := net.InterfaceByName(uplinkName)
+	if err != nil {
+		return err
+	}
+	peers, err := readDiscoveryPeers(peersFile, config.UplinkIPv4)
+	if err != nil {
+		return err
+	}
+	peerFile, err := os.Stat(peersFile)
+	if err != nil {
+		return err
+	}
+	unlock, err := lockDiscoveryRelay()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	var currentPeers atomic.Value
+	currentPeers.Store(peers)
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go watchDiscoveryPeers(peersFile, config.UplinkIPv4, peerFile.ModTime(), &currentPeers, stopped)
+
+	tap, tapInterface, err := createDiscoveryTap(defaultDiscoveryTap)
+	if err != nil {
+		return err
+	}
+	defer tap.Close()
+	if err := setDiscoveryInterface(uint32(tapInterface.Index)); err != nil {
+		return err
+	}
+	defer func() {
+		if err := setDiscoveryInterface(uint32(uplink.Index)); err != nil {
+			fmt.Fprintf(os.Stderr, "atlas-wg-mesh: warning: restore multicast discovery: %v\n", err)
+		}
+	}()
+
+	// Source relayed messages from the uplink address so FOUND returns there.
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP(config.UplinkIPv4[:]), Port: meshPort})
+	if err != nil {
+		return err
+	}
+	defer socket.Close()
+
+	interrupted := make(chan os.Signal, 1)
+	signal.Notify(interrupted, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(interrupted)
+	go func() {
+		<-interrupted
+		_ = tap.Close()
+	}()
+
+	go relayAnnouncements(socket, config.UplinkIPv4, &currentPeers, verbose)
+	return relayTapFrames(tap, socket, &currentPeers, verbose)
+}
+
+// watchDiscoveryPeers replaces the peer list after a successful file update.
+func watchDiscoveryPeers(path string, self [4]byte, modified time.Time, current *atomic.Value, stopped <-chan struct{}) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopped:
+			return
+		case <-ticker.C:
+		}
+
+		info, err := os.Stat(path)
+		if err != nil || info.ModTime().Equal(modified) {
+			continue
+		}
+		peers, err := readDiscoveryPeers(path, self)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "atlas-wg-mesh: warning: reload %s: %v\n", path, err)
+			continue
+		}
+
+		current.Store(peers)
+		modified = info.ModTime()
+	}
+}
+
+// readDiscoveryPeers parses one IPv4 address per non-comment line. It drops
+// this host, which would otherwise relay its own NOW_HERE back to itself.
+func readDiscoveryPeers(path string, self [4]byte) ([]*net.UDPAddr, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	peers := make([]*net.UDPAddr, 0)
+	scanner := bufio.NewScanner(file)
+	line := 0
+	for scanner.Scan() {
+		line++
+		value := strings.TrimSpace(strings.SplitN(scanner.Text(), "#", 2)[0])
+		if value == "" {
+			continue
+		}
+		address := net.ParseIP(value)
+		if address == nil || address.To4() == nil {
+			return nil, fmt.Errorf("%s:%d: expected an IPv4 address", path, line)
+		}
+		if [4]byte(address.To4()) == self {
+			continue
+		}
+		peers = append(peers, &net.UDPAddr{IP: address, Port: meshPort})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(peers) == 0 {
+		return nil, fmt.Errorf("%s contains no peers", path)
+	}
+	return peers, nil
+}
+
+// createDiscoveryTap creates and enables the TAP used for BPF redirects.
+//
+// The descriptor is opened raw rather than with os.OpenFile, which would hand
+// it to the runtime poller before TUNSETIFF attaches a device. Polling an
+// unattached tun latches EPOLLERR, and the first read then fails with "not
+// pollable". Registering after the ioctl keeps Close able to stop a read.
+func createDiscoveryTap(name string) (tap *os.File, iface *net.Interface, err error) {
+	descriptor, err := unix.Open("/dev/net/tun", unix.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if err != nil {
+			unix.Close(descriptor)
+		}
+	}()
+
+	request, err := unix.NewIfreq(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	request.SetUint16(unix.IFF_TAP | unix.IFF_NO_PI)
+	if err = unix.IoctlIfreq(descriptor, unix.TUNSETIFF, request); err != nil {
+		return nil, nil, err
+	}
+	if err = unix.SetNonblock(descriptor, true); err != nil {
+		return nil, nil, err
+	}
+	tap = os.NewFile(uintptr(descriptor), "/dev/net/tun")
+	// Silence the kernel's own IPv6 traffic on a device that carries only
+	// discovery frames.
+	_ = runCommand("sysctl", "-qw", "net.ipv6.conf."+request.Name()+".disable_ipv6=1")
+	if err = runCommand("ip", "link", "set", request.Name(), "up"); err != nil {
+		return nil, nil, err
+	}
+	iface, err = net.InterfaceByName(request.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+	return tap, iface, nil
+}
+
+// relayTapFrames forwards WHO_HAS frames emitted by BPF.
+func relayTapFrames(tap *os.File, socket *net.UDPConn, currentPeers *atomic.Value, verbose bool) error {
+	frame := make([]byte, discoveryReadSize)
+	for {
+		length, err := tap.Read(frame)
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+
+		message, ok := whoHasMessage(frame[:length])
+		if !ok {
+			continue
+		}
+		logRelayMessage(verbose, "RX", message, nil)
+		relayMessage(socket, currentPeers, message, verbose)
+	}
+}
+
+// relayAnnouncements forwards local NOW_HERE announcements from the CLI.
+//
+// Only this host may be relayed. The uplink hook normally consumes discovery
+// from other hosts before it reaches any socket, but while that hook is
+// detached those frames arrive here instead, and forwarding them would make
+// this host reflect every announcement it receives.
+func relayAnnouncements(socket *net.UDPConn, self [4]byte, currentPeers *atomic.Value, verbose bool) {
+	message := make([]byte, meshAnnouncementSize)
+	for {
+		length, from, err := socket.ReadFromUDP(message)
+		if err != nil {
+			return
+		}
+
+		if !from.IP.Equal(net.IP(self[:])) {
+			continue
+		}
+		if length != len(message) || message[0] != 1 || message[1] != 4 {
+			continue
+		}
+		logRelayMessage(verbose, "RX", message, nil)
+		relayMessage(socket, currentPeers, message, verbose)
+	}
+}
+
+// relayMessage sends one discovery payload to every configured peer. An
+// unreachable peer is reported and skipped; the rest still get the message.
+func relayMessage(socket *net.UDPConn, currentPeers *atomic.Value, message []byte, verbose bool) {
+	for _, peer := range currentPeers.Load().([]*net.UDPAddr) {
+		if _, err := socket.WriteToUDP(message, peer); err != nil {
+			fmt.Fprintf(os.Stderr, "atlas-wg-mesh: warning: relay to %s: %v\n", peer, err)
+			continue
+		}
+		logRelayMessage(verbose, "TX", message, peer)
+	}
+}
+
+// whoHasMessage returns the payload from a BPF-generated WHO_HAS frame.
+func whoHasMessage(frame []byte) ([]byte, bool) {
+	if len(frame) != discoveryFrameSize {
+		return nil, false
+	}
+	message := frame[discoveryMessageOffset:]
+	return message, message[0] == 1 && message[1] == 1
+}
+
+// logRelayMessage prints accepted and forwarded discovery messages on request.
+func logRelayMessage(verbose bool, direction string, message []byte, peer *net.UDPAddr) {
+	if !verbose {
+		return
+	}
+	operation := operationName(message[1])
+	virtualMachine := netip.AddrFrom16([16]byte(message[4:20]))
+	if peer == nil {
+		fmt.Printf("%s %s vm=%s\n", direction, operation, virtualMachine)
+		return
+	}
+	fmt.Printf("%s %s vm=%s peer=%s\n", direction, operation, virtualMachine, peer)
+}
+
+// lockDiscoveryRelay allows one relay and releases automatically on a crash.
+func lockDiscoveryRelay() (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(discoveryRelayLockPath), 0755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(discoveryRelayLockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("discovery relay is already running: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}

--- a/services/wg-mesh/cli/go.mod
+++ b/services/wg-mesh/cli/go.mod
@@ -10,5 +10,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.43.0
 )

--- a/services/wg-mesh/cli/main.go
+++ b/services/wg-mesh/cli/main.go
@@ -50,7 +50,8 @@ func init() {
 	virtualMachineCommand.AddCommand(addVirtualMachineCommand, removeVirtualMachineCommand, listVirtualMachinesCommand)
 	debugCommand.AddCommand(debugStatusCommand, debugEnableCommand, debugDisableCommand, inspectCommand, dumpCommand, topCommand)
 	remoteCommand.AddCommand(remotePurgeCommand)
-	rootCommand.AddCommand(configureCommand, statusCommand, virtualMachineCommand, remoteCommand, debugCommand, upgradeCommand, versionCommand, resetCommand)
+	discoveryRelayCommand.Flags().BoolVar(&discoveryVerbose, "verbose", false, "log relayed discovery messages")
+	rootCommand.AddCommand(configureCommand, statusCommand, virtualMachineCommand, remoteCommand, debugCommand, discoveryRelayCommand, upgradeCommand, versionCommand, resetCommand)
 }
 
 func main() {

--- a/services/wg-mesh/cli/network.go
+++ b/services/wg-mesh/cli/network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -48,9 +49,9 @@ func readHostConfig(uplinkName, wireGuardName string) (hostConfig, error) {
 	}
 
 	config := hostConfig{
-		UplinkIndex:   uint32(uplinkInterface.Index),
-		UplinkIPv4:    [4]byte(uplinkIPv4.To4()),
-		WireGuardIPv6: [16]byte(wireGuardIPv6.To16()),
+		DiscoveryIndex: uint32(uplinkInterface.Index),
+		UplinkIPv4:     [4]byte(uplinkIPv4.To4()),
+		WireGuardIPv6:  [16]byte(wireGuardIPv6.To16()),
 	}
 	copy(config.UplinkMAC[:], uplinkInterface.HardwareAddr)
 	return config, nil
@@ -80,13 +81,31 @@ func configuredInterfaces() (hostInterfaces, error) {
 		return hostInterfaces{}, err
 	}
 	interfaces := hostInterfaces{}
-	if uplink, err := net.InterfaceByIndex(int(config.UplinkIndex)); err == nil {
-		interfaces.uplinkName = uplink.Name
-	}
+	interfaces.uplinkName = interfaceWithIPv4(config.UplinkIPv4)
 	if wireGuardName := interfaceWithAddress(config.WireGuardIPv6); wireGuardName != "" {
 		interfaces.wireGuardName = wireGuardName
 	}
 	return interfaces, nil
+}
+
+func interfaceWithIPv4(target [4]byte) string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range interfaces {
+		addresses, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, address := range addresses {
+			network, ok := address.(*net.IPNet)
+			if ok && network.IP.To4() != nil && [4]byte(network.IP.To4()) == target {
+				return iface.Name
+			}
+		}
+	}
+	return ""
 }
 
 func interfaceWithAddress(target [16]byte) string {
@@ -139,14 +158,24 @@ func parseMeshAddress(addressText string) ([16]byte, error) {
 }
 
 func announceVirtualMachine(address [16]byte, config hostConfig) error {
-	conn, err := net.ListenUDP("udp4", nil)
+	destination, multicast, err := discoveryAnnouncementDestination(config)
+	if err != nil {
+		return err
+	}
+	localAddress := (*net.UDPAddr)(nil)
+	if !multicast {
+		localAddress = &net.UDPAddr{IP: net.IP(config.UplinkIPv4[:])}
+	}
+	conn, err := net.ListenUDP("udp4", localAddress)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
-	if err := configureMulticastSocket(conn, config.UplinkIPv4); err != nil {
-		return err
+	if multicast {
+		if err := configureMulticastSocket(conn, config.UplinkIPv4); err != nil {
+			return err
+		}
 	}
 	message := make([]byte, meshAnnouncementSize)
 	message[0] = 1
@@ -154,7 +183,6 @@ func announceVirtualMachine(address [16]byte, config hostConfig) error {
 	copy(message[4:20], address[:])
 	copy(message[20:], config.WireGuardIPv6[:])
 
-	destination := &net.UDPAddr{IP: net.ParseIP(meshMulticastAddress), Port: meshPort}
 	for attempt := range meshAnnouncementAttempts {
 		if attempt > 0 {
 			time.Sleep(meshAnnouncementInterval)
@@ -164,6 +192,21 @@ func announceVirtualMachine(address [16]byte, config hostConfig) error {
 		}
 	}
 	return nil
+}
+
+func discoveryAnnouncementDestination(config hostConfig) (*net.UDPAddr, bool, error) {
+	uplinkName := interfaceWithIPv4(config.UplinkIPv4)
+	if uplinkName == "" {
+		return nil, false, errors.New("cannot find the configured uplink")
+	}
+	uplink, err := net.InterfaceByName(uplinkName)
+	if err != nil {
+		return nil, false, err
+	}
+	if config.DiscoveryIndex != uint32(uplink.Index) {
+		return &net.UDPAddr{IP: net.IP(config.UplinkIPv4[:]), Port: meshPort}, false, nil
+	}
+	return &net.UDPAddr{IP: net.ParseIP(meshMulticastAddress), Port: meshPort}, true, nil
 }
 
 func configureMulticastSocket(conn *net.UDPConn, source [4]byte) error {

--- a/services/wg-mesh/docs/design.md
+++ b/services/wg-mesh/docs/design.md
@@ -39,7 +39,7 @@ VMs use `fdaa::/16`; host WireGuard addresses use `fdab::/16`. The VM hook drops
 
 Nonzero tenant IDs are isolated from each other. Tenant `0` can communicate with every tenant and must be assigned only to trusted platform services.
 
-Discovery runs on a trusted multicast Layer-2 domain. `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated, so a host on that network can influence learned VM locations. WireGuard encrypts traffic only to configured peers.
+Discovery runs on a trusted multicast Layer-2 domain. `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated, so a host on that network can influence learned VM locations. On networks that use the [discovery relay](unicast-network.md), allow UDP port `7373` only between trusted relay peers; unicast discovery is not limited to the multicast TTL. WireGuard encrypts traffic only to configured peers.
 
 Each VM defaults to 10 `WHO_HAS` messages per second with a burst of 50. This limits multicast floods from a VM; it does not authenticate discovery messages.
 
@@ -53,7 +53,7 @@ Each VM defaults to 10 `WHO_HAS` messages per second with a burst of 50. This li
 
 | Map | Purpose |
 | --- | --- |
-| `config` | Host configuration and discovery limits. |
+| `config` | Host configuration, the discovery interface, and discovery limits. |
 | `local_vms`, `remote_vms` | Local ownership and learned remote locations. |
 | `discovery_limits` | Per-VM discovery rate-limit state. |
 | `debug_config`, `debug_stats`, `debug_events` | Optional debug state and events. |

--- a/services/wg-mesh/docs/operations.md
+++ b/services/wg-mesh/docs/operations.md
@@ -4,18 +4,23 @@ The `atlas-wg-mesh` CLI configures local host and VM lifecycle state. It embeds 
 
 ## Contents
 
-- [Requirements](#requirements)
-- [Network and security](#network-and-security)
-- [Build a release](#build-a-release)
-- [Install a host](#install-a-host)
-- [Add a VM](#add-a-vm)
-- [Move a VM](#move-a-vm)
-- [Remove a VM](#remove-a-vm)
-- [Check status](#check-status)
-- [Debug in production](#debug-in-production)
-- [Upgrade BPF programs](#upgrade-bpf-programs)
-- [Remove remote entries](#remove-remote-entries)
-- [Remove a host installation](#remove-a-host-installation)
+- [Atlas WG Mesh operations guide](#atlas-wg-mesh-operations-guide)
+  - [Contents](#contents)
+  - [Requirements](#requirements)
+  - [Network and security](#network-and-security)
+  - [Build a release](#build-a-release)
+  - [Install a host](#install-a-host)
+  - [Add a VM](#add-a-vm)
+  - [Move a VM](#move-a-vm)
+  - [Remove a VM](#remove-a-vm)
+  - [List local VM ownership](#list-local-vm-ownership)
+  - [Rejoin after a dead declaration](#rejoin-after-a-dead-declaration)
+  - [Check status](#check-status)
+  - [Debug in production](#debug-in-production)
+  - [Upgrade BPF programs](#upgrade-bpf-programs)
+  - [Remove remote entries](#remove-remote-entries)
+  - [Remove a host installation](#remove-a-host-installation)
+  - [Force reset fallback](#force-reset-fallback)
 
 ## Requirements
 
@@ -25,14 +30,14 @@ Atlas WG Mesh pins state at `/sys/fs/bpf/atlas-wg-mesh`.
 
 ## Network and security
 
-| Use | Value |
-| --- | --- |
-| VM address range | `fdaa::/16` |
-| WireGuard address range | `fdab::/16` |
-| Discovery destination | `239.1.1.1:7373` |
-| Uplink MTU | 1500 or greater |
-| WireGuard MTU | 1420 |
-| VM interface and guest MTU | 1380 |
+| Use                        | Value                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| VM address range           | `fdaa::/16`                                                                                 |
+| WireGuard address range    | `fdab::/16`                                                                                 |
+| Discovery destination      | `239.1.1.1:7373`, or each peer on UDP `7373` with the [discovery relay](unicast-network.md) |
+| Uplink MTU                 | 1500 or greater                                                                             |
+| WireGuard MTU              | 1420                                                                                        |
+| VM interface and guest MTU | 1380                                                                                        |
 
 Discovery uses IPv4 multicast with a time to live of `1`. Restrict this Layer-2 domain to trusted participating hosts: `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated. Tenant `0` can communicate with every tenant, so reserve it for trusted platform services.
 
@@ -90,7 +95,7 @@ atlas-wg-mesh vm remove --interface veth0 --address fdaa:1:0:7::1
 atlas-wg-mesh vm add --interface veth0 --address fdaa:1:0:7::1
 ```
 
-The `vm add` command sends five `NOW_HERE` messages. Hosts that already know the VM update the learned WireGuard path. The VM keeps its private IPv6 address.
+The `vm add` command sends three `NOW_HERE` messages. Hosts that already know the VM update the learned WireGuard path. The VM keeps its private IPv6 address.
 
 ## Remove a VM
 
@@ -147,6 +152,7 @@ Run this command to show the host configuration and local VM count:
 ```sh
 atlas-wg-mesh status
 ```
+
 
 ## Debug in production
 

--- a/services/wg-mesh/docs/unicast-network.md
+++ b/services/wg-mesh/docs/unicast-network.md
@@ -1,0 +1,50 @@
+# Unicast discovery networks
+
+Atlas WG Mesh normally uses IPv4 multicast for discovery. Use this guide only when the participating hosts cannot share that multicast Layer-2 domain.
+
+## When to use this
+
+Some cloud providers do not provide multicast natively. Use the discovery relay there as a unicast alternative to the normal multicast network.
+
+The relay forwards the multicast-style `WHO_HAS` and `NOW_HERE` messages to every configured peer. `FOUND` is already a unicast reply and does not go through the relay; it is sent with a time to live of 64, so it reaches a requester behind a router.
+
+## Requirements
+
+- Configure Atlas WG Mesh normally on every host.
+- Permit each host to send UDP port `7373` to every other participating host.
+- Create the same complete peer list on every host, using each host's reachable uplink IPv4 address. The local host is ignored if it appears, so the same file can be copied everywhere.
+- Keep the peer file writable only by trusted administrators. Discovery messages are not authenticated.
+
+For example, a peer file on host `10.20.0.10` can contain:
+
+```text
+10.20.0.11
+10.20.0.12
+```
+
+
+## Start the relay
+
+Run one relay on every participating host and keep it running with the host's service manager:
+
+```sh
+atlas-wg-mesh discovery-relay PEERS_FILE
+```
+
+Restart it automatically. A relay killed without running its cleanup leaves the BPF discovery redirect pointing at a TAP that no longer exists, and every `WHO_HAS` is dropped until the relay returns. `atlas-wg-mesh status` reports that state as a missing interface.
+
+The relay creates an `atlas-wg-relay` TAP device and sets BPF's discovery redirect to that device. It sends `WHO_HAS` and `NOW_HERE` messages as UDP unicast to every peer in the file. On clean exit, it restores BPF discovery delivery to the physical uplink, returning the host to its normal multicast behavior.
+
+A second relay exits rather than competing with the active one. `SIGTERM` and `SIGINT` use the clean shutdown path.
+
+Use `--verbose` to log each accepted message and each peer send.
+
+## Update peers
+
+The relay checks the peer file modification time once per second. When the file changes, it parses and atomically adopts the new list. If a changed file is invalid, the relay logs a warning and continues to use its previous valid list.
+
+Write a complete replacement file and rename it into place so the relay does not observe a partial edit.
+
+## Upgrade
+
+Run `atlas-wg-mesh upgrade` normally while the relay is running. The upgrade preserves the configured discovery interface, so the relay TAP stays active. Restart the relay after replacing its binary to run the new relay code.


### PR DESCRIPTION
  Add a discovery relay for environments where multicast is unavailable,
  such as some cloud VPCs.

  Atlas WG Mesh still uses multicast by default. When enabled, the relay
  forwards WHO_HAS and NOW_HERE messages to configured peers over UDP
  unicast. FOUND remains a direct reply between hosts.

  The relay reloads peer changes automatically, supports verbose logging,
  uses a single-instance lock, and restores multicast delivery on
  SIGTERM/SIGINT.

  See docs/unicast-network.md for setup and operational details.