### PR TITLE
feat(wg-mesh): Restrict cross-tenant access to privileged VMs

### DIFF
--- a/services/wg-mesh/bpf/address.h
+++ b/services/wg-mesh/bpf/address.h
@@ -23,13 +23,6 @@ static __always_inline __be32 get_tenant(const struct in6_addr *ipv6_address)
 	return ipv6_address->s6_addr32[1];
 }
 
-static __always_inline int tenants_can_communicate(const struct in6_addr *source, const struct in6_addr *destination)
-{
-	/* Tenant zero is reserved for trusted shared services such as proxies. */
-	return !get_tenant(source) || !get_tenant(destination) ||
-		   get_tenant(source) == get_tenant(destination);
-}
-
 static __always_inline int are_ipv6_addresses_equal(const struct in6_addr *left, const struct in6_addr *right)
 {
 	return left->s6_addr32[0] == right->s6_addr32[0] &&

--- a/services/wg-mesh/bpf/state.h
+++ b/services/wg-mesh/bpf/state.h
@@ -3,7 +3,7 @@
 #ifndef ATLAS_STATE_H
 #define ATLAS_STATE_H
 
-#include "protocol.h"
+#include "address.h"
 
 /* VMs connected to this host. The value is the ifindex of the interface that owns
  * the VM, so one VM cannot send traffic with another VM's source address. */
@@ -14,6 +14,16 @@ struct
 	__type(value, __u32);
 	__uint(max_entries, 4096);
 } local_vms SEC(".maps");
+
+/* Privileged-tenant addresses allowed to communicate with other tenants. The
+ * controller keeps this whitelist in sync on every host. */
+struct
+{
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct in6_addr);
+	__type(value, __u8);
+	__uint(max_entries, 4096);
+} privileged_tenant_allowed_addresses SEC(".maps");
 
 /* Learned remote VM-to-WireGuard-host locations. A miss sends WHO_HAS. */
 struct
@@ -77,6 +87,22 @@ static __always_inline int owns_source_address(
 	__u32 *owner = bpf_map_lookup_elem(&local_vms, virtual_machine);
 
 	return owner && *owner == ifindex;
+}
+
+/* Cross-tenant traffic is permitted only when one endpoint is a whitelisted
+ * privileged-tenant address. This preserves request and response traffic. */
+static __always_inline int tenants_can_communicate(
+	const struct in6_addr *source, const struct in6_addr *destination)
+{
+	if (get_tenant(source) == get_tenant(destination))
+		return 1;
+
+	if (get_tenant(source) == 0 &&
+		bpf_map_lookup_elem(&privileged_tenant_allowed_addresses, source) != NULL)
+		return 1;
+
+	return get_tenant(destination) == 0 &&
+		   bpf_map_lookup_elem(&privileged_tenant_allowed_addresses, destination) != NULL;
 }
 
 /* Get the remote location (WireGuard address of the bare metal host) of the given VM. */

--- a/services/wg-mesh/cli/commands.go
+++ b/services/wg-mesh/cli/commands.go
@@ -288,7 +288,15 @@ func showStatus() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("discovery interface: %s\nlocal VMs: %d\nremote locations: %d/%d\nWireGuard address: %s\n", discoveryInterfaceName(config), count, remoteCount, remoteCapacity, netip.AddrFrom16(config.WireGuardIPv6))
+	privilegedVMs, err := privilegedTenantAllowedAddresses()
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	privilegedCount := "unavailable"
+	if err == nil {
+		privilegedCount = fmt.Sprint(len(privilegedVMs))
+	}
+	fmt.Printf("discovery interface: %s\nlocal VMs: %d\nprivileged VMs: %s\nremote locations: %d/%d\nWireGuard address: %s\n", discoveryInterfaceName(config), count, privilegedCount, remoteCount, remoteCapacity, netip.AddrFrom16(config.WireGuardIPv6))
 	if config.WhoHasRate == 0 {
 		fmt.Println("WHO_HAS rate limit: disabled")
 	} else {

--- a/services/wg-mesh/cli/main.go
+++ b/services/wg-mesh/cli/main.go
@@ -29,6 +29,11 @@ func init() {
 	removeVirtualMachineCommand.MarkFlagRequired("interface")
 	removeVirtualMachineCommand.MarkFlagRequired("address")
 	listVirtualMachinesCommand.Flags().BoolVar(&listVirtualMachinesJSON, "json", false, "print JSON")
+	addPrivilegedVMCommand.Flags().StringVar(&privilegedVMAddress, "address", "", "privileged VM IPv6 address")
+	addPrivilegedVMCommand.MarkFlagRequired("address")
+	removePrivilegedVMCommand.Flags().StringVar(&privilegedVMAddress, "address", "", "privileged VM IPv6 address")
+	removePrivilegedVMCommand.MarkFlagRequired("address")
+	listPrivilegedVMCommand.Flags().BoolVar(&listPrivilegedVMJSON, "json", false, "print JSON")
 	resetCommand.Flags().BoolVar(&resetForce, "force", false, "detach VM hooks and remove BPF state even when local VM entries remain")
 
 	inspectCommand.Flags().StringVar(&inspectAddressText, "address", "", "VM IPv6 address")
@@ -48,10 +53,11 @@ func init() {
 	upgradeCommand.Flags().BoolVar(&upgradeForce, "force", false, "allow a state-breaking upgrade")
 
 	virtualMachineCommand.AddCommand(addVirtualMachineCommand, removeVirtualMachineCommand, listVirtualMachinesCommand)
+	privilegedVMCommand.AddCommand(addPrivilegedVMCommand, removePrivilegedVMCommand, listPrivilegedVMCommand)
 	debugCommand.AddCommand(debugStatusCommand, debugEnableCommand, debugDisableCommand, inspectCommand, dumpCommand, topCommand)
 	remoteCommand.AddCommand(remotePurgeCommand)
 	discoveryRelayCommand.Flags().BoolVar(&discoveryVerbose, "verbose", false, "log relayed discovery messages")
-	rootCommand.AddCommand(configureCommand, statusCommand, virtualMachineCommand, remoteCommand, debugCommand, discoveryRelayCommand, upgradeCommand, versionCommand, resetCommand)
+	rootCommand.AddCommand(configureCommand, statusCommand, virtualMachineCommand, privilegedVMCommand, remoteCommand, debugCommand, discoveryRelayCommand, upgradeCommand, versionCommand, resetCommand)
 }
 
 func main() {

--- a/services/wg-mesh/cli/network.go
+++ b/services/wg-mesh/cli/network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -155,6 +156,10 @@ func parseMeshAddress(addressText string) ([16]byte, error) {
 		return [16]byte{}, fmt.Errorf("%q is not in fdaa::/16", addressText)
 	}
 	return meshAddress, nil
+}
+
+func meshTenant(address [16]byte) uint32 {
+	return binary.BigEndian.Uint32(address[4:8])
 }
 
 func announceVirtualMachine(address [16]byte, config hostConfig) error {

--- a/services/wg-mesh/cli/privileged_vm.go
+++ b/services/wg-mesh/cli/privileged_vm.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"sort"
+
+	"github.com/cilium/ebpf"
+	"github.com/spf13/cobra"
+)
+
+const privilegedTenantAllowedAddressesMap = "privileged_tenant_allowed_addresses"
+
+var privilegedVMAddress string
+
+var listPrivilegedVMJSON bool
+
+var privilegedVMCommand = &cobra.Command{
+	Use:   "privileged-vm",
+	Short: "manage privileged VMs allowed to access other tenants",
+	Args:  cobra.NoArgs,
+	RunE:  showHelp,
+}
+
+var addPrivilegedVMCommand = &cobra.Command{
+	Use:   "add",
+	Short: "allow a privileged VM to access other tenants",
+	Args:  cobra.NoArgs,
+	RunE: func(*cobra.Command, []string) error {
+		return addPrivilegedVM(privilegedVMAddress)
+	},
+}
+
+var removePrivilegedVMCommand = &cobra.Command{
+	Use:   "remove",
+	Short: "remove a privileged VM's cross-tenant access",
+	Args:  cobra.NoArgs,
+	RunE: func(*cobra.Command, []string) error {
+		return removePrivilegedVM(privilegedVMAddress)
+	},
+}
+
+var listPrivilegedVMCommand = &cobra.Command{
+	Use:   "list",
+	Short: "list privileged VMs allowed to access other tenants",
+	Args:  cobra.NoArgs,
+	RunE: func(*cobra.Command, []string) error {
+		return listPrivilegedVMs()
+	},
+}
+
+func addPrivilegedVM(addressText string) error {
+	address, err := parsePrivilegedTenantAddress(addressText)
+	if err != nil {
+		return err
+	}
+	allowlist, err := openMap(privilegedTenantAllowedAddressesMap)
+	if err != nil {
+		return err
+	}
+	defer allowlist.Close()
+	if err := allowlist.Put(address, uint8(1)); err != nil {
+		return err
+	}
+	fmt.Printf("Privileged VM %s can access other tenants\n", netip.AddrFrom16(address))
+	return nil
+}
+
+func removePrivilegedVM(addressText string) error {
+	address, err := parsePrivilegedTenantAddress(addressText)
+	if err != nil {
+		return err
+	}
+	allowlist, err := openMap(privilegedTenantAllowedAddressesMap)
+	if err != nil {
+		return err
+	}
+	defer allowlist.Close()
+	if err := deletePrivilegedVMAddress(allowlist, address); err != nil {
+		return err
+	}
+	fmt.Printf("Privileged VM %s can no longer access other tenants\n", netip.AddrFrom16(address))
+	return nil
+}
+
+func listPrivilegedVMs() error {
+	addresses, err := privilegedTenantAllowedAddresses()
+	if err != nil {
+		return err
+	}
+	if listPrivilegedVMJSON {
+		return json.NewEncoder(os.Stdout).Encode(privilegedVMList(addresses))
+	}
+	for _, address := range addresses {
+		fmt.Println(address)
+	}
+	return nil
+}
+
+type privilegedVMListItem struct {
+	Address string `json:"address"`
+}
+
+func privilegedVMList(addresses []string) []privilegedVMListItem {
+	items := make([]privilegedVMListItem, len(addresses))
+	for index, address := range addresses {
+		items[index] = privilegedVMListItem{Address: address}
+	}
+	return items
+}
+
+func privilegedTenantAllowedAddresses() ([]string, error) {
+	allowlist, err := openMap(privilegedTenantAllowedAddressesMap)
+	if err != nil {
+		return nil, err
+	}
+	defer allowlist.Close()
+
+	addresses := make([]netip.Addr, 0)
+	var address [16]byte
+	var value uint8
+	iterator := allowlist.Iterate()
+	for iterator.Next(&address, &value) {
+		addresses = append(addresses, netip.AddrFrom16(address))
+	}
+	if err := iterator.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(addresses, func(left, right int) bool {
+		return addresses[left].Less(addresses[right])
+	})
+	entries := make([]string, len(addresses))
+	for index, address := range addresses {
+		entries[index] = address.String()
+	}
+	return entries, nil
+}
+
+func parsePrivilegedTenantAddress(addressText string) ([16]byte, error) {
+	address, err := parseMeshAddress(addressText)
+	if err != nil {
+		return [16]byte{}, err
+	}
+	if meshTenant(address) != 0 {
+		return [16]byte{}, fmt.Errorf("%q is not a privileged-tenant VM address", addressText)
+	}
+	return address, nil
+}
+
+func deletePrivilegedVMAddress(allowlist *ebpf.Map, address [16]byte) error {
+	err := allowlist.Delete(address)
+	if errors.Is(err, ebpf.ErrKeyNotExist) {
+		return nil
+	}
+	return err
+}

--- a/services/wg-mesh/cli/upgrade.go
+++ b/services/wg-mesh/cli/upgrade.go
@@ -205,7 +205,7 @@ func virtualMachineInterfaces() (map[[16]byte]string, error) {
 }
 
 func existingMaps() (map[string]*ebpf.Map, func(), error) {
-	names := []string{"config", "local_vms", "remote_vms", "discovery_limits", "debug_config", "debug_stats", "debug_events", "build_hash"}
+	names := []string{"config", "local_vms", privilegedTenantAllowedAddressesMap, "remote_vms", "discovery_limits", "debug_config", "debug_stats", "debug_events", "build_hash"}
 	maps := make(map[string]*ebpf.Map)
 	for _, name := range names {
 		bpfMap, err := openMap(name)

--- a/services/wg-mesh/docs/design.md
+++ b/services/wg-mesh/docs/design.md
@@ -37,7 +37,7 @@ Atlas WG Mesh owns traffic between VM addresses. A source address must be regist
 
 VMs use `fdaa::/16`; host WireGuard addresses use `fdab::/16`. The VM hook drops traffic to `fdab::/16`, so VMs cannot reach the host subnet through Atlas WG Mesh.
 
-Nonzero tenant IDs are isolated from each other. Tenant `0` can communicate with every tenant and must be assigned only to trusted platform services.
+Nonzero tenant IDs are isolated from each other. Cross-tenant traffic is permitted only when either endpoint is a privileged tenant-`0` VM whose full IPv6 address is in the controller-managed whitelist. This allows request and response traffic while preventing access to every other tenant-`0` VM.
 
 Discovery runs on a trusted multicast Layer-2 domain. `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated, so a host on that network can influence learned VM locations. On networks that use the [discovery relay](unicast-network.md), allow UDP port `7373` only between trusted relay peers; unicast discovery is not limited to the multicast TTL. WireGuard encrypts traffic only to configured peers.
 
@@ -55,6 +55,7 @@ Each VM defaults to 10 `WHO_HAS` messages per second with a burst of 50. This li
 | --- | --- |
 | `config` | Host configuration, the discovery interface, and discovery limits. |
 | `local_vms`, `remote_vms` | Local ownership and learned remote locations. |
+| `privileged_tenant_allowed_addresses` | Privileged-tenant VM addresses permitted to communicate across tenants. |
 | `discovery_limits` | Per-VM discovery rate-limit state. |
 | `debug_config`, `debug_stats`, `debug_events` | Optional debug state and events. |
 | `build_hash` | Installed BPF object hash. |

--- a/services/wg-mesh/docs/operations.md
+++ b/services/wg-mesh/docs/operations.md
@@ -14,6 +14,7 @@ The `atlas-wg-mesh` CLI configures local host and VM lifecycle state. It embeds 
   - [Move a VM](#move-a-vm)
   - [Remove a VM](#remove-a-vm)
   - [List local VM ownership](#list-local-vm-ownership)
+  - [Manage privileged VMs](#manage-privileged-vms)
   - [Rejoin after a dead declaration](#rejoin-after-a-dead-declaration)
   - [Check status](#check-status)
   - [Debug in production](#debug-in-production)
@@ -39,7 +40,7 @@ Atlas WG Mesh pins state at `/sys/fs/bpf/atlas-wg-mesh`.
 | WireGuard MTU              | 1420                                                                                        |
 | VM interface and guest MTU | 1380                                                                                        |
 
-Discovery uses IPv4 multicast with a time to live of `1`. Restrict this Layer-2 domain to trusted participating hosts: `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated. Tenant `0` can communicate with every tenant, so reserve it for trusted platform services.
+Discovery uses IPv4 multicast with a time to live of `1`. Restrict this Layer-2 domain to trusted participating hosts: `WHO_HAS`, `FOUND`, and `NOW_HERE` messages are not authenticated. Cross-tenant traffic is permitted only when one endpoint is a controller-whitelisted privileged tenant-`0` VM address, so reserve those addresses for trusted platform services.
 
 ## Build a release
 
@@ -105,7 +106,7 @@ Run this command before you delete the VM interface:
 atlas-wg-mesh vm remove --interface veth0 --address fdaa:1:0:7::1
 ```
 
-The command removes the VM hook, the local BPF map entry, and the host route.
+The command removes the VM hook, the local BPF map entry, and the host route. It does not change privileged-VM policy: when an address is retired or reassigned, the controller must remove it from the privileged VM whitelist separately.
 
 ## List local VM ownership
 
@@ -128,6 +129,19 @@ An `ifindex:N` value means the registered interface no longer exists.
 
 To clear that single orphaned ownership entry, run `vm remove` with the missing interface name and VM address. The command removes the map entry without resetting the rest of the host.
 
+## Manage privileged VMs
+
+Tenant-`0` is the privileged tenant. A privileged VM can communicate with other tenants only after the controller adds its full IPv6 address to the whitelist on each host. Other tenants can communicate only with those whitelisted privileged VMs, which preserves request and response traffic without exposing every tenant-`0` VM:
+
+```sh
+atlas-wg-mesh privileged-vm add --address fdaa:1:0:0::1
+atlas-wg-mesh privileged-vm remove --address fdaa:1:0:0::1
+atlas-wg-mesh privileged-vm list
+atlas-wg-mesh privileged-vm list --json
+```
+
+`list --json` returns an array of objects with an `address` field, matching the shape used by `vm list --json`. The controller owns reconciliation: compare those addresses with the desired privileged-tenant VM addresses, and use `add` and `remove` to apply the difference. The whitelist is BPF state shared by all local hooks, so its desired contents must be synced to every Atlas WG Mesh host.
+
 ## Rejoin after a dead declaration
 
 This is the normal controller rejoin path. It preserves the uplink and WireGuard hooks, healthy VM registrations, and learned remote locations:
@@ -147,7 +161,7 @@ Reconcile immediately when the host reconnects. Until stale entries are removed,
 
 ## Check status
 
-Run this command to show the host configuration and local VM count:
+Run this command to show the host configuration, local VM count, and privileged-VM count:
 
 ```sh
 atlas-wg-mesh status
@@ -166,7 +180,7 @@ Run the newer CLI binary on the host:
 atlas-wg-mesh upgrade
 ```
 
-It compares the embedded BPF hash, keeps compatible pinned maps, and replaces every Atlas WG Mesh hook. If the embedded BPF hash differs and maps are incompatible, run `atlas-wg-mesh upgrade --force`; it rebuilds BPF state, restores local VMs from their routes, and clears learned remote locations. When the hashes already match, `upgrade --force` does nothing.
+It compares the embedded BPF hash, keeps compatible pinned maps including `privileged_tenant_allowed_addresses`, and replaces every Atlas WG Mesh hook. If the embedded BPF hash differs and maps are incompatible, run `atlas-wg-mesh upgrade --force`; it rebuilds BPF state, restores local VMs from their routes, and clears learned remote locations. When the hashes already match, `upgrade --force` does nothing.
 
 Use `atlas-wg-mesh version` to show CLI and BPF hashes.
 
@@ -201,4 +215,4 @@ atlas-wg-mesh configure --uplink eth0 --wireguard wg0
 atlas-wg-mesh vm add --interface veth0 --address fdaa:1:0:7::1 --mtu 1380
 ```
 
-A forced reset also clears `remote_vms`; discovery rebuilds those entries.
+A forced reset also clears `remote_vms` and `privileged_tenant_allowed_addresses`; discovery rebuilds remote locations, while the controller must reconcile privileged VMs again.


### PR DESCRIPTION
Related https://github.com/frappe/atlas/pull/167

- Added a controller-managed privileged VM whitelist for tenant 0. Permit cross-tenant traffic only when either endpoint is a whitelisted privileged address, preserving request/response flows while isolating other tenant-0 VMs.
- Added privileged-vm CLI management with JSON output, preserve policy across compatible BPF upgrades, report its status count, and document controller reconciliation and lifecycle behavior.