### PR TITLE
fix(metal): Fix VM stop and its reported state

### DIFF
--- a/metal/docs/api.md
+++ b/metal/docs/api.md
@@ -25,7 +25,9 @@ the client polls `GET /vms/{id}` until `state` settles. A failure shows as
   "disk": { "size_mib": 2048, "used_mib": 137, "snapshots": 2 }
 }
 ```
-`state` ∈ `created | running | paused | stopped | failed | destroyed`.
+`state` ∈ `created | running | paused | stopped | failed | destroyed`. `state` is
+derived from the VM's systemd unit. A VM stopped on request reports `stopped`;
+`failed` means the VM died on its own.
 
 | Method | Path | Action |
 |---|---|---|

--- a/metal/docs/api.md
+++ b/metal/docs/api.md
@@ -48,9 +48,12 @@ install them at boot. metald assigns `id`/`ip`/`mac` and boots the guest.
 (a fresh jailer process) and reboots from its persisted disk and network; a
 running VM → `409`.
 
-**Stop** `POST /vms/{id}/stop` — `{ "force": false }`. `false` = Ctrl+Alt+Del,
-`true` = SIGKILL. The disk, network and state are kept, so the VM can be started
-again.
+**Stop** `POST /vms/{id}/stop` — `{ "force": false }`. `true` = SIGKILL at once.
+`false` sends Ctrl+Alt+Del and gives the guest 30s to shut itself down, then
+escalates to a systemd stop job. Firecracker delivers Ctrl+Alt+Del through its
+emulated i8042 controller, so a guest kernel built without an i8042 keyboard
+driver never sees it and always reaches the escalation. The disk, network and
+state are kept, so the VM can be started again.
 
 **Resize** `POST /vms/{id}/resize` — `{ "disk_mib" }`. `disk_mib` is grow-only; a
 smaller value → `409`. The disk grows online (`zfs set volsize` + firecracker

--- a/metal/internal/firecracker/machine.go
+++ b/metal/internal/firecracker/machine.go
@@ -67,12 +67,23 @@ func (m *machine) Start(ctx context.Context) error {
 }
 
 // Stop shuts the guest down: force sends SIGKILL via systemd, otherwise the
-// guest is asked to shut itself down first.
+// guest is asked to shut itself down first. Stop returns only once the process
+// has exited, so the VM state it leaves behind is truthful.
 func (m *machine) Stop(ctx context.Context, force bool) error {
 	if force {
-		return m.units.Kill(ctx, m.cfg.ID, syscall.SIGKILL)
+		if err := m.units.Kill(ctx, m.cfg.ID, syscall.SIGKILL); err != nil {
+			return err
+		}
+	} else if err := m.shutdownGuest(ctx); err != nil {
+		return err
 	}
-	return m.shutdownGuest(ctx)
+	if _, err := m.units.Wait(ctx, m.cfg.ID); err != nil {
+		return err
+	}
+	// systemd marks a unit failed when its main process is killed or exits
+	// non-zero, which a deliberate stop always is. Clear that, so a stopped VM
+	// reports StateStopped and only a real crash reports StateFailed.
+	return m.units.ResetFailed(ctx, m.cfg.ID)
 }
 
 // shutdownGuest sends Ctrl+Alt+Del and gives the guest stopTimeout to shut
@@ -99,6 +110,7 @@ func (m *machine) shutdownGuest(ctx context.Context) error {
 // so it is idempotent: a resource already gone is not an error.
 func (m *machine) Destroy(ctx context.Context) error {
 	_ = m.units.Stop(ctx, m.cfg.ID)
+	_ = m.units.ResetFailed(ctx, m.cfg.ID) // do not leave a failed unit behind
 	_ = m.net.Release(ctx, m.cfg.ID)
 	_ = m.images.Release(ctx, m.cfg.ID)
 	return os.RemoveAll(m.dir)

--- a/metal/internal/firecracker/machine.go
+++ b/metal/internal/firecracker/machine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/frappe/atlas/metal/internal/firecracker/api"
 	"github.com/frappe/atlas/metal/internal/network"
@@ -13,29 +14,35 @@ import (
 	"github.com/frappe/atlas/metal/internal/vm"
 )
 
+// defaultStopTimeout is how long a guest gets to shut itself down after
+// Ctrl+Alt+Del before metald escalates to a systemd stop job.
+const defaultStopTimeout = 30 * time.Second
+
 // machine implements vm.VM as a client-side handle: a systemd unit (metal-vm@id)
 // plus an API client over that unit's socket. It holds no child process.
 type machine struct {
-	cfg      vmConfig
-	dir      string // per-VM state dir
-	units    systemd.Manager
-	images   storage.Resolver
-	net      network.Allocator
-	api      *api.Client
-	persist  func(vmConfig) error        // rewrite the VM's config.json
-	relaunch func(context.Context) error // (re)start a stopped VM's jailer unit
+	cfg         vmConfig
+	dir         string // per-VM state dir
+	units       systemd.Manager
+	images      storage.Resolver
+	net         network.Allocator
+	api         *api.Client
+	stopTimeout time.Duration
+	persist     func(vmConfig) error        // rewrite the VM's config.json
+	relaunch    func(context.Context) error // (re)start a stopped VM's jailer unit
 }
 
 func (d *Driver) newMachine(vc vmConfig) *machine {
 	return &machine{
-		cfg:      vc,
-		dir:      d.cfg.vmDir(vc.ID),
-		units:    d.units,
-		images:   d.images,
-		net:      d.net,
-		api:      api.New(vc.Sock),
-		persist:  d.cfg.writeVMConfig,
-		relaunch: func(ctx context.Context) error { return d.relaunch(ctx, vc) },
+		cfg:         vc,
+		dir:         d.cfg.vmDir(vc.ID),
+		units:       d.units,
+		images:      d.images,
+		net:         d.net,
+		api:         api.New(vc.Sock),
+		stopTimeout: defaultStopTimeout,
+		persist:     d.cfg.writeVMConfig,
+		relaunch:    func(ctx context.Context) error { return d.relaunch(ctx, vc) },
 	}
 }
 
@@ -59,17 +66,33 @@ func (m *machine) Start(ctx context.Context) error {
 	return m.api.InstanceStart(ctx)
 }
 
-// Stop shuts the guest down: force sends SIGKILL via systemd, otherwise a
-// graceful Ctrl+Alt+Del followed by waiting (bounded by ctx) for exit.
+// Stop shuts the guest down: force sends SIGKILL via systemd, otherwise the
+// guest is asked to shut itself down first.
 func (m *machine) Stop(ctx context.Context, force bool) error {
 	if force {
 		return m.units.Kill(ctx, m.cfg.ID, syscall.SIGKILL)
 	}
+	return m.shutdownGuest(ctx)
+}
+
+// shutdownGuest sends Ctrl+Alt+Del and gives the guest stopTimeout to shut
+// itself down. Firecracker delivers the keys through its emulated i8042
+// controller, so a guest kernel built without an i8042 keyboard driver never
+// sees them. The wait is therefore bounded, and metald escalates to a systemd
+// stop job when the guest does not exit.
+func (m *machine) shutdownGuest(ctx context.Context) error {
 	if err := m.api.SendCtrlAltDel(ctx); err != nil {
 		return err
 	}
-	_, err := m.units.Wait(ctx, m.cfg.ID)
-	return err
+	wait, cancel := context.WithTimeout(ctx, m.stopTimeout)
+	defer cancel()
+	if _, err := m.units.Wait(wait, m.cfg.ID); err == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return m.units.Stop(ctx, m.cfg.ID)
 }
 
 // Destroy stops the unit and frees the VM's network, disk and state. Best-effort

--- a/metal/internal/firecracker/stop_test.go
+++ b/metal/internal/firecracker/stop_test.go
@@ -12,13 +12,16 @@ import (
 
 	"github.com/frappe/atlas/metal/internal/firecracker/api"
 	"github.com/frappe/atlas/metal/internal/systemd"
+	"github.com/frappe/atlas/metal/internal/vm"
 )
 
 // stubUnits is a systemd.Manager whose unit stays active until it is stopped or
 // killed. Wait blocks while the unit is active, like the D-Bus manager does.
+// A killed unit reports "failed" until ResetFailed clears it, as systemd does.
 type stubUnits struct {
 	mu     sync.Mutex
 	active bool
+	failed bool
 	stops  int
 	kills  int
 	waits  int
@@ -45,11 +48,27 @@ func (s *stubUnits) Kill(context.Context, string, syscall.Signal) error {
 	defer s.mu.Unlock()
 	s.kills++
 	s.active = false
+	s.failed = true
+	return nil
+}
+
+func (s *stubUnits) ResetFailed(context.Context, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failed = false
 	return nil
 }
 
 func (s *stubUnits) Status(context.Context, string) (systemd.Status, error) {
-	return systemd.Status{}, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch {
+	case s.failed:
+		return systemd.Status{ActiveState: "failed"}, nil
+	case s.active:
+		return systemd.Status{ActiveState: "active"}, nil
+	}
+	return systemd.Status{ActiveState: "inactive"}, nil
 }
 
 func (s *stubUnits) Wait(ctx context.Context, _ string) (systemd.Result, error) {
@@ -150,11 +169,48 @@ func TestStopForceKills(t *testing.T) {
 	if err := m.Stop(context.Background(), true); err != nil {
 		t.Fatal(err)
 	}
-	stops, kills, _ := units.counts()
+	stops, kills, waits := units.counts()
 	if kills != 1 {
 		t.Errorf("kills = %d, want 1", kills)
 	}
 	if stops != 0 {
 		t.Errorf("systemd stops = %d, want 0", stops)
+	}
+	if waits == 0 {
+		t.Error("Stop did not wait for the process to exit")
+	}
+}
+
+// systemd flags a unit killed out of band as failed. A VM stopped on purpose
+// must still report StateStopped.
+func TestStopClearsTheFailedUnitState(t *testing.T) {
+	for _, force := range []bool{true, false} {
+		units := &stubUnits{active: true}
+		m := testMachine(units, fcSocket(t, nil), 20*time.Millisecond)
+
+		if err := m.Stop(context.Background(), force); err != nil {
+			t.Fatalf("force=%v: %v", force, err)
+		}
+		st, err := units.Status(context.Background(), m.cfg.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := m.state(context.Background(), st); got != vm.StateStopped {
+			t.Errorf("force=%v: state = %q, want %q", force, got, vm.StateStopped)
+		}
+	}
+}
+
+// A VM that died on its own was not stopped on purpose, so it keeps StateFailed.
+func TestCrashedVMReportsFailed(t *testing.T) {
+	units := &stubUnits{failed: true}
+	m := testMachine(units, fcSocket(t, nil), time.Minute)
+
+	st, err := units.Status(context.Background(), m.cfg.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.state(context.Background(), st); got != vm.StateFailed {
+		t.Errorf("state = %q, want %q", got, vm.StateFailed)
 	}
 }

--- a/metal/internal/firecracker/stop_test.go
+++ b/metal/internal/firecracker/stop_test.go
@@ -1,0 +1,160 @@
+package firecracker
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/frappe/atlas/metal/internal/firecracker/api"
+	"github.com/frappe/atlas/metal/internal/systemd"
+)
+
+// stubUnits is a systemd.Manager whose unit stays active until it is stopped or
+// killed. Wait blocks while the unit is active, like the D-Bus manager does.
+type stubUnits struct {
+	mu     sync.Mutex
+	active bool
+	stops  int
+	kills  int
+	waits  int
+}
+
+func (s *stubUnits) shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = false
+}
+
+func (s *stubUnits) Start(context.Context, string) error { return nil }
+
+func (s *stubUnits) Stop(context.Context, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stops++
+	s.active = false
+	return nil
+}
+
+func (s *stubUnits) Kill(context.Context, string, syscall.Signal) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.kills++
+	s.active = false
+	return nil
+}
+
+func (s *stubUnits) Status(context.Context, string) (systemd.Status, error) {
+	return systemd.Status{}, nil
+}
+
+func (s *stubUnits) Wait(ctx context.Context, _ string) (systemd.Result, error) {
+	s.mu.Lock()
+	s.waits++
+	s.mu.Unlock()
+	for {
+		s.mu.Lock()
+		up := s.active
+		s.mu.Unlock()
+		if !up {
+			return systemd.Result{}, nil
+		}
+		select {
+		case <-ctx.Done():
+			return systemd.Result{}, ctx.Err()
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func (s *stubUnits) List(context.Context) ([]string, error)                  { return nil, nil }
+func (s *stubUnits) SetLimits(context.Context, string, systemd.Limits) error { return nil }
+
+func (s *stubUnits) counts() (stops, kills, waits int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stops, s.kills, s.waits
+}
+
+// fcSocket serves a firecracker API socket that accepts every request and runs
+// onRequest, which stands in for the guest reacting to the action.
+func fcSocket(t *testing.T, onRequest func()) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "fc.socket")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if onRequest != nil {
+			onRequest()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(l)
+	t.Cleanup(func() { srv.Close() })
+	return sock
+}
+
+func testMachine(units systemd.Manager, sock string, timeout time.Duration) *machine {
+	return &machine{
+		cfg:         vmConfig{ID: "abc", Sock: sock},
+		units:       units,
+		api:         api.New(sock),
+		stopTimeout: timeout,
+	}
+}
+
+// A guest without an i8042 keyboard driver never sees Ctrl+Alt+Del, so Stop must
+// give up waiting and let systemd terminate the VM.
+func TestStopEscalatesWhenGuestIgnoresCtrlAltDel(t *testing.T) {
+	units := &stubUnits{active: true}
+	m := testMachine(units, fcSocket(t, nil), 20*time.Millisecond)
+
+	if err := m.Stop(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	stops, kills, _ := units.counts()
+	if stops != 1 {
+		t.Errorf("systemd stops = %d, want 1", stops)
+	}
+	if kills != 0 {
+		t.Errorf("kills = %d, want 0", kills)
+	}
+}
+
+func TestStopLetsGuestShutItselfDown(t *testing.T) {
+	units := &stubUnits{active: true}
+	m := testMachine(units, fcSocket(t, units.shutdown), time.Minute)
+
+	if err := m.Stop(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	stops, kills, waits := units.counts()
+	if stops != 0 || kills != 0 {
+		t.Errorf("stops = %d, kills = %d, want 0 and 0", stops, kills)
+	}
+	if waits == 0 {
+		t.Error("Stop did not wait for the guest to exit")
+	}
+}
+
+func TestStopForceKills(t *testing.T) {
+	units := &stubUnits{active: true}
+	m := testMachine(units, fcSocket(t, nil), time.Minute)
+
+	if err := m.Stop(context.Background(), true); err != nil {
+		t.Fatal(err)
+	}
+	stops, kills, _ := units.counts()
+	if kills != 1 {
+		t.Errorf("kills = %d, want 1", kills)
+	}
+	if stops != 0 {
+		t.Errorf("systemd stops = %d, want 0", stops)
+	}
+}

--- a/metal/internal/systemd/dbus.go
+++ b/metal/internal/systemd/dbus.go
@@ -70,6 +70,10 @@ func (d *DBus) Kill(ctx context.Context, id string, sig syscall.Signal) error {
 	return d.conn.KillUnitWithTarget(ctx, unitName(id), sd.All, int32(sig))
 }
 
+func (d *DBus) ResetFailed(ctx context.Context, id string) error {
+	return d.conn.ResetFailedUnitContext(ctx, unitName(id))
+}
+
 func (d *DBus) Status(ctx context.Context, id string) (Status, error) {
 	unit := unitName(id)
 	props, err := d.conn.GetUnitPropertiesContext(ctx, unit)

--- a/metal/internal/systemd/manager.go
+++ b/metal/internal/systemd/manager.go
@@ -11,6 +11,8 @@ type Manager interface {
 	Start(ctx context.Context, id string) error
 	Stop(ctx context.Context, id string) error
 	Kill(ctx context.Context, id string, sig syscall.Signal) error
+	// ResetFailed clears a unit's failed state, so it reports inactive again.
+	ResetFailed(ctx context.Context, id string) error
 	Status(ctx context.Context, id string) (Status, error)
 	// Wait blocks until the unit goes inactive/failed and returns its result.
 	Wait(ctx context.Context, id string) (Result, error)


### PR DESCRIPTION
## Issue

A stop with `force=false` never returned. It sent Ctrl+Alt+Del and then waited on
the request context, which has no deadline. Firecracker delivers those keys
through its emulated i8042 controller, and the guest kernel in use
(`vmlinux-5.10.223` from the Firecracker CI bucket) contains no `i8042` or
`atkbd` symbols, so the guest never saw them.

A VM that was shut down then reported `state: "failed"`. A force stop killed the
unit with SIGKILL outside a systemd stop job, so systemd recorded an unexpected
death and left the unit failed. Nothing ever cleared it.

## Overview

Stop now bounds the graceful wait and escalates to a systemd stop job. It also
waits for the process to exit and clears the unit's failed state, so only a VM
that died on its own reports `failed`.

## Changes

- Give the guest 30s to shut itself down after Ctrl+Alt+Del, then escalate to a
  systemd stop job.
- Add `ResetFailed` to the systemd manager, backed by `ResetFailedUnit`.
- Clear the failed unit state after every stop that metald asked for, and on
  destroy.
- Wait for the process to exit before `Stop` returns, so a force stop no longer
  reports the VM as still running.
- Add tests for the escalation, the clean guest shutdown, the force path, and
  both state outcomes.
- Update `metal/docs/api.md`.

## Notes

`SuccessExitStatus=SIGKILL` in `metal-vm@.service` was the other option. It is
not used here because it would also hide a real crash, such as an OOM kill.
`ResetFailed` only clears the state that metald caused.

## Testing

`go test ./... -race` from `metal/`.