### PR TITLE
feat(metal): Add support for traffic bandwith limit and ip attach/detach

### DIFF
--- a/atlas/server/doctype/server_ip_address/server_ip_address.py
+++ b/atlas/server/doctype/server_ip_address/server_ip_address.py
@@ -51,13 +51,13 @@ class ServerIPAddress(Document):
 			frappe.throw(_("Detach this IP address before deletion."))
 		frappe.get_single("Atlas Settings").server_provider_controller.delete_ip(self.provider_resource_id)
 
-	def begin_assignment(self, server: Document, virtual_machine: str) -> None:
+	def begin_assignment(self, server: str, virtual_machine: str) -> None:
 		"""Set an attach intent for this address."""
 		if self.status != "Allocated":
 			frappe.throw(_("Server IP Address {0} is not available.").format(self.name))
 
 		self.status = "Attaching"
-		self.server = server.name
+		self.server = server
 		self.virtual_machine = virtual_machine
 		self.intent_version = (self.intent_version or 0) + 1
 		self.save(ignore_permissions=True)

--- a/atlas/vm/README.md
+++ b/atlas/vm/README.md
@@ -83,7 +83,7 @@ Egress controls internet reachability. It does not control mesh reachability.
 | Mode | VM can reach | Public IPv4 | Throughput limits |
 |---|---|---|---|
 | `uplink` | mesh peers and the internet | allowed | private and public |
-| `mesh` | mesh peers only | rejected | private only |
+| `mesh` | mesh peers only | rejected | private applied, public stored |
 | `none` | nothing | rejected | none |
 
 A public IPv4 address needs `uplink`. Atlas refuses `mesh` and `none` while an address is attached.

--- a/atlas/vm/README.md
+++ b/atlas/vm/README.md
@@ -35,7 +35,7 @@ Atlas never uploads memory or Firecracker state to S3. A memory snapshot needs a
 
 ## Machine image transfer
 
-The Create Machine Image action calls `POST /vms/{id}/snapshots`. Metal creates local staging and returns a UUIDv7. Atlas uses this UUID as the Virtual Machine Image name. A long background job then:
+The Create Machine Image action calls `POST /vms/{id}/snapshots`. Metal returns a UUIDv7 for local staging. Atlas uses it as the Virtual Machine Image name. A background job then:
 
 1. Creates separate S3 multipart uploads for `images/{image-id}/rootfs.img` and `images/{image-id}/kernel`.
 2. Signs 2 GiB upload parts for 24 hours.
@@ -43,7 +43,7 @@ The Create Machine Image action calls `POST /vms/{id}/snapshots`. Metal creates 
 4. Verifies the sizes, SHA-256 values, part numbers, ETags, and final S3 object sizes.
 5. Completes both uploads and deletes the local staging data.
 
-The image record keeps the source server, multipart upload IDs, transfer status, and an error. Retry Transfer continues from these values. `source_virtual_machine` is audit text only. Metal deletes staging data after 48 hours without activity.
+The image record keeps the source server, upload IDs, status, and errors. Retry Transfer uses these values. `source_virtual_machine` is audit text only. Metal deletes staging after 48 hours without activity.
 
 ## System image publisher
 
@@ -64,6 +64,31 @@ Atlas can replace the complete VM SSH key list without storing it in the Virtual
 Atlas stores custom VM metadata as key-value rows and sends it to Metal. Guests read each value from `latest/meta-data/attributes/<key>`.
 
 The Ubuntu image builder installs the Atlas cloud-init datasource. See [`build_ubuntu_server_image.sh`](scripts/build_ubuntu_server_image.sh).
+
+## Network changes
+
+Metal owns the VM network state. Atlas reads it, changes one setting, and sends all mutable settings with `PUT /vms/{name}/network`. It stops if Metal does not return the current state.
+
+| Action | Behavior |
+|---|---|
+| Attach IP Address | Sets an attach intent and sends the address with `uplink` egress. |
+| Detach IP Address | Sends an empty address and sets a detach intent. |
+| Edit Throughput Limits | Sends private and public limits in Mbps. `0` removes a limit. |
+| Change Egress Mode | Sends `uplink`, `mesh`, or `none`. |
+
+Atlas applies the Metal change before it releases an address. A VM can hold one public IPv4 address. Public IPv4, egress, and throughput limits can also be set during creation.
+
+Egress controls internet reachability. It does not control mesh reachability.
+
+| Mode | VM can reach | Public IPv4 | Throughput limits |
+|---|---|---|---|
+| `uplink` | mesh peers and the internet | allowed | private and public |
+| `mesh` | mesh peers only | rejected | private only |
+| `none` | nothing | rejected | none |
+
+A public IPv4 address needs `uplink`. Atlas refuses `mesh` and `none` while an address is attached.
+
+Active connections can stop when the public IPv4 address or the egress mode changes.
 
 ## Termination and deletion
 

--- a/atlas/vm/core/metal_client.py
+++ b/atlas/vm/core/metal_client.py
@@ -110,6 +110,17 @@ class MetalClient:
 			expected_status=200,
 		)
 
+	def update_virtual_machine_network(
+		self, virtual_machine_id: str, network: dict[str, Any]
+	) -> dict[str, Any]:
+		"""Replace the mutable network settings for one VM without a restart."""
+		return self._request(
+			"PUT",
+			f"/vms/{quote(virtual_machine_id, safe='')}/network",
+			json=network,
+			expected_status=200,
+		)
+
 	def resize_virtual_machine_disk(self, virtual_machine_id: str, disk_mib: int) -> None:
 		"""Ask Metal to increase one VM disk size."""
 		self._request(

--- a/atlas/vm/core/virtual_machine_manager.py
+++ b/atlas/vm/core/virtual_machine_manager.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 	from atlas.atlas.doctype.atlas_settings.atlas_settings import AtlasSettings
 	from atlas.server.doctype.server.server import Server
 	from atlas.server.doctype.server_ip_address.server_ip_address import ServerIPAddress
+	from atlas.vm.doctype.virtual_machine.virtual_machine import VirtualMachine
 	from atlas.vm.doctype.virtual_machine_image.virtual_machine_image import VirtualMachineImage
 
 
@@ -31,6 +32,8 @@ class VirtualMachineCreateRequest:
 	ssh_keys: tuple[str, ...] = ()
 	user_data: str = ""
 	egress: str = "host"
+	private_network_throughput_mbps: int = 0
+	public_network_throughput_mbps: int = 0
 	server_ip_address: str | None = None
 	metadata: dict[str, str] = field(default_factory=dict)
 
@@ -66,9 +69,19 @@ class VirtualMachineCreateRequest:
 			ssh_keys=tuple(str(payload.get("ssh_keys") or "").splitlines()),
 			user_data=str(payload.get("user_data") or ""),
 			egress=egress,
+			private_network_throughput_mbps=cls._throughput(payload, "private_network_throughput_mbps"),
+			public_network_throughput_mbps=cls._throughput(payload, "public_network_throughput_mbps"),
 			server_ip_address=payload.get("server_ip_address") or None,
 			metadata=cls._metadata(payload),
 		)
+
+	@staticmethod
+	def _throughput(payload: dict[str, Any], field: str) -> int:
+		"""Return one throughput limit in Mbps. A value of 0 does not apply a limit."""
+		value = payload.get(field) or 0
+		if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+			raise ValueError(f"{field} must be a non-negative integer.")
+		return value
 
 	@staticmethod
 	def _metadata(payload: dict[str, Any]) -> dict[str, str]:
@@ -130,7 +143,11 @@ class VirtualMachineManager:
 		server_name = cast(str, server.name)
 		virtual_machine = self.insert_draft(request, image_name, server_name)
 		virtual_machine_name = cast(str, virtual_machine.name)
-		server_ip_address = self.assign_ip_address(request.server_ip_address, server, virtual_machine_name)
+		server_ip_address = (
+			virtual_machine.assign_ip_address(request.server_ip_address)
+			if request.server_ip_address
+			else None
+		)
 		metal_request = self.get_metal_request(request, image, virtual_machine, server_ip_address)
 		frappe.db.commit()  # nosemgrep
 
@@ -204,7 +221,7 @@ class VirtualMachineManager:
 		)
 		return cast("Server", frappe.get_doc("Server", selected_capacity.server))
 
-	def insert_draft(self, request: VirtualMachineCreateRequest, image: str, server: str) -> Document:
+	def insert_draft(self, request: VirtualMachineCreateRequest, image: str, server: str) -> "VirtualMachine":
 		virtual_machine = frappe.get_doc(
 			{
 				"doctype": "Virtual Machine",
@@ -218,19 +235,7 @@ class VirtualMachineManager:
 			}
 		)
 		virtual_machine.flags.created_by_virtual_machine_api = True
-		return virtual_machine.insert(ignore_permissions=True)
-
-	def assign_ip_address(
-		self, name: str | None, server: "Server", virtual_machine: str
-	) -> "ServerIPAddress | None":
-		if not name:
-			return None
-		address = cast(
-			"ServerIPAddress",
-			frappe.get_doc("Server IP Address", name, for_update=True),
-		)
-		address.begin_assignment(server, virtual_machine)
-		return address
+		return cast("VirtualMachine", virtual_machine.insert(ignore_permissions=True))
 
 	def get_metal_request(
 		self,
@@ -251,6 +256,8 @@ class VirtualMachineManager:
 			"network": {
 				"public_ipv4": server_ip_address.address if server_ip_address else None,
 				"wireguard_mesh_ipv6": self.get_wireguard_mesh_ipv6(virtual_machine),
+				"private_network_throughput_mbps": request.private_network_throughput_mbps,
+				"public_network_throughput_mbps": request.public_network_throughput_mbps,
 				"egress": request.egress,
 			},
 		}

--- a/atlas/vm/core/virtual_machine_manager.py
+++ b/atlas/vm/core/virtual_machine_manager.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 	from atlas.vm.doctype.virtual_machine_image.virtual_machine_image import VirtualMachineImage
 
 
+EGRESS_MODES = ("uplink", "mesh", "none")
+
+
 @dataclass(frozen=True, slots=True)
 class VirtualMachineCreateRequest:
 	"""Store the validated values for one VM request."""
@@ -31,7 +34,7 @@ class VirtualMachineCreateRequest:
 	hostname: str = ""
 	ssh_keys: tuple[str, ...] = ()
 	user_data: str = ""
-	egress: str = "host"
+	egress: str = "uplink"
 	private_network_throughput_mbps: int = 0
 	public_network_throughput_mbps: int = 0
 	server_ip_address: str | None = None
@@ -55,9 +58,13 @@ class VirtualMachineCreateRequest:
 		if not isinstance(tenant_id, int) or isinstance(tenant_id, bool) or not 0 <= tenant_id <= 0xFFFFFFFF:
 			raise ValueError("Tenant ID must be a 32-bit unsigned integer.")
 
-		egress = payload.get("egress") or "host"
-		if egress not in {"host", "none"}:
-			raise ValueError("Egress must be host or none.")
+		egress = payload.get("egress") or "uplink"
+		if egress not in EGRESS_MODES:
+			raise ValueError("Egress must be uplink, mesh, or none.")
+
+		public_throughput = cls._throughput(payload, "public_network_throughput_mbps")
+		server_ip_address = payload.get("server_ip_address") or None
+		cls._validate_internet_path(egress, server_ip_address)
 
 		return cls(
 			virtual_machine_image=image,
@@ -70,10 +77,16 @@ class VirtualMachineCreateRequest:
 			user_data=str(payload.get("user_data") or ""),
 			egress=egress,
 			private_network_throughput_mbps=cls._throughput(payload, "private_network_throughput_mbps"),
-			public_network_throughput_mbps=cls._throughput(payload, "public_network_throughput_mbps"),
-			server_ip_address=payload.get("server_ip_address") or None,
+			public_network_throughput_mbps=public_throughput,
+			server_ip_address=server_ip_address,
 			metadata=cls._metadata(payload),
 		)
+
+	@staticmethod
+	def _validate_internet_path(egress: str, server_ip_address: str | None) -> None:
+		"""Reject a public IPv4 address when the mode has no internet path."""
+		if egress != "uplink" and server_ip_address:
+			raise ValueError("A public IPv4 address requires uplink egress.")
 
 	@staticmethod
 	def _throughput(payload: dict[str, Any], field: str) -> int:

--- a/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
+import frappe
 import requests
 from frappe.tests import UnitTestCase
 
@@ -11,6 +13,7 @@ from atlas.vm.core.virtual_machine_manager import (
 	VirtualMachineManager,
 )
 from atlas.vm.doctype.virtual_machine import virtual_machine as virtual_machine_module
+from atlas.vm.doctype.virtual_machine.virtual_machine import VirtualMachine
 
 
 class TestVirtualMachineRequest(UnitTestCase):
@@ -53,6 +56,34 @@ class TestVirtualMachineRequest(UnitTestCase):
 					"disk_mib": 10240,
 					"tenant_id": 7,
 					"metadata": {"": "value"},
+				}
+			)
+
+	def test_request_parses_throughput_limits(self) -> None:
+		request = VirtualMachineCreateRequest.from_value(
+			{
+				"virtual_machine_image": "Ubuntu 24.04",
+				"vcpus": 2,
+				"memory_mib": 2048,
+				"disk_mib": 10240,
+				"tenant_id": 7,
+				"private_network_throughput_mbps": 100,
+			}
+		)
+
+		self.assertEqual(request.private_network_throughput_mbps, 100)
+		self.assertEqual(request.public_network_throughput_mbps, 0)
+
+	def test_request_rejects_negative_throughput(self) -> None:
+		with self.assertRaises(ValueError):
+			VirtualMachineCreateRequest.from_value(
+				{
+					"virtual_machine_image": "Ubuntu 24.04",
+					"vcpus": 2,
+					"memory_mib": 2048,
+					"disk_mib": 10240,
+					"tenant_id": 7,
+					"public_network_throughput_mbps": -1,
 				}
 			)
 
@@ -105,6 +136,25 @@ class TestVirtualMachineManager(UnitTestCase):
 
 		self.assertEqual(metal_request["image"], image_request)
 		image.get_metal_image_request.assert_called_once_with("")
+
+	def test_metal_request_carries_throughput_limits(self) -> None:
+		request = VirtualMachineCreateRequest(
+			"machine-image",
+			2,
+			2048,
+			10240,
+			7,
+			private_network_throughput_mbps=100,
+			public_network_throughput_mbps=50,
+		)
+		image = SimpleNamespace(get_metal_image_request=Mock(return_value={}))
+		virtual_machine = SimpleNamespace(tenant_id=7, name="VM-00001")
+
+		with patch.object(VirtualMachineManager, "get_wireguard_mesh_ipv6", return_value="fdaa::1"):
+			metal_request = VirtualMachineManager().get_metal_request(request, image, virtual_machine, None)
+
+		self.assertEqual(metal_request["network"]["private_network_throughput_mbps"], 100)
+		self.assertEqual(metal_request["network"]["public_network_throughput_mbps"], 50)
 
 
 class TestMetalClient(UnitTestCase):
@@ -194,6 +244,27 @@ class TestMetalClient(UnitTestCase):
 		)
 		self.assertEqual(request.call_args.kwargs["json"], {"metadata": {"env": "prod"}})
 
+	def test_update_network_uses_vm_subresource(self) -> None:
+		client = MetalClient.__new__(MetalClient)
+		client.base_url = "http://10.0.0.2:9000"
+		client.headers = {"Authorization": "Bearer token"}
+		response = SimpleNamespace(status_code=200, content=b"{}", json=lambda: {})
+		network = {
+			"egress": "host",
+			"public_ipv4": "203.0.113.10",
+			"private_network_throughput_mbps": 100,
+			"public_network_throughput_mbps": 50,
+		}
+
+		with patch("atlas.vm.core.metal_client.requests.request", return_value=response) as request:
+			client.update_virtual_machine_network("VM-00001", network)
+
+		self.assertEqual(
+			request.call_args.args[:2],
+			("PUT", "http://10.0.0.2:9000/vms/VM-00001/network"),
+		)
+		self.assertEqual(request.call_args.kwargs["json"], network)
+
 	def test_snapshot_calls_use_unified_image_paths(self) -> None:
 		client = MetalClient.__new__(MetalClient)
 		client.base_url = "http://10.0.0.2:9000"
@@ -270,6 +341,176 @@ class TestMetalClient(UnitTestCase):
 			client.put_virtual_machine("VM-00001", {})
 
 		self.assertTrue(raised.exception.uncertain)
+
+
+class TestVirtualMachineNetwork(UnitTestCase):
+	"""Cover the live network updates that do not restart the VM."""
+
+	def build_virtual_machine(self, network: dict) -> tuple[VirtualMachine, Mock]:
+		virtual_machine = VirtualMachine.__new__(VirtualMachine)
+		virtual_machine.name = "VM-00001"
+		virtual_machine.server = "node-1"
+		virtual_machine.is_draft = 0
+		virtual_machine.is_terminating = 0
+
+		client = Mock()
+		client.get_virtual_machine.return_value = {"network": network}
+		client.update_virtual_machine_network.return_value = {"network": network}
+		return virtual_machine, client
+
+	def patches(self, client: Mock, address_name: str | None) -> tuple[Any, ...]:
+		return (
+			patch.object(virtual_machine_module, "MetalClient", return_value=client),
+			patch.object(virtual_machine_module.frappe, "get_doc", return_value=Mock()),
+			patch.object(virtual_machine_module.frappe, "only_for"),
+			patch.object(
+				virtual_machine_module.frappe,
+				"db",
+				Mock(exists=Mock(return_value=address_name)),
+			),
+		)
+
+	def test_update_network_keeps_the_unchanged_metal_values(self) -> None:
+		virtual_machine, client = self.build_virtual_machine(
+			{
+				"egress": "host",
+				"public_ipv4": "203.0.113.10",
+				"private_network_throughput_mbps": 100,
+				"public_network_throughput_mbps": 50,
+			}
+		)
+
+		with (
+			patch.object(virtual_machine_module, "MetalClient", return_value=client),
+			patch.object(virtual_machine_module.frappe, "get_doc", return_value=Mock()),
+		):
+			virtual_machine.update_network(public_network_throughput_mbps=25)
+
+		client.update_virtual_machine_network.assert_called_once_with(
+			"VM-00001",
+			{
+				"egress": "host",
+				"public_ipv4": "203.0.113.10",
+				"private_network_throughput_mbps": 100,
+				"public_network_throughput_mbps": 25,
+			},
+		)
+
+	def test_update_network_stops_when_metal_reports_no_settings(self) -> None:
+		"""An unknown current state must not detach the address through a default."""
+		virtual_machine, client = self.build_virtual_machine({})
+
+		with (
+			patch.object(virtual_machine_module, "MetalClient", return_value=client),
+			patch.object(virtual_machine_module.frappe, "get_doc", return_value=Mock()),
+			self.assertRaises(frappe.ValidationError),
+		):
+			virtual_machine.update_network(public_network_throughput_mbps=25)
+
+		client.update_virtual_machine_network.assert_not_called()
+
+	def test_update_network_rejects_a_draft(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		virtual_machine.is_draft = 1
+
+		with (
+			patch.object(virtual_machine_module, "MetalClient", return_value=client),
+			self.assertRaises(frappe.ValidationError),
+		):
+			virtual_machine.update_network(public_network_throughput_mbps=25)
+
+	def test_attach_ip_address_requests_host_egress(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "none"})
+		address = SimpleNamespace(address="203.0.113.10")
+		metal_client, get_doc, only_for, database = self.patches(client, None)
+
+		with (
+			metal_client,
+			get_doc,
+			only_for,
+			database,
+			patch.object(VirtualMachine, "assign_ip_address", return_value=address) as assign,
+		):
+			virtual_machine.attach_ip_address("203.0.113.10")
+
+		assign.assert_called_once_with("203.0.113.10")
+		request = client.update_virtual_machine_network.call_args.args[1]
+		self.assertEqual(request["egress"], "host")
+		self.assertEqual(request["public_ipv4"], "203.0.113.10")
+
+	def test_attach_ip_address_rejects_a_second_address(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
+
+		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+			virtual_machine.attach_ip_address("203.0.113.11")
+
+		client.update_virtual_machine_network.assert_not_called()
+
+	def test_detach_ip_address_updates_metal_before_the_release(self) -> None:
+		virtual_machine, client = self.build_virtual_machine(
+			{"egress": "host", "public_ipv4": "203.0.113.10"}
+		)
+		calls: list[str] = []
+		client.update_virtual_machine_network.side_effect = lambda *arguments: calls.append("metal") or {}
+		metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
+
+		with (
+			metal_client,
+			get_doc,
+			only_for,
+			database,
+			patch.object(
+				VirtualMachine,
+				"release_ip_address",
+				side_effect=lambda self=None: calls.append("release"),
+			),
+		):
+			virtual_machine.detach_ip_address()
+
+		self.assertEqual(calls, ["metal", "release"])
+		request = client.update_virtual_machine_network.call_args.args[1]
+		self.assertEqual(request["public_ipv4"], "")
+		self.assertEqual(request["egress"], "host")
+
+	def test_update_egress_sends_the_new_mode(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		metal_client, get_doc, only_for, database = self.patches(client, None)
+
+		with metal_client, get_doc, only_for, database:
+			virtual_machine.update_egress("none")
+
+		self.assertEqual(client.update_virtual_machine_network.call_args.args[1]["egress"], "none")
+
+	def test_update_egress_rejects_an_unknown_mode(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		metal_client, get_doc, only_for, database = self.patches(client, None)
+
+		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+			virtual_machine.update_egress("server")
+
+		client.update_virtual_machine_network.assert_not_called()
+
+	def test_update_egress_keeps_host_uplink_for_an_attached_address(self) -> None:
+		"""Metal forces host egress for a public IPv4 address, so Atlas refuses the change."""
+		virtual_machine, client = self.build_virtual_machine(
+			{"egress": "host", "public_ipv4": "203.0.113.10"}
+		)
+		metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
+
+		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+			virtual_machine.update_egress("none")
+
+		client.update_virtual_machine_network.assert_not_called()
+
+	def test_update_network_throughput_rejects_negative_values(self) -> None:
+		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		metal_client, get_doc, only_for, database = self.patches(client, None)
+
+		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+			virtual_machine.update_network_throughput(-1, 0)
+
+		client.update_virtual_machine_network.assert_not_called()
 
 
 class TestReconcileTerminating(UnitTestCase):

--- a/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
@@ -30,7 +30,7 @@ class TestVirtualMachineRequest(UnitTestCase):
 		)
 
 		self.assertEqual(request.ssh_keys, ("key-one", "key-two"))
-		self.assertEqual(request.egress, "host")
+		self.assertEqual(request.egress, "uplink")
 
 	def test_request_parses_metadata(self) -> None:
 		request = VirtualMachineCreateRequest.from_value(
@@ -73,6 +73,38 @@ class TestVirtualMachineRequest(UnitTestCase):
 
 		self.assertEqual(request.private_network_throughput_mbps, 100)
 		self.assertEqual(request.public_network_throughput_mbps, 0)
+
+	def test_request_accepts_mesh_egress(self) -> None:
+		request = VirtualMachineCreateRequest.from_value(
+			{
+				"virtual_machine_image": "Ubuntu 24.04",
+				"vcpus": 2,
+				"memory_mib": 2048,
+				"disk_mib": 10240,
+				"tenant_id": 7,
+				"egress": "mesh",
+				"private_network_throughput_mbps": 100,
+			}
+		)
+
+		self.assertEqual(request.egress, "mesh")
+		self.assertEqual(request.private_network_throughput_mbps, 100)
+
+	def test_request_rejects_a_public_address_without_uplink(self) -> None:
+		base = {
+			"virtual_machine_image": "Ubuntu 24.04",
+			"vcpus": 2,
+			"memory_mib": 2048,
+			"disk_mib": 10240,
+			"tenant_id": 7,
+			"egress": "mesh",
+		}
+		with self.assertRaises(ValueError):
+			VirtualMachineCreateRequest.from_value({**base, "server_ip_address": "203.0.113.10"})
+
+		# A public limit is stored, not rejected, so a mode change needs no cleanup.
+		request = VirtualMachineCreateRequest.from_value({**base, "public_network_throughput_mbps": 50})
+		self.assertEqual(request.public_network_throughput_mbps, 50)
 
 	def test_request_rejects_negative_throughput(self) -> None:
 		with self.assertRaises(ValueError):
@@ -250,7 +282,7 @@ class TestMetalClient(UnitTestCase):
 		client.headers = {"Authorization": "Bearer token"}
 		response = SimpleNamespace(status_code=200, content=b"{}", json=lambda: {})
 		network = {
-			"egress": "host",
+			"egress": "uplink",
 			"public_ipv4": "203.0.113.10",
 			"private_network_throughput_mbps": 100,
 			"public_network_throughput_mbps": 50,
@@ -373,7 +405,7 @@ class TestVirtualMachineNetwork(UnitTestCase):
 	def test_update_network_keeps_the_unchanged_metal_values(self) -> None:
 		virtual_machine, client = self.build_virtual_machine(
 			{
-				"egress": "host",
+				"egress": "uplink",
 				"public_ipv4": "203.0.113.10",
 				"private_network_throughput_mbps": 100,
 				"public_network_throughput_mbps": 50,
@@ -389,7 +421,7 @@ class TestVirtualMachineNetwork(UnitTestCase):
 		client.update_virtual_machine_network.assert_called_once_with(
 			"VM-00001",
 			{
-				"egress": "host",
+				"egress": "uplink",
 				"public_ipv4": "203.0.113.10",
 				"private_network_throughput_mbps": 100,
 				"public_network_throughput_mbps": 25,
@@ -410,7 +442,7 @@ class TestVirtualMachineNetwork(UnitTestCase):
 		client.update_virtual_machine_network.assert_not_called()
 
 	def test_update_network_rejects_a_draft(self) -> None:
-		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		virtual_machine, client = self.build_virtual_machine({"egress": "uplink"})
 		virtual_machine.is_draft = 1
 
 		with (
@@ -435,11 +467,11 @@ class TestVirtualMachineNetwork(UnitTestCase):
 
 		assign.assert_called_once_with("203.0.113.10")
 		request = client.update_virtual_machine_network.call_args.args[1]
-		self.assertEqual(request["egress"], "host")
+		self.assertEqual(request["egress"], "uplink")
 		self.assertEqual(request["public_ipv4"], "203.0.113.10")
 
 	def test_attach_ip_address_rejects_a_second_address(self) -> None:
-		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		virtual_machine, client = self.build_virtual_machine({"egress": "uplink"})
 		metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
 
 		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
@@ -449,7 +481,7 @@ class TestVirtualMachineNetwork(UnitTestCase):
 
 	def test_detach_ip_address_updates_metal_before_the_release(self) -> None:
 		virtual_machine, client = self.build_virtual_machine(
-			{"egress": "host", "public_ipv4": "203.0.113.10"}
+			{"egress": "uplink", "public_ipv4": "203.0.113.10"}
 		)
 		calls: list[str] = []
 		client.update_virtual_machine_network.side_effect = lambda *arguments: calls.append("metal") or {}
@@ -471,19 +503,19 @@ class TestVirtualMachineNetwork(UnitTestCase):
 		self.assertEqual(calls, ["metal", "release"])
 		request = client.update_virtual_machine_network.call_args.args[1]
 		self.assertEqual(request["public_ipv4"], "")
-		self.assertEqual(request["egress"], "host")
+		self.assertEqual(request["egress"], "uplink")
 
 	def test_update_egress_sends_the_new_mode(self) -> None:
-		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		virtual_machine, client = self.build_virtual_machine({"egress": "uplink"})
 		metal_client, get_doc, only_for, database = self.patches(client, None)
 
 		with metal_client, get_doc, only_for, database:
-			virtual_machine.update_egress("none")
+			virtual_machine.update_egress("mesh")
 
-		self.assertEqual(client.update_virtual_machine_network.call_args.args[1]["egress"], "none")
+		self.assertEqual(client.update_virtual_machine_network.call_args.args[1]["egress"], "mesh")
 
 	def test_update_egress_rejects_an_unknown_mode(self) -> None:
-		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+		virtual_machine, client = self.build_virtual_machine({"egress": "uplink"})
 		metal_client, get_doc, only_for, database = self.patches(client, None)
 
 		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
@@ -491,26 +523,43 @@ class TestVirtualMachineNetwork(UnitTestCase):
 
 		client.update_virtual_machine_network.assert_not_called()
 
-	def test_update_egress_keeps_host_uplink_for_an_attached_address(self) -> None:
-		"""Metal forces host egress for a public IPv4 address, so Atlas refuses the change."""
+	def test_update_egress_keeps_the_internet_path_for_an_attached_address(self) -> None:
+		"""A public IPv4 address needs uplink, so Atlas refuses mesh and none."""
 		virtual_machine, client = self.build_virtual_machine(
-			{"egress": "host", "public_ipv4": "203.0.113.10"}
+			{"egress": "uplink", "public_ipv4": "203.0.113.10"}
 		)
-		metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
 
-		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
-			virtual_machine.update_egress("none")
+		for egress in ("mesh", "none"):
+			metal_client, get_doc, only_for, database = self.patches(client, "203.0.113.10")
+			with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+				virtual_machine.update_egress(egress)
 
 		client.update_virtual_machine_network.assert_not_called()
 
-	def test_update_network_throughput_rejects_negative_values(self) -> None:
-		virtual_machine, client = self.build_virtual_machine({"egress": "host"})
+	def test_update_network_throughput_rejects_bad_values(self) -> None:
+		"""A malformed value must fail, not silently become 0 and remove the limit."""
+		virtual_machine, client = self.build_virtual_machine({"egress": "uplink"})
+
+		for private, public in ((-1, 0), ("abc", 0), (0, "")):
+			metal_client, get_doc, only_for, database = self.patches(client, None)
+			with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
+				virtual_machine.update_network_throughput(private, public)
+
+		client.update_virtual_machine_network.assert_not_called()
+
+	def test_update_egress_keeps_a_stored_public_limit(self) -> None:
+		"""Atlas resends every setting, so a stored public limit must not block a mode change."""
+		virtual_machine, client = self.build_virtual_machine(
+			{"egress": "uplink", "public_network_throughput_mbps": 31}
+		)
 		metal_client, get_doc, only_for, database = self.patches(client, None)
 
-		with metal_client, get_doc, only_for, database, self.assertRaises(frappe.ValidationError):
-			virtual_machine.update_network_throughput(-1, 0)
+		with metal_client, get_doc, only_for, database:
+			virtual_machine.update_egress("mesh")
 
-		client.update_virtual_machine_network.assert_not_called()
+		request = client.update_virtual_machine_network.call_args.args[1]
+		self.assertEqual(request["egress"], "mesh")
+		self.assertEqual(request["public_network_throughput_mbps"], 31)
 
 
 class TestReconcileTerminating(UnitTestCase):

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -366,7 +366,7 @@ function showAttachIPAddressDialog(frm) {
 			label: __("Server IP Address"),
 			options: "Server IP Address",
 			reqd: 1,
-			get_query: () => ({ filters: { status: "Allocated" } }),
+			filters: { status: "Allocated" },
 		},
 		({ server_ip_address }) =>
 			frm

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -29,11 +29,11 @@ frappe.ui.form.on("Virtual Machine", {
 		}
 
 		[
-			[__("Start"), "start", is_stopped, __("Starting...")],
-			[__("Stop"), "stop", is_running || is_paused, __("Stopping...")],
-			[__("Reboot"), "reboot", is_running, __("Rebooting...")],
-			[__("Pause"), "pause", is_running, __("Pausing...")],
-			[__("Resume"), "resume", is_paused, __("Resuming...")],
+			[__("Start VM"), "start", is_stopped, __("Starting...")],
+			[__("Stop VM"), "stop", is_running || is_paused, __("Stopping...")],
+			[__("Reboot VM"), "reboot", is_running, __("Rebooting...")],
+			[__("Pause VM"), "pause", is_running, __("Pausing...")],
+			[__("Resume VM"), "resume", is_paused, __("Resuming...")],
 		].forEach(([label, method, condition, freeze_message]) => {
 			if (!condition) {
 				return;
@@ -49,7 +49,7 @@ frappe.ui.form.on("Virtual Machine", {
 		});
 
 		frm.add_custom_button(
-			__("Snapshot"),
+			__("Snapshot VM"),
 			() => showCreateMachineImageDialog(frm),
 			__("Actions")
 		);
@@ -72,7 +72,30 @@ frappe.ui.form.on("Virtual Machine", {
 			__("Actions")
 		);
 		frm.add_custom_button(
-			__("Terminate"),
+			__("Edit Network Throughput"),
+			() => showEditThroughputDialog(frm),
+			__("Actions")
+		);
+		frm.add_custom_button(
+			__("Change Egress Mode"),
+			() => showEgressDialog(frm),
+			__("Actions")
+		);
+		if (frm.doc.public_ipv4) {
+			frm.add_custom_button(
+				__("Detach IP Address"),
+				() => detachIPAddress(frm),
+				__("Actions")
+			);
+		} else {
+			frm.add_custom_button(
+				__("Attach IP Address"),
+				() => showAttachIPAddressDialog(frm),
+				__("Actions")
+			);
+		}
+		frm.add_custom_button(
+			__("Terminate VM"),
 			() =>
 				frm
 					.call({
@@ -271,5 +294,108 @@ function showResizeComputeDialog(frm) {
 				.then(() => frm.reload_doc()),
 		__("Resize Compute"),
 		__("Resize")
+	);
+}
+
+function showEditThroughputDialog(frm) {
+	frappe.prompt(
+		[
+			{
+				fieldname: "private_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Private Throughput (Mbps)"),
+				default: frm.doc.private_network_throughput_mbps,
+				description: __("0 does not apply a limit."),
+			},
+			{
+				fieldname: "public_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Public Throughput (Mbps)"),
+				default: frm.doc.public_network_throughput_mbps,
+				description: __("0 does not apply a limit."),
+			},
+		],
+		(values) =>
+			frm
+				.call({
+					method: "update_network_throughput",
+					doc: frm.doc,
+					args: values,
+					freeze: true,
+					freeze_message: __("Updating throughput limits..."),
+				})
+				.then(() => frm.reload_doc()),
+		__("Edit Network Throughput"),
+		__("Save")
+	);
+}
+
+function showEgressDialog(frm) {
+	frappe.prompt(
+		{
+			fieldname: "egress",
+			fieldtype: "Select",
+			label: __("Egress"),
+			options: ["host", "none"],
+			reqd: 1,
+			default: frm.doc.egress,
+			description: __(
+				"none leaves the VM without a host uplink. Active connections can stop."
+			),
+		},
+		({ egress }) =>
+			frm
+				.call({
+					method: "update_egress",
+					doc: frm.doc,
+					args: { egress },
+					freeze: true,
+					freeze_message: __("Changing egress mode..."),
+				})
+				.then(() => frm.reload_doc()),
+		__("Change Egress Mode"),
+		__("Save")
+	);
+}
+
+function showAttachIPAddressDialog(frm) {
+	frappe.prompt(
+		{
+			fieldname: "server_ip_address",
+			fieldtype: "Link",
+			label: __("Server IP Address"),
+			options: "Server IP Address",
+			reqd: 1,
+			get_query: () => ({ filters: { status: "Allocated" } }),
+		},
+		({ server_ip_address }) =>
+			frm
+				.call({
+					method: "attach_ip_address",
+					doc: frm.doc,
+					args: { server_ip_address },
+					freeze: true,
+					freeze_message: __("Attaching IP address..."),
+				})
+				.then(() => frm.reload_doc()),
+		__("Attach IP Address"),
+		__("Attach")
+	);
+}
+
+function detachIPAddress(frm) {
+	frappe.confirm(
+		__("Detach {0} from this Virtual Machine? Active connections can stop.", [
+			frm.doc.public_ipv4,
+		]),
+		() =>
+			frm
+				.call({
+					method: "detach_ip_address",
+					doc: frm.doc,
+					freeze: true,
+					freeze_message: __("Detaching IP address..."),
+				})
+				.then(() => frm.reload_doc())
 	);
 }

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -336,11 +336,11 @@ function showEgressDialog(frm) {
 			fieldname: "egress",
 			fieldtype: "Select",
 			label: __("Egress"),
-			options: ["host", "none"],
+			options: ["uplink", "mesh", "none"],
 			reqd: 1,
 			default: frm.doc.egress,
 			description: __(
-				"none leaves the VM without a host uplink. Active connections can stop."
+				"uplink reaches the internet. mesh reaches tenant VMs only. none isolates the VM. Active connections can stop."
 			),
 		},
 		({ egress }) =>

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -24,9 +24,11 @@
   "section_break_network",
   "egress",
   "wireguard_mesh_ipv6",
+  "private_network_throughput_mbps",
   "column_break_network",
   "public_ipv4",
   "mac",
+  "public_network_throughput_mbps",
   "other_data_section",
   "ssh_keys",
   "metadata"
@@ -176,6 +178,20 @@
    "read_only": 1
   },
   {
+   "fieldname": "private_network_throughput_mbps",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Private Throughput (Mbps)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "public_network_throughput_mbps",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Public Throughput (Mbps)",
+   "read_only": 1
+  },
+  {
    "fieldname": "ssh_keys",
    "fieldtype": "Small Text",
    "is_virtual": 1,
@@ -210,7 +226,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2026-09-04 19:10:51.233607",
+ "modified": "2026-09-05 09:55:41.374911",
  "modified_by": "Administrator",
  "module": "VM",
  "name": "Virtual Machine",

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -9,7 +9,7 @@ from frappe.model.document import Document
 from frappe.utils import add_to_date, cint, now_datetime
 
 from atlas.vm.core.metal_client import MetalClient, MetalClientError, throw_metal_error
-from atlas.vm.core.virtual_machine_manager import VirtualMachineManager
+from atlas.vm.core.virtual_machine_manager import EGRESS_MODES, VirtualMachineManager
 
 if TYPE_CHECKING:
 	from atlas.server.doctype.server_ip_address.server_ip_address import ServerIPAddress
@@ -232,7 +232,7 @@ class VirtualMachine(Document):
 			frappe.throw(_("Detach the current public IPv4 address first."))
 
 		address = self.assign_ip_address(server_ip_address)
-		return self.update_network(egress="host", public_ipv4=address.address)
+		return self.update_network(egress="uplink", public_ipv4=address.address)
 
 	@frappe.whitelist(methods=["POST"])
 	def detach_ip_address(self) -> dict[str, Any]:
@@ -247,12 +247,12 @@ class VirtualMachine(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def update_egress(self, egress: str) -> dict[str, Any]:
-		"""Change the host uplink mode without a VM restart."""
+		"""Change internet reachability without a VM restart. Mesh reachability does not change."""
 		frappe.only_for("System Manager")
-		if egress not in {"host", "none"}:
-			frappe.throw(_("Egress must be host or none."))
-		if egress == "none" and frappe.db.exists("Server IP Address", {"virtual_machine": self.name}):
-			frappe.throw(_("Detach the public IPv4 address before you remove host egress."))
+		if egress not in EGRESS_MODES:
+			frappe.throw(_("Egress must be uplink, mesh, or none."))
+		if egress != "uplink" and frappe.db.exists("Server IP Address", {"virtual_machine": self.name}):
+			frappe.throw(_("Detach the public IPv4 address before you remove the internet path."))
 
 		return self.update_network(egress=egress)
 
@@ -262,14 +262,21 @@ class VirtualMachine(Document):
 	) -> dict[str, Any]:
 		"""Change the throughput limits in Mbps without a VM restart. A value of 0 removes the limit."""
 		frappe.only_for("System Manager")
-		limits = {
-			"private_network_throughput_mbps": cint(private_network_throughput_mbps),
-			"public_network_throughput_mbps": cint(public_network_throughput_mbps),
-		}
-		if any(value < 0 for value in limits.values()):
-			frappe.throw(_("Network throughput must not be negative."))
+		return self.update_network(
+			private_network_throughput_mbps=self.parse_throughput(private_network_throughput_mbps),
+			public_network_throughput_mbps=self.parse_throughput(public_network_throughput_mbps),
+		)
 
-		return self.update_network(**limits)
+	def parse_throughput(self, value: object) -> int:
+		"""Return one throughput limit in Mbps. A malformed value is an error, not 0."""
+		try:
+			throughput = int(str(value).strip())
+		except TypeError, ValueError:
+			frappe.throw(_("Network throughput must be a whole number of Mbps."))
+			raise AssertionError from None
+		if throughput < 0:
+			frappe.throw(_("Network throughput must not be negative."))
+		return throughput
 
 	def update_network(self, **changes: Any) -> dict[str, Any]:
 		"""Send the complete desired network settings to Metal.

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import frappe
 from frappe import _, request_cache
@@ -10,6 +10,9 @@ from frappe.utils import add_to_date, cint, now_datetime
 
 from atlas.vm.core.metal_client import MetalClient, MetalClientError, throw_metal_error
 from atlas.vm.core.virtual_machine_manager import VirtualMachineManager
+
+if TYPE_CHECKING:
+	from atlas.server.doctype.server_ip_address.server_ip_address import ServerIPAddress
 
 DRAFT_EXPIRY_MINUTES = 2
 
@@ -67,6 +70,15 @@ class VirtualMachine(Document):
 				frappe.throw(_("Terminate Virtual Machine {0} before deletion.").format(self.name))
 		self.release_ip_address()
 
+	def assign_ip_address(self, server_ip_address: str) -> "ServerIPAddress":
+		"""Set an attach intent for one reserved address."""
+		address = cast(
+			"ServerIPAddress",
+			frappe.get_doc("Server IP Address", server_ip_address, for_update=True),
+		)
+		address.begin_assignment(self.server, self.name)
+		return address
+
 	def release_ip_address(self) -> None:
 		address_name = frappe.db.get_value("Server IP Address", {"virtual_machine": self.name})
 		if address_name:
@@ -109,6 +121,14 @@ class VirtualMachine(Document):
 	@property
 	def public_ipv4(self) -> str | None:
 		return (self.get_metal_vm_info().get("network") or {}).get("public_ipv4")
+
+	@property
+	def private_network_throughput_mbps(self) -> int:
+		return (self.get_metal_vm_info().get("network") or {}).get("private_network_throughput_mbps") or 0
+
+	@property
+	def public_network_throughput_mbps(self) -> int:
+		return (self.get_metal_vm_info().get("network") or {}).get("public_network_throughput_mbps") or 0
 
 	@property
 	def ssh_keys(self) -> str:
@@ -200,6 +220,81 @@ class VirtualMachine(Document):
 			return MetalClient(frappe.get_doc("Server", self.server)).replace_virtual_machine_metadata(
 				self.name, metadata
 			)
+		except MetalClientError as error:
+			throw_metal_error(error)
+			raise AssertionError from error
+
+	@frappe.whitelist(methods=["POST"])
+	def attach_ip_address(self, server_ip_address: str) -> dict[str, Any]:
+		"""Attach one reserved public IPv4 address without a VM restart."""
+		frappe.only_for("System Manager")
+		if frappe.db.exists("Server IP Address", {"virtual_machine": self.name}):
+			frappe.throw(_("Detach the current public IPv4 address first."))
+
+		address = self.assign_ip_address(server_ip_address)
+		return self.update_network(egress="host", public_ipv4=address.address)
+
+	@frappe.whitelist(methods=["POST"])
+	def detach_ip_address(self) -> dict[str, Any]:
+		"""Remove the public IPv4 address without a VM restart."""
+		frappe.only_for("System Manager")
+		if not frappe.db.exists("Server IP Address", {"virtual_machine": self.name}):
+			frappe.throw(_("This Virtual Machine has no public IPv4 address."))
+
+		information = self.update_network(public_ipv4="")
+		self.release_ip_address()
+		return information
+
+	@frappe.whitelist(methods=["POST"])
+	def update_egress(self, egress: str) -> dict[str, Any]:
+		"""Change the host uplink mode without a VM restart."""
+		frappe.only_for("System Manager")
+		if egress not in {"host", "none"}:
+			frappe.throw(_("Egress must be host or none."))
+		if egress == "none" and frappe.db.exists("Server IP Address", {"virtual_machine": self.name}):
+			frappe.throw(_("Detach the public IPv4 address before you remove host egress."))
+
+		return self.update_network(egress=egress)
+
+	@frappe.whitelist(methods=["POST"])
+	def update_network_throughput(
+		self, private_network_throughput_mbps: int, public_network_throughput_mbps: int
+	) -> dict[str, Any]:
+		"""Change the throughput limits in Mbps without a VM restart. A value of 0 removes the limit."""
+		frappe.only_for("System Manager")
+		limits = {
+			"private_network_throughput_mbps": cint(private_network_throughput_mbps),
+			"public_network_throughput_mbps": cint(public_network_throughput_mbps),
+		}
+		if any(value < 0 for value in limits.values()):
+			frappe.throw(_("Network throughput must not be negative."))
+
+		return self.update_network(**limits)
+
+	def update_network(self, **changes: Any) -> dict[str, Any]:
+		"""Send the complete desired network settings to Metal.
+
+		Metal replaces every mutable setting, so unchanged values come from the
+		live Metal state instead of a local default.
+		"""
+		if self.is_draft:
+			frappe.throw(_("Wait for Virtual Machine creation before a network change."))
+		if self.is_terminating:
+			frappe.throw(_("Virtual Machine {0} is terminating.").format(self.name))
+
+		try:
+			client = MetalClient(frappe.get_doc("Server", self.server))
+			network = client.get_virtual_machine(self.name).get("network") or {}
+			if not network.get("egress"):
+				frappe.throw(_("Metal did not report the current network settings."))
+			request = {
+				"egress": network["egress"],
+				"public_ipv4": network.get("public_ipv4") or "",
+				"private_network_throughput_mbps": network.get("private_network_throughput_mbps") or 0,
+				"public_network_throughput_mbps": network.get("public_network_throughput_mbps") or 0,
+				**changes,
+			}
+			return client.update_virtual_machine_network(self.name, request)
 		except MetalClientError as error:
 			throw_metal_error(error)
 			raise AssertionError from error

--- a/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
@@ -1,16 +1,19 @@
 function showCreateVirtualMachineDialog() {
 	const dialog = new frappe.ui.Dialog({
 		title: __("Create Virtual Machine"),
+		size: "large",
 		fields: [
+			{ fieldtype: "Section Break", label: __("Machine") },
 			{
 				fieldname: "virtual_machine_image",
 				fieldtype: "Link",
 				label: __("Virtual Machine Image"),
 				options: "Virtual Machine Image",
 				reqd: 1,
-				get_query: () => ({ filters: { enabled: 1, status: "Available" } }),
+				filters: { enabled: 1, status: "Available" },
 			},
 			{ fieldname: "vcpus", fieldtype: "Int", label: __("vCPUs"), reqd: 1, default: 1 },
+			{ fieldtype: "Column Break" },
 			{
 				fieldname: "memory_mib",
 				fieldtype: "Int",
@@ -27,8 +30,19 @@ function showCreateVirtualMachineDialog() {
 			},
 			{ fieldtype: "Section Break", label: __("Guest") },
 			{ fieldname: "hostname", fieldtype: "Data", label: __("Hostname") },
-			{ fieldname: "ssh_keys", fieldtype: "Small Text", label: __("SSH Keys") },
-			{ fieldname: "user_data", fieldtype: "Code", label: __("User Data"), options: "YAML" },
+			{
+				fieldname: "ssh_keys",
+				fieldtype: "Code",
+				label: __("SSH Keys"),
+				description: __("One public key per line."),
+			},
+			{ fieldtype: "Column Break" },
+			{
+				fieldname: "user_data",
+				fieldtype: "Code",
+				label: __("User Data"),
+				options: "YAML",
+			},
 			{ fieldtype: "Section Break", label: __("Network") },
 			{
 				fieldname: "egress",
@@ -38,20 +52,6 @@ function showCreateVirtualMachineDialog() {
 				default: "uplink",
 				reqd: 1,
 				description: __("uplink reaches the internet. mesh reaches tenant VMs only."),
-			},
-			{
-				fieldname: "private_network_throughput_mbps",
-				fieldtype: "Int",
-				label: __("Private Network Throughput (Mbps)"),
-				default: 0,
-				description: __("0 does not apply a limit."),
-			},
-			{
-				fieldname: "public_network_throughput_mbps",
-				fieldtype: "Int",
-				label: __("Public Network Throughput (Mbps)"),
-				default: 0,
-				description: __("0 does not apply a limit."),
 			},
 			{
 				fieldname: "tenant_id",
@@ -65,7 +65,23 @@ function showCreateVirtualMachineDialog() {
 				fieldtype: "Link",
 				label: __("Public IPv4"),
 				options: "Server IP Address",
-				get_query: () => ({ filters: { status: "Allocated" } }),
+				depends_on: 'eval:doc.egress == "uplink"',
+				filters: { status: "Allocated" },
+			},
+			{ fieldtype: "Column Break" },
+			{
+				fieldname: "private_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Private Network Throughput (Mbps)"),
+				default: 0,
+				description: __("0 does not apply a limit."),
+			},
+			{
+				fieldname: "public_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Public Network Throughput (Mbps)"),
+				default: 0,
+				description: __("0 does not apply a limit."),
 			},
 		],
 		primary_action_label: __("Create"),

--- a/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
@@ -39,6 +39,20 @@ function showCreateVirtualMachineDialog() {
 				reqd: 1,
 			},
 			{
+				fieldname: "private_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Private Network Throughput (Mbps)"),
+				default: 0,
+				description: __("0 does not apply a limit."),
+			},
+			{
+				fieldname: "public_network_throughput_mbps",
+				fieldtype: "Int",
+				label: __("Public Network Throughput (Mbps)"),
+				default: 0,
+				description: __("0 does not apply a limit."),
+			},
+			{
 				fieldname: "tenant_id",
 				fieldtype: "Int",
 				label: __("Tenant ID"),

--- a/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine_list.js
@@ -34,9 +34,10 @@ function showCreateVirtualMachineDialog() {
 				fieldname: "egress",
 				fieldtype: "Select",
 				label: __("Egress"),
-				options: "host\nnone",
-				default: "host",
+				options: "uplink\nmesh\nnone",
+				default: "uplink",
 				reqd: 1,
+				description: __("uplink reaches the internet. mesh reaches tenant VMs only."),
 			},
 			{
 				fieldname: "private_network_throughput_mbps",

--- a/metal/docs/api.md
+++ b/metal/docs/api.md
@@ -126,10 +126,10 @@ Lifecycle requests return `202`. Poll `GET /vms/{id}` until `state` reaches `des
 | Value | VM can reach | Public IPv4 | Throughput limits |
 |---|---|---|---|
 | `uplink` | mesh peers and the internet | allowed | private and public |
-| `mesh` | mesh peers only | rejected | private only |
+| `mesh` | mesh peers only | rejected | private applied, public stored |
 | `none` | nothing | rejected | none |
 
-`host` is a deprecated alias for `uplink`. `egress` is required.
+`egress` is required.
 
 Use an empty `public_ipv4` to detach the address. Throughput values apply in both directions. `0` removes a limit. Metal keeps a limit that the mode does not permit and applies it when the mode permits it. Active connections can stop when the public IPv4 address or the egress mode changes.
 

--- a/metal/docs/api.md
+++ b/metal/docs/api.md
@@ -56,7 +56,9 @@ Content-Type: application/json
   "network": {
     "public_ipv4": "203.0.113.10",
     "wireguard_mesh_ipv6": "fdaa:1:0:7::1",
-    "egress": "host"
+    "private_network_throughput_mbps": 100,
+    "public_network_throughput_mbps": 50,
+    "egress": "uplink"
   }
 }
 ```
@@ -93,6 +95,7 @@ They do not contain image transport URLs, the internal guest IP, or the Firecrac
 | `PUT` | `/vms/{id}` | create or confirm a VM reservation |
 | `GET` | `/vms` | list VMs |
 | `GET` | `/vms/{id}` | get one VM |
+| `PUT` | `/vms/{id}/network` | update mutable network settings |
 | `PUT` | `/vms/{id}/ssh-keys` | replace all authorized SSH keys |
 | `POST` | `/vms/{id}/actions/start` | request the running state |
 | `POST` | `/vms/{id}/actions/stop` | request the stopped state |
@@ -107,11 +110,34 @@ Lifecycle requests return `202`. Poll `GET /vms/{id}` until `state` reaches `des
 
 `PUT /vms/{id}/ssh-keys` accepts the complete desired `ssh_keys` list and returns the updated VM. An empty list removes all keys. The list can contain at most 100 unique OpenSSH keys. Each key must use one line and be at most 16 KiB. Running and paused VMs receive updated MMDS immediately. Stopped VMs use the keys at their next boot.
 
+`PUT /vms/{id}/network` replaces mutable network settings without a VM restart and returns the updated VM.
+
+```json
+{
+  "egress": "uplink",
+  "public_ipv4": "203.0.113.10",
+  "private_network_throughput_mbps": 100,
+  "public_network_throughput_mbps": 50
+}
+```
+
+`egress` controls internet reachability. It does not control mesh reachability.
+
+| Value | VM can reach | Public IPv4 | Throughput limits |
+|---|---|---|---|
+| `uplink` | mesh peers and the internet | allowed | private and public |
+| `mesh` | mesh peers only | rejected | private only |
+| `none` | nothing | rejected | none |
+
+`host` is a deprecated alias for `uplink`. `egress` is required.
+
+Use an empty `public_ipv4` to detach the address. Throughput values apply in both directions. `0` removes a limit. Metal keeps a limit that the mode does not permit and applies it when the mode permits it. Active connections can stop when the public IPv4 address or the egress mode changes.
+
 `GET /vms/{id}/console` upgrades the request to a websocket for the serial console. The bearer token guards the handshake. Metal sends console output as binary frames. A viewer sends keystrokes as binary frames and a terminal resize as a text frame `{"resize":{"cols":80,"rows":24}}`. New viewers first receive the recent scrollback. Metal keeps the console open only while the VM runs. After a metald restart, the console is unavailable until the VM starts again, and the socket closes with a going-away status.
 
 ## Image staging
 
-Metal does not expose image list, image delete, or in-place snapshot restore APIs. Atlas uses a VM disk checkpoint to create a new immutable image.
+Metal uses a VM disk checkpoint to create a new immutable image. It does not expose image list, delete, or restore APIs.
 
 | Method | Path | Action |
 |---|---|---|
@@ -120,13 +146,11 @@ Metal does not expose image list, image delete, or in-place snapshot restore API
 | `GET` | `/snapshots/{snapshot_id}` | get upload status and completed artifact details |
 | `DELETE` | `/snapshots/{snapshot_id}` | remove local staging |
 
-The create response contains the Metal-generated snapshot ID and the exact rootfs and kernel sizes. Atlas uses the ID as its Machine image document name. Upload parts are 2 GiB, except for the final part. Metal streams each part in the background. The status reports each part HTTP ETag and the SHA-256 value of each complete artifact. Atlas completes the multipart uploads, then deletes local staging.
+The create response contains the snapshot ID and rootfs and kernel sizes. Atlas uses the ID as its Machine image name. Parts are 2 GiB, except the final part. The status reports part ETags and artifact SHA-256 values.
 
-The upload request returns `202`. Poll `GET /snapshots/{snapshot_id}` until the state is `completed` or `failed`. The status reports `uploaded_bytes`, `total_bytes`, and `progress_percent` while the upload runs. The completed response also contains the artifact sizes, SHA-256 values, and ETags.
+The upload request returns `202`. Poll `GET /snapshots/{snapshot_id}` until `completed` or `failed`. The response reports progress during upload and artifact details when complete.
 
-Metal updates snapshot activity when an upload starts or finishes. The image reconciler deletes local staging after 48 hours without activity.
-
-A staging snapshot is only an image-transfer resource. It cannot roll back its source VM.
+Metal updates snapshot activity during upload. The image reconciler deletes staging after 48 hours without activity. A staging snapshot cannot roll back its source VM.
 
 ## Controller exchange
 

--- a/metal/docs/architecture.md
+++ b/metal/docs/architecture.md
@@ -70,7 +70,7 @@ If warm boot fails, Metal removes the attempted VM disk and uses cold boot.
 
 ## Network
 
-Each VM uses one Linux network namespace and one `tap0` device. Host egress adds a veth pair, routes, and NAT rules. Public IPv4 support adds host forwarding rules.
+Each VM uses one Linux network namespace and one `tap0` device. `uplink` and `mesh` egress add a veth pair. `uplink` also adds routes and NAT rules. Public IPv4 support adds host forwarding rules.
 
 `POST /sync` also applies the managed WireGuard peer set for the host.
 

--- a/metal/docs/networking.md
+++ b/metal/docs/networking.md
@@ -13,25 +13,40 @@ guest eth0
     |
 network namespace metal-<id>
     |
-    ├─ egress none: no host uplink
-    └─ egress host: vg-<user-id> <-> vh-<user-id> -> host uplink
+    +- egress none:   no veth pair, no path out
+    +- egress mesh:   vg-<user-id> <-> vh-<user-id>
+    +- egress uplink: vg-<user-id> <-> vh-<user-id> -> host uplink
 ```
+
+## Egress modes
+
+Egress controls internet reachability. It does not control mesh reachability. The veth pair is the private network attachment. The default route and the namespace NAT are the internet path.
+
+| Mode | veth pair | Default route and NAT | Public IPv4 | VM can reach |
+|---|---|---|---|---|
+| `uplink` | yes | yes | allowed | mesh peers and the internet |
+| `mesh` | yes | no | rejected | mesh peers only |
+| `none` | no | no | rejected | nothing |
+
+`host` is a deprecated alias for `uplink`. Metal reads it and writes `uplink` at the next update.
+
+A change between `uplink` and `mesh` keeps the veth pair. A change to `none` removes it.
 
 ## Addressing
 
 The guest address is `172.16.0.2`. The gateway is `172.16.0.1`. Metal derives the MAC address from the VM ID.
 
-For host egress, Metal derives one transit `/30` from the VM user ID. This removes the need for a persisted address allocator.
+For `uplink` and `mesh`, Metal derives one transit `/30` from the VM user ID. This removes the need for a persisted address allocator.
 
 ## NAT
 
-Host egress adds a default route and namespace NAT. Host setup adds uplink NAT for the transit range.
+`uplink` adds a default route and namespace NAT. Host setup adds uplink NAT for the transit range.
 
 `Allocate` is idempotent when the namespace already exists. `Release` removes public IPv4 rules before it removes the namespace.
 
 ## Public IPv4
 
-A public IPv4 address requires host egress. Metal adds these rules:
+A public IPv4 address requires `uplink`. Metal rejects it for `mesh` and `none`. Metal adds these rules:
 
 - Host DNAT from the public address to the namespace transit address.
 - Host SNAT from the namespace transit address to the public address.
@@ -39,6 +54,18 @@ A public IPv4 address requires host egress. Metal adds these rules:
 - Namespace DNAT from the transit address to the guest address.
 
 Each rule has the comment `metal-public-ipv4-<vm-id>`. This lets Metal remove only the rules for one VM.
+
+## Throughput limits
+
+The VM network configuration can set `private_network_throughput_mbps` and `public_network_throughput_mbps`. Each value applies in both directions. A value of `0` does not apply a limit.
+
+Metal applies the limits inside the namespace, on `vg-<user-id>`. The host end `vh-<user-id>` belongs to Atlas WG Mesh, which attaches a terminating `direct-action` program to its `clsact` hook. Metal keeps the policers on the end that it owns, so neither component can stop the other. Private traffic uses the RFC 1918 ranges `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`, and the IPv6 unique local range `fc00::/7`, which contains every mesh prefix. Public traffic uses the remaining IPv4 addresses.
+
+The VM is inside the namespace, so `egress` carries traffic from the VM and the remote end is the destination. `ingress` carries traffic to the VM and the two are reversed.
+
+The private filters use a lower `tc` priority than the public filter, so a private packet stops at the private policer. The virtual Ethernet removal clears the traffic-control rules.
+
+`uplink` and `mesh` have a veth pair, so both receive the limits. A `mesh` VM has no internet path, so Metal rejects a public limit for it. A `none` VM has no veth pair and receives no limits. Metal keeps the requested values and applies them when the veth pair returns.
 
 ## WireGuard peers
 
@@ -57,6 +84,9 @@ Firecracker serves MMDS at `169.254.169.254`. The payload contains the instance 
 - A namespace for each VM lets every guest use the same private IPv4 address.
 - User-ID-derived veth names fit the Linux interface name limit.
 - Deterministic addresses and MAC values need no mutable allocator state.
-- `egress: none` leaves the VM without a host uplink.
+- Egress is one axis: internet reachability. Mesh reachability is always on for a VM with a veth pair.
+- The veth pair is the private attachment, so `mesh` keeps it and only `none` removes it.
+- A change between `uplink` and `mesh` keeps the interface, so it does not disturb the Atlas WG Mesh hook.
+- `egress: none` isolates the whole VM.
 - Tagged public IPv4 rules permit exact cleanup for one VM.
 - `/sync` replaces the complete managed WireGuard peer set.

--- a/metal/docs/networking.md
+++ b/metal/docs/networking.md
@@ -28,8 +28,6 @@ Egress controls internet reachability. It does not control mesh reachability. Th
 | `mesh` | yes | no | rejected | mesh peers only |
 | `none` | no | no | rejected | nothing |
 
-`host` is a deprecated alias for `uplink`. Metal reads it and writes `uplink` at the next update.
-
 A change between `uplink` and `mesh` keeps the veth pair. A change to `none` removes it.
 
 ## Addressing
@@ -65,7 +63,7 @@ The VM is inside the namespace, so `egress` carries traffic from the VM and the 
 
 The private filters use a lower `tc` priority than the public filter, so a private packet stops at the private policer. The virtual Ethernet removal clears the traffic-control rules.
 
-`uplink` and `mesh` have a veth pair, so both receive the limits. A `mesh` VM has no internet path, so Metal rejects a public limit for it. A `none` VM has no veth pair and receives no limits. Metal keeps the requested values and applies them when the veth pair returns.
+`uplink` and `mesh` have a veth pair, so both receive the private limit. A `mesh` VM has no internet path, so Metal keeps a public limit and does not apply it. A `none` VM has no veth pair and receives no limits. Metal keeps the requested values and applies them when the veth pair returns.
 
 ## WireGuard peers
 

--- a/metal/internal/api/routes.go
+++ b/metal/internal/api/routes.go
@@ -10,6 +10,7 @@ func (s *Server) registerRoutes(router *echo.Echo) {
 	virtualMachineRoutes.GET("", s.listVirtualMachines)
 	virtualMachineRoutes.PUT("/:id", s.createVirtualMachine)
 	virtualMachineRoutes.GET("/:id", s.getVirtualMachine)
+	virtualMachineRoutes.PUT("/:id/network", s.updateVirtualMachineNetwork)
 	virtualMachineRoutes.PUT("/:id/ssh-keys", s.replaceVirtualMachineSSHKeys)
 	virtualMachineRoutes.PUT("/:id/metadata", s.replaceVirtualMachineMetadata)
 

--- a/metal/internal/api/server_test.go
+++ b/metal/internal/api/server_test.go
@@ -294,7 +294,7 @@ func (stubConsoleBroker) Attach(context.Context, string, io.ReadWriter, <-chan c
 }
 
 const (
-	validCreateRequest = `{"vcpus":1,"memory_mib":512,"disk_mib":1024,"image":{"ref":"ubuntu","architecture":"amd64","rootfs":{"url":"https://atlas.example/ubuntu.ext4?signature=secret","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"kernel":{"url":"https://atlas.example/vmlinux?signature=secret","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},"network":{"wireguard_mesh_ipv6":"fdaa:1:0:7::1","egress":"host"}}`
+	validCreateRequest = `{"vcpus":1,"memory_mib":512,"disk_mib":1024,"image":{"ref":"ubuntu","architecture":"amd64","rootfs":{"url":"https://atlas.example/ubuntu.ext4?signature=secret","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"kernel":{"url":"https://atlas.example/vmlinux?signature=secret","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},"network":{"wireguard_mesh_ipv6":"fdaa:1:0:7::1","egress":"uplink"}}`
 	validSSHKey        = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA user@example"
 )
 
@@ -433,9 +433,9 @@ func TestInternalErrorDoesNotLeakDetails(t *testing.T) {
 func TestCreateRejectsInvalidNetwork(t *testing.T) {
 	srv := newTestServer(t)
 	invalidAddress := strings.Replace(validCreateRequest, "fdaa:1:0:7::1", "2001:db8::1", 1)
-	invalidEgress := strings.Replace(validCreateRequest, `"egress":"host"`, `"egress":"server"`, 1)
-	negativePrivateThroughput := strings.Replace(validCreateRequest, `"egress":"host"`, `"private_network_throughput_mbps":-1,"egress":"host"`, 1)
-	negativePublicThroughput := strings.Replace(validCreateRequest, `"egress":"host"`, `"public_network_throughput_mbps":-1,"egress":"host"`, 1)
+	invalidEgress := strings.Replace(validCreateRequest, `"egress":"uplink"`, `"egress":"server"`, 1)
+	negativePrivateThroughput := strings.Replace(validCreateRequest, `"egress":"uplink"`, `"private_network_throughput_mbps":-1,"egress":"host"`, 1)
+	negativePublicThroughput := strings.Replace(validCreateRequest, `"egress":"uplink"`, `"public_network_throughput_mbps":-1,"egress":"host"`, 1)
 	do(t, srv, http.MethodPut, "/vms/vm1", invalidAddress, http.StatusBadRequest)
 	do(t, srv, http.MethodPut, "/vms/vm1", invalidEgress, http.StatusBadRequest)
 	do(t, srv, http.MethodPut, "/vms/vm1", negativePrivateThroughput, http.StatusBadRequest)
@@ -444,7 +444,7 @@ func TestCreateRejectsInvalidNetwork(t *testing.T) {
 
 func TestCreateReturnsNetworkThroughput(t *testing.T) {
 	srv := newTestServer(t)
-	body := strings.Replace(validCreateRequest, `"egress":"host"`, `"private_network_throughput_mbps":100,"public_network_throughput_mbps":50,"egress":"host"`, 1)
+	body := strings.Replace(validCreateRequest, `"egress":"uplink"`, `"private_network_throughput_mbps":100,"public_network_throughput_mbps":50,"egress":"uplink"`, 1)
 	recorder := do(t, srv, http.MethodPut, "/vms/vm1", body, http.StatusAccepted)
 
 	var response virtualMachineResponse
@@ -456,17 +456,31 @@ func TestCreateReturnsNetworkThroughput(t *testing.T) {
 	}
 }
 
-func TestCreatePublicIPv4EnablesHostEgress(t *testing.T) {
+// A public IPv4 address needs an internet path. The request is rejected instead
+// of silently changing the egress mode that the caller asked for.
+func TestCreateRejectsPublicIPv4WithoutUplink(t *testing.T) {
 	srv := newTestServer(t)
-	body := strings.Replace(validCreateRequest, `"egress":"host"`, `"public_ipv4":"203.0.113.10","egress":"none"`, 1)
+	for _, egress := range []string{"mesh", "none"} {
+		body := strings.Replace(validCreateRequest, `"egress":"uplink"`,
+			`"public_ipv4":"203.0.113.10","egress":"`+egress+`"`, 1)
+		do(t, srv, http.MethodPut, "/vms/vm1", body, http.StatusBadRequest)
+	}
+}
+
+// A mode without an internet path keeps a public limit but does not apply it.
+// This lets a caller change the mode without clearing the stored limits first.
+func TestCreateKeepsThePublicThroughputWithoutUplink(t *testing.T) {
+	srv := newTestServer(t)
+	body := strings.Replace(validCreateRequest, `"egress":"uplink"`,
+		`"public_network_throughput_mbps":50,"egress":"mesh"`, 1)
 	recorder := do(t, srv, http.MethodPut, "/vms/vm1", body, http.StatusAccepted)
 
 	var response virtualMachineResponse
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatal(err)
 	}
-	if response.Network.Egress != string(vm.EgressHost) {
-		t.Fatalf("egress = %q, want host", response.Network.Egress)
+	if response.Network.PublicNetworkThroughputMbps != 50 {
+		t.Fatalf("public throughput = %+v", response.Network)
 	}
 }
 
@@ -474,19 +488,42 @@ func TestUpdateNetworkAppliesLiveSettings(t *testing.T) {
 	srv := newTestServer(t)
 	do(t, srv, http.MethodPut, "/vms/vm1", validCreateRequest, http.StatusAccepted)
 
-	body := `{"egress":"none","public_ipv4":"203.0.113.10","private_network_throughput_mbps":100,"public_network_throughput_mbps":50}`
+	body := `{"egress":"uplink","public_ipv4":"203.0.113.10","private_network_throughput_mbps":100,"public_network_throughput_mbps":50}`
 	recorder := do(t, srv, http.MethodPut, "/vms/vm1/network", body, http.StatusOK)
 
 	var response virtualMachineResponse
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatal(err)
 	}
-	if response.Network.Egress != string(vm.EgressHost) || response.Network.PublicIPv4 != "203.0.113.10" {
+	if response.Network.Egress != string(vm.EgressUplink) || response.Network.PublicIPv4 != "203.0.113.10" {
 		t.Fatalf("network = %+v", response.Network)
 	}
 	if response.Network.PrivateNetworkThroughputMbps != 100 || response.Network.PublicNetworkThroughputMbps != 50 {
 		t.Fatalf("network throughput = %+v", response.Network)
 	}
+}
+
+func TestUpdateNetworkAcceptsMeshAndRejectsPublicIPv4(t *testing.T) {
+	srv := newTestServer(t)
+	do(t, srv, http.MethodPut, "/vms/vm1", validCreateRequest, http.StatusAccepted)
+
+	recorder := do(t, srv, http.MethodPut, "/vms/vm1/network",
+		`{"egress":"mesh","private_network_throughput_mbps":100}`, http.StatusOK)
+	var response virtualMachineResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Network.Egress != string(vm.EgressMesh) {
+		t.Fatalf("egress = %q, want %q", response.Network.Egress, vm.EgressMesh)
+	}
+
+	do(t, srv, http.MethodPut, "/vms/vm1/network",
+		`{"egress":"mesh","public_ipv4":"203.0.113.10"}`, http.StatusBadRequest)
+
+	// Atlas resends every mutable setting, so a stored public limit must not
+	// block a change to a mode that cannot apply it.
+	do(t, srv, http.MethodPut, "/vms/vm1/network",
+		`{"egress":"none","public_network_throughput_mbps":50}`, http.StatusOK)
 }
 
 func TestResizeDiskGrows(t *testing.T) {

--- a/metal/internal/api/server_test.go
+++ b/metal/internal/api/server_test.go
@@ -53,17 +53,20 @@ func (driver *fakeVirtualMachineDriver) Create(_ context.Context, id string, spe
 	}
 
 	virtualMachine := &fakeVM{info: vm.Info{
-		ID:                id,
-		State:             vm.StateUnknown,
-		DesiredState:      vm.StateRunning,
-		VCPUs:             specification.VCPUs,
-		MemoryMiB:         specification.MemoryMiB,
-		DiskMiB:           specification.DiskMiB,
-		Image:             specification.Image,
-		SSHKeys:           append([]string(nil), specification.SSHKeys...),
-		MAC:               "06:00:00:00:00:01",
-		Egress:            specification.Network.Egress,
-		WireGuardMeshIPv6: specification.Network.WireGuardMeshIPv6,
+		ID:                           id,
+		State:                        vm.StateUnknown,
+		DesiredState:                 vm.StateRunning,
+		VCPUs:                        specification.VCPUs,
+		MemoryMiB:                    specification.MemoryMiB,
+		DiskMiB:                      specification.DiskMiB,
+		Image:                        specification.Image,
+		SSHKeys:                      append([]string(nil), specification.SSHKeys...),
+		MAC:                          "06:00:00:00:00:01",
+		PublicIPv4:                   specification.Network.PublicIPv4,
+		Egress:                       specification.Network.Egress,
+		WireGuardMeshIPv6:            specification.Network.WireGuardMeshIPv6,
+		PrivateNetworkThroughputMbps: specification.Network.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  specification.Network.PublicNetworkThroughputMbps,
 	}}
 	driver.virtualMachines[id] = virtualMachine
 
@@ -125,6 +128,18 @@ func (driver *fakeVirtualMachineDriver) ReplaceMetadata(
 		return vm.ErrNotFound
 	}
 	virtualMachine.info.Metadata = maps.Clone(metadata)
+	return nil
+}
+
+func (driver *fakeVirtualMachineDriver) UpdateNetwork(_ context.Context, id string, update vm.NetworkUpdate) error {
+	virtualMachine, found := driver.virtualMachines[id]
+	if !found {
+		return vm.ErrNotFound
+	}
+	virtualMachine.info.Egress = update.Egress
+	virtualMachine.info.PublicIPv4 = update.PublicIPv4
+	virtualMachine.info.PrivateNetworkThroughputMbps = update.PrivateNetworkThroughputMbps
+	virtualMachine.info.PublicNetworkThroughputMbps = update.PublicNetworkThroughputMbps
 	return nil
 }
 
@@ -419,8 +434,59 @@ func TestCreateRejectsInvalidNetwork(t *testing.T) {
 	srv := newTestServer(t)
 	invalidAddress := strings.Replace(validCreateRequest, "fdaa:1:0:7::1", "2001:db8::1", 1)
 	invalidEgress := strings.Replace(validCreateRequest, `"egress":"host"`, `"egress":"server"`, 1)
+	negativePrivateThroughput := strings.Replace(validCreateRequest, `"egress":"host"`, `"private_network_throughput_mbps":-1,"egress":"host"`, 1)
+	negativePublicThroughput := strings.Replace(validCreateRequest, `"egress":"host"`, `"public_network_throughput_mbps":-1,"egress":"host"`, 1)
 	do(t, srv, http.MethodPut, "/vms/vm1", invalidAddress, http.StatusBadRequest)
 	do(t, srv, http.MethodPut, "/vms/vm1", invalidEgress, http.StatusBadRequest)
+	do(t, srv, http.MethodPut, "/vms/vm1", negativePrivateThroughput, http.StatusBadRequest)
+	do(t, srv, http.MethodPut, "/vms/vm1", negativePublicThroughput, http.StatusBadRequest)
+}
+
+func TestCreateReturnsNetworkThroughput(t *testing.T) {
+	srv := newTestServer(t)
+	body := strings.Replace(validCreateRequest, `"egress":"host"`, `"private_network_throughput_mbps":100,"public_network_throughput_mbps":50,"egress":"host"`, 1)
+	recorder := do(t, srv, http.MethodPut, "/vms/vm1", body, http.StatusAccepted)
+
+	var response virtualMachineResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Network.PrivateNetworkThroughputMbps != 100 || response.Network.PublicNetworkThroughputMbps != 50 {
+		t.Fatalf("network throughput = %+v", response.Network)
+	}
+}
+
+func TestCreatePublicIPv4EnablesHostEgress(t *testing.T) {
+	srv := newTestServer(t)
+	body := strings.Replace(validCreateRequest, `"egress":"host"`, `"public_ipv4":"203.0.113.10","egress":"none"`, 1)
+	recorder := do(t, srv, http.MethodPut, "/vms/vm1", body, http.StatusAccepted)
+
+	var response virtualMachineResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Network.Egress != string(vm.EgressHost) {
+		t.Fatalf("egress = %q, want host", response.Network.Egress)
+	}
+}
+
+func TestUpdateNetworkAppliesLiveSettings(t *testing.T) {
+	srv := newTestServer(t)
+	do(t, srv, http.MethodPut, "/vms/vm1", validCreateRequest, http.StatusAccepted)
+
+	body := `{"egress":"none","public_ipv4":"203.0.113.10","private_network_throughput_mbps":100,"public_network_throughput_mbps":50}`
+	recorder := do(t, srv, http.MethodPut, "/vms/vm1/network", body, http.StatusOK)
+
+	var response virtualMachineResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Network.Egress != string(vm.EgressHost) || response.Network.PublicIPv4 != "203.0.113.10" {
+		t.Fatalf("network = %+v", response.Network)
+	}
+	if response.Network.PrivateNetworkThroughputMbps != 100 || response.Network.PublicNetworkThroughputMbps != 50 {
+		t.Fatalf("network throughput = %+v", response.Network)
+	}
 }
 
 func TestResizeDiskGrows(t *testing.T) {

--- a/metal/internal/api/virtual_machine_network.go
+++ b/metal/internal/api/virtual_machine_network.go
@@ -53,8 +53,9 @@ func (s *Server) updateVirtualMachineNetwork(c echo.Context) error {
 }
 
 func (request networkUpdateRequest) validate() error {
-	if request.Egress != string(vm.EgressHost) && request.Egress != string(vm.EgressNone) {
-		return fmt.Errorf("egress must be host or none")
+	egress := vm.Egress(request.Egress)
+	if !egress.IsValid() {
+		return fmt.Errorf("egress must be %s, %s, or %s", vm.EgressUplink, vm.EgressMesh, vm.EgressNone)
 	}
 	if request.PrivateNetworkThroughputMbps < 0 || request.PublicNetworkThroughputMbps < 0 {
 		return fmt.Errorf("network throughput values must not be negative")
@@ -66,16 +67,15 @@ func (request networkUpdateRequest) validate() error {
 	if err != nil || !publicAddress.Is4() {
 		return fmt.Errorf("public_ipv4 must be an IPv4 address")
 	}
+	if !egress.HasInternetPath() {
+		return fmt.Errorf("public_ipv4 requires %s egress", vm.EgressUplink)
+	}
 	return nil
 }
 
 func (request networkUpdateRequest) update() vm.NetworkUpdate {
-	egress := vm.Egress(request.Egress)
-	if request.PublicIPv4 != "" {
-		egress = vm.EgressHost
-	}
 	return vm.NetworkUpdate{
-		Egress:                       egress,
+		Egress:                       vm.Egress(request.Egress),
 		PublicIPv4:                   request.PublicIPv4,
 		PrivateNetworkThroughputMbps: request.PrivateNetworkThroughputMbps,
 		PublicNetworkThroughputMbps:  request.PublicNetworkThroughputMbps,

--- a/metal/internal/api/virtual_machine_network.go
+++ b/metal/internal/api/virtual_machine_network.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/frappe/atlas/metal/internal/vm"
+)
+
+type networkUpdateRequest struct {
+	Egress                       string `json:"egress"`
+	PublicIPv4                   string `json:"public_ipv4"`
+	PrivateNetworkThroughputMbps int    `json:"private_network_throughput_mbps"`
+	PublicNetworkThroughputMbps  int    `json:"public_network_throughput_mbps"`
+}
+
+// @Summary	Update mutable VM network settings
+// @Description	Apply public IPv4, host egress, and throughput settings without restarting the VM.
+// @Tags		vms
+// @Accept		json
+// @Produce	json
+// @Param		id		path	string				true	"Virtual machine identifier"
+// @Param		body	body	networkUpdateRequest	true	"Network settings"
+// @Success	200	{object}	virtualMachineResponse
+// @Failure	400	{object}	errorResponse
+// @Failure	409	{object}	errorResponse
+// @Router		/vms/{id}/network [put]
+func (s *Server) updateVirtualMachineNetwork(c echo.Context) error {
+	var request networkUpdateRequest
+	if err := c.Bind(&request); err != nil {
+		return badRequest("invalid JSON request")
+	}
+	if err := request.validate(); err != nil {
+		return badRequest(err.Error())
+	}
+
+	virtualMachine, err := s.loadVirtualMachine(c)
+	if err != nil {
+		return err
+	}
+	if err := s.virtualMachineDriver.UpdateNetwork(c.Request().Context(), virtualMachine.ID(), request.update()); err != nil {
+		return err
+	}
+
+	updatedVirtualMachine, err := s.loadVirtualMachine(c)
+	if err != nil {
+		return err
+	}
+	return s.respondWithVirtualMachine(c, http.StatusOK, updatedVirtualMachine)
+}
+
+func (request networkUpdateRequest) validate() error {
+	if request.Egress != string(vm.EgressHost) && request.Egress != string(vm.EgressNone) {
+		return fmt.Errorf("egress must be host or none")
+	}
+	if request.PrivateNetworkThroughputMbps < 0 || request.PublicNetworkThroughputMbps < 0 {
+		return fmt.Errorf("network throughput values must not be negative")
+	}
+	if request.PublicIPv4 == "" {
+		return nil
+	}
+	publicAddress, err := netip.ParseAddr(request.PublicIPv4)
+	if err != nil || !publicAddress.Is4() {
+		return fmt.Errorf("public_ipv4 must be an IPv4 address")
+	}
+	return nil
+}
+
+func (request networkUpdateRequest) update() vm.NetworkUpdate {
+	egress := vm.Egress(request.Egress)
+	if request.PublicIPv4 != "" {
+		egress = vm.EgressHost
+	}
+	return vm.NetworkUpdate{
+		Egress:                       egress,
+		PublicIPv4:                   request.PublicIPv4,
+		PrivateNetworkThroughputMbps: request.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  request.PublicNetworkThroughputMbps,
+	}
+}

--- a/metal/internal/api/virtual_machine_request.go
+++ b/metal/internal/api/virtual_machine_request.go
@@ -56,9 +56,11 @@ type imageArtifactRequest struct {
 }
 
 type networkRequest struct {
-	PublicIPv4        string `json:"public_ipv4"`
-	WireGuardMeshIPv6 string `json:"wireguard_mesh_ipv6"`
-	Egress            string `json:"egress"`
+	PublicIPv4                   string `json:"public_ipv4"`
+	WireGuardMeshIPv6            string `json:"wireguard_mesh_ipv6"`
+	PrivateNetworkThroughputMbps int    `json:"private_network_throughput_mbps"`
+	PublicNetworkThroughputMbps  int    `json:"public_network_throughput_mbps"`
+	Egress                       string `json:"egress"`
 }
 
 type computeResizeRequest struct {
@@ -151,6 +153,10 @@ func (request *memorySnapshotConfigurationRequest) specification() *vm.MemorySna
 }
 
 func (request networkRequest) validate() error {
+	if request.PrivateNetworkThroughputMbps < 0 || request.PublicNetworkThroughputMbps < 0 {
+		return fmt.Errorf("network throughput values must not be negative")
+	}
+
 	wireGuardAddress, err := netip.ParseAddr(request.WireGuardMeshIPv6)
 	if err != nil || !wireGuardMeshPrefix.Contains(wireGuardAddress) {
 		return fmt.Errorf("network.wireguard_mesh_ipv6 must be in fdaa::/16")
@@ -166,18 +172,20 @@ func (request networkRequest) validate() error {
 	if err != nil || !publicAddress.Is4() {
 		return fmt.Errorf("network.public_ipv4 must be an IPv4 address")
 	}
-	if request.Egress != string(vm.EgressHost) {
-		return fmt.Errorf("network.public_ipv4 requires host egress")
-	}
-
 	return nil
 }
 
 func (request networkRequest) spec() vm.Network {
+	egress := vm.Egress(request.Egress)
+	if request.PublicIPv4 != "" {
+		egress = vm.EgressHost
+	}
 	return vm.Network{
-		PublicIPv4:        request.PublicIPv4,
-		WireGuardMeshIPv6: request.WireGuardMeshIPv6,
-		Egress:            vm.Egress(request.Egress),
+		PublicIPv4:                   request.PublicIPv4,
+		WireGuardMeshIPv6:            request.WireGuardMeshIPv6,
+		PrivateNetworkThroughputMbps: request.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  request.PublicNetworkThroughputMbps,
+		Egress:                       egress,
 	}
 }
 

--- a/metal/internal/api/virtual_machine_request.go
+++ b/metal/internal/api/virtual_machine_request.go
@@ -161,8 +161,9 @@ func (request networkRequest) validate() error {
 	if err != nil || !wireGuardMeshPrefix.Contains(wireGuardAddress) {
 		return fmt.Errorf("network.wireguard_mesh_ipv6 must be in fdaa::/16")
 	}
-	if request.Egress != string(vm.EgressHost) && request.Egress != string(vm.EgressNone) {
-		return fmt.Errorf("network.egress must be host or none")
+	egress := vm.Egress(request.Egress)
+	if !egress.IsValid() {
+		return fmt.Errorf("network.egress must be %s, %s, or %s", vm.EgressUplink, vm.EgressMesh, vm.EgressNone)
 	}
 	if request.PublicIPv4 == "" {
 		return nil
@@ -172,20 +173,19 @@ func (request networkRequest) validate() error {
 	if err != nil || !publicAddress.Is4() {
 		return fmt.Errorf("network.public_ipv4 must be an IPv4 address")
 	}
+	if !egress.HasInternetPath() {
+		return fmt.Errorf("network.public_ipv4 requires %s egress", vm.EgressUplink)
+	}
 	return nil
 }
 
 func (request networkRequest) spec() vm.Network {
-	egress := vm.Egress(request.Egress)
-	if request.PublicIPv4 != "" {
-		egress = vm.EgressHost
-	}
 	return vm.Network{
 		PublicIPv4:                   request.PublicIPv4,
 		WireGuardMeshIPv6:            request.WireGuardMeshIPv6,
 		PrivateNetworkThroughputMbps: request.PrivateNetworkThroughputMbps,
 		PublicNetworkThroughputMbps:  request.PublicNetworkThroughputMbps,
-		Egress:                       egress,
+		Egress:                       vm.Egress(request.Egress),
 	}
 }
 

--- a/metal/internal/api/virtual_machine_response.go
+++ b/metal/internal/api/virtual_machine_response.go
@@ -42,10 +42,12 @@ type imageArtifactResponse struct {
 }
 
 type networkResponse struct {
-	MAC               string `json:"mac"`
-	PublicIPv4        string `json:"public_ipv4,omitempty"`
-	WireGuardMeshIPv6 string `json:"wireguard_mesh_ipv6"`
-	Egress            string `json:"egress"`
+	MAC                          string `json:"mac"`
+	PublicIPv4                   string `json:"public_ipv4,omitempty"`
+	WireGuardMeshIPv6            string `json:"wireguard_mesh_ipv6"`
+	PrivateNetworkThroughputMbps int    `json:"private_network_throughput_mbps"`
+	PublicNetworkThroughputMbps  int    `json:"public_network_throughput_mbps"`
+	Egress                       string `json:"egress"`
 }
 
 type diskResponse struct {
@@ -70,10 +72,12 @@ func toVirtualMachine(information vm.Info) virtualMachineResponse {
 		Hostname:     information.Hostname,
 		Metadata:     maps.Clone(information.Metadata),
 		Network: networkResponse{
-			MAC:               information.MAC,
-			PublicIPv4:        information.PublicIPv4,
-			WireGuardMeshIPv6: information.WireGuardMeshIPv6,
-			Egress:            string(information.Egress),
+			MAC:                          information.MAC,
+			PublicIPv4:                   information.PublicIPv4,
+			WireGuardMeshIPv6:            information.WireGuardMeshIPv6,
+			PrivateNetworkThroughputMbps: information.PrivateNetworkThroughputMbps,
+			PublicNetworkThroughputMbps:  information.PublicNetworkThroughputMbps,
+			Egress:                       string(information.Egress),
 		},
 		Disk: diskResponse{
 			SizeMiB: information.DiskMiB,

--- a/metal/internal/api/virtual_machines.go
+++ b/metal/internal/api/virtual_machines.go
@@ -105,9 +105,11 @@ func virtualMachineReservationResponse(virtualMachineID string, specification vm
 		Hostname:     specification.Hostname,
 		Metadata:     maps.Clone(specification.Metadata),
 		Network: networkResponse{
-			PublicIPv4:        specification.Network.PublicIPv4,
-			WireGuardMeshIPv6: specification.Network.WireGuardMeshIPv6,
-			Egress:            string(specification.Network.Egress),
+			PublicIPv4:                   specification.Network.PublicIPv4,
+			WireGuardMeshIPv6:            specification.Network.WireGuardMeshIPv6,
+			PrivateNetworkThroughputMbps: specification.Network.PrivateNetworkThroughputMbps,
+			PublicNetworkThroughputMbps:  specification.Network.PublicNetworkThroughputMbps,
+			Egress:                       string(specification.Network.Egress),
 		},
 		Disk: diskResponse{SizeMiB: specification.DiskMiB},
 	}

--- a/metal/internal/firecracker/driver.go
+++ b/metal/internal/firecracker/driver.go
@@ -305,9 +305,15 @@ func (d *Driver) UpdateNetwork(ctx context.Context, id string, update vm.Network
 	if err != nil {
 		return err
 	}
-	if update.PublicIPv4 != "" {
-		update.Egress = vm.EgressHost
+	if update.PublicIPv4 != "" && !update.Egress.HasInternetPath() {
+		return fmt.Errorf("public IPv4 requires %s egress", vm.EgressUplink)
 	}
+
+	// Hold the allocation mutex across the check and the write, so two VMs cannot
+	// claim one public IPv4 address. Create takes the same lock in this order.
+	d.allocationMutex.Lock()
+	defer d.allocationMutex.Unlock()
+
 	if inUse, err := d.isPublicIPv4InUse(id, update.PublicIPv4); err != nil {
 		return err
 	} else if inUse {

--- a/metal/internal/firecracker/driver.go
+++ b/metal/internal/firecracker/driver.go
@@ -293,6 +293,52 @@ func (d *Driver) ReplaceMetadata(ctx context.Context, id string, metadata map[st
 	return d.cfg.writeVMConfig(configuration)
 }
 
+// UpdateNetwork updates mutable network settings without restarting the VM.
+func (d *Driver) UpdateNetwork(ctx context.Context, id string, update vm.NetworkUpdate) error {
+	unlock, err := d.operationLocks.lock(ctx, id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	configuration, err := d.cfg.readVMConfig(id)
+	if err != nil {
+		return err
+	}
+	if update.PublicIPv4 != "" {
+		update.Egress = vm.EgressHost
+	}
+	if inUse, err := d.isPublicIPv4InUse(id, update.PublicIPv4); err != nil {
+		return err
+	} else if inUse {
+		return vm.ErrConflict
+	}
+
+	desired := configuration.Spec.Network
+	desired.Egress = update.Egress
+	desired.PublicIPv4 = update.PublicIPv4
+	desired.PrivateNetworkThroughputMbps = update.PrivateNetworkThroughputMbps
+	desired.PublicNetworkThroughputMbps = update.PublicNetworkThroughputMbps
+
+	request := network.UpdateRequest{
+		VirtualMachineID: id,
+		UserID:           configuration.UID,
+		Previous:         configuration.Spec.Network,
+		Desired:          desired,
+	}
+	if err := d.networkAllocator.Update(ctx, request); err != nil {
+		return fmt.Errorf("update network: %w", err)
+	}
+
+	configuration.Spec.Network = desired
+	if err := d.cfg.writeVMConfig(configuration); err != nil {
+		rollbackRequest := request
+		rollbackRequest.Previous, rollbackRequest.Desired = request.Desired, request.Previous
+		return errors.Join(err, d.networkAllocator.Update(ctx, rollbackRequest))
+	}
+	return nil
+}
+
 // updateRunningMetadata updates MMDS before persisting the new VM spec
 func (d *Driver) updateRunningMetadata(ctx context.Context, id string, configuration vmConfig) error {
 	unitStatus, err := d.units.Status(ctx, id)
@@ -643,11 +689,13 @@ func copyChown(
 
 func (d *Driver) allocateNetwork(ctx context.Context, configuration vmConfig) (network.Interface, error) {
 	return d.networkAllocator.Allocate(ctx, network.Request{
-		VirtualMachineID: configuration.ID,
-		Egress:           configuration.Spec.Network.Egress,
-		PublicIPv4:       configuration.Spec.Network.PublicIPv4,
-		UserID:           configuration.UID,
-		GroupID:          configuration.GID,
+		VirtualMachineID:             configuration.ID,
+		Egress:                       configuration.Spec.Network.Egress,
+		PublicIPv4:                   configuration.Spec.Network.PublicIPv4,
+		PrivateNetworkThroughputMbps: configuration.Spec.Network.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  configuration.Spec.Network.PublicNetworkThroughputMbps,
+		UserID:                       configuration.UID,
+		GroupID:                      configuration.GID,
 	})
 }
 

--- a/metal/internal/firecracker/driver_test.go
+++ b/metal/internal/firecracker/driver_test.go
@@ -126,7 +126,7 @@ func TestUpdateNetworkPersistsAndAppliesSettings(t *testing.T) {
 	}
 
 	update := vm.NetworkUpdate{
-		Egress:                       vm.EgressHost,
+		Egress:                       vm.EgressUplink,
 		PublicIPv4:                   "203.0.113.10",
 		PrivateNetworkThroughputMbps: 100,
 		PublicNetworkThroughputMbps:  50,
@@ -142,8 +142,26 @@ func TestUpdateNetworkPersistsAndAppliesSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if configuration.Spec.Network != (vm.Network{Egress: vm.EgressHost, PublicIPv4: update.PublicIPv4, PrivateNetworkThroughputMbps: 100, PublicNetworkThroughputMbps: 50}) {
+	if configuration.Spec.Network != (vm.Network{Egress: vm.EgressUplink, PublicIPv4: update.PublicIPv4, PrivateNetworkThroughputMbps: 100, PublicNetworkThroughputMbps: 50}) {
 		t.Fatalf("network = %+v", configuration.Spec.Network)
+	}
+}
+
+func TestUpdateNetworkRejectsPublicIPv4WithoutUplink(t *testing.T) {
+	driver, networkAllocator, _ := testDriver(t)
+	if _, err := driver.Create(context.Background(), "vm-1", vm.Spec{Network: vm.Network{Egress: vm.EgressUplink}}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := driver.UpdateNetwork(context.Background(), "vm-1", vm.NetworkUpdate{
+		Egress:     vm.EgressMesh,
+		PublicIPv4: "203.0.113.10",
+	})
+	if err == nil {
+		t.Fatal("a public IPv4 address without an internet path must fail")
+	}
+	if networkAllocator.updateRequest.VirtualMachineID != "" {
+		t.Fatal("the network must not change when the request is invalid")
 	}
 }
 

--- a/metal/internal/firecracker/driver_test.go
+++ b/metal/internal/firecracker/driver_test.go
@@ -16,14 +16,22 @@ type fakeNetwork struct {
 	allocateCalls int
 	releaseCalls  int
 	releaseError  error
+	request       network.Request
+	updateRequest network.UpdateRequest
 }
 
-func (f *fakeNetwork) Allocate(context.Context, network.Request) (network.Interface, error) {
+func (f *fakeNetwork) Allocate(_ context.Context, request network.Request) (network.Interface, error) {
 	f.allocateCalls++
+	f.request = request
 	return network.Interface{GuestIPAddress: "172.16.0.2", MACAddress: "02:00:00:00:00:01"}, nil
 }
 
 func (f *fakeNetwork) Resolve(string) network.Interface { return network.Interface{} }
+
+func (f *fakeNetwork) Update(_ context.Context, request network.UpdateRequest) error {
+	f.updateRequest = request
+	return nil
+}
 
 func (f *fakeNetwork) Release(context.Context, string) error {
 	f.releaseCalls++
@@ -85,6 +93,57 @@ func TestCreateRejectsChangedSpecForStableID(t *testing.T) {
 	}
 	if _, err := driver.Create(context.Background(), "vm-1", vm.Spec{VCPUs: 2}); !errors.Is(err, vm.ErrConflict) {
 		t.Fatalf("create changed spec = %v, want ErrConflict", err)
+	}
+}
+
+func TestAllocateNetworkPassesThroughputLimits(t *testing.T) {
+	driver, networkAllocator, _ := testDriver(t)
+	configuration := vmConfig{
+		ID:  "vm-1",
+		UID: 1000,
+		GID: 1000,
+		Spec: vm.Spec{Network: vm.Network{
+			PrivateNetworkThroughputMbps: 100,
+			PublicNetworkThroughputMbps:  50,
+		}},
+	}
+
+	if _, err := driver.allocateNetwork(context.Background(), configuration); err != nil {
+		t.Fatal(err)
+	}
+	if networkAllocator.allocateCalls != 1 {
+		t.Fatalf("network allocations = %d, want 1", networkAllocator.allocateCalls)
+	}
+	if networkAllocator.request.PrivateNetworkThroughputMbps != 100 || networkAllocator.request.PublicNetworkThroughputMbps != 50 {
+		t.Fatalf("throughput limits = %+v", networkAllocator.request)
+	}
+}
+
+func TestUpdateNetworkPersistsAndAppliesSettings(t *testing.T) {
+	driver, networkAllocator, _ := testDriver(t)
+	if _, err := driver.Create(context.Background(), "vm-1", vm.Spec{Network: vm.Network{Egress: vm.EgressNone}}); err != nil {
+		t.Fatal(err)
+	}
+
+	update := vm.NetworkUpdate{
+		Egress:                       vm.EgressHost,
+		PublicIPv4:                   "203.0.113.10",
+		PrivateNetworkThroughputMbps: 100,
+		PublicNetworkThroughputMbps:  50,
+	}
+	if err := driver.UpdateNetwork(context.Background(), "vm-1", update); err != nil {
+		t.Fatal(err)
+	}
+	if networkAllocator.updateRequest.Previous.Egress != vm.EgressNone || networkAllocator.updateRequest.Desired.PublicIPv4 != update.PublicIPv4 {
+		t.Fatalf("network update = %+v", networkAllocator.updateRequest)
+	}
+
+	configuration, err := driver.cfg.readVMConfig("vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.Spec.Network != (vm.Network{Egress: vm.EgressHost, PublicIPv4: update.PublicIPv4, PrivateNetworkThroughputMbps: 100, PublicNetworkThroughputMbps: 50}) {
+		t.Fatalf("network = %+v", configuration.Spec.Network)
 	}
 }
 

--- a/metal/internal/firecracker/integration_test.go
+++ b/metal/internal/firecracker/integration_test.go
@@ -82,7 +82,7 @@ func spec(image, pub string) vm.Spec {
 			KernelSHA256: os.Getenv("METAL_KERNEL_SHA256"),
 			Architecture: runtime.GOARCH,
 		},
-		Network: vm.Network{Egress: vm.EgressHost},
+		Network: vm.Network{Egress: vm.EgressUplink},
 		SSHKeys: []string{pub},
 	}
 }

--- a/metal/internal/firecracker/machine_state.go
+++ b/metal/internal/firecracker/machine_state.go
@@ -14,20 +14,22 @@ func (m *machine) Info(ctx context.Context) (vm.Info, error) {
 		return vm.Info{}, err
 	}
 	info := vm.Info{
-		ID:                m.cfg.ID,
-		State:             m.state(ctx, st),
-		DesiredState:      m.cfg.DesiredState,
-		VCPUs:             m.cfg.Spec.VCPUs,
-		MemoryMiB:         m.cfg.Spec.MemoryMiB,
-		DiskMiB:           m.cfg.Spec.DiskMiB,
-		Image:             m.cfg.Spec.Image,
-		SSHKeys:           append([]string(nil), m.cfg.Spec.SSHKeys...),
-		Hostname:          m.cfg.Spec.Hostname,
-		Metadata:          maps.Clone(m.cfg.Spec.Metadata),
-		MAC:               m.cfg.MAC,
-		PublicIPv4:        m.cfg.Spec.Network.PublicIPv4,
-		WireGuardMeshIPv6: m.cfg.Spec.Network.WireGuardMeshIPv6,
-		Egress:            m.cfg.Spec.Network.Egress,
+		ID:                           m.cfg.ID,
+		State:                        m.state(ctx, st),
+		DesiredState:                 m.cfg.DesiredState,
+		VCPUs:                        m.cfg.Spec.VCPUs,
+		MemoryMiB:                    m.cfg.Spec.MemoryMiB,
+		DiskMiB:                      m.cfg.Spec.DiskMiB,
+		Image:                        m.cfg.Spec.Image,
+		SSHKeys:                      append([]string(nil), m.cfg.Spec.SSHKeys...),
+		Hostname:                     m.cfg.Spec.Hostname,
+		Metadata:                     maps.Clone(m.cfg.Spec.Metadata),
+		MAC:                          m.cfg.MAC,
+		PublicIPv4:                   m.cfg.Spec.Network.PublicIPv4,
+		WireGuardMeshIPv6:            m.cfg.Spec.Network.WireGuardMeshIPv6,
+		PrivateNetworkThroughputMbps: m.cfg.Spec.Network.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  m.cfg.Spec.Network.PublicNetworkThroughputMbps,
+		Egress:                       m.cfg.Spec.Network.Egress,
 	}
 
 	if usage, err := m.d.virtualMachineStorage.DiskUsage(ctx, m.cfg.ID); err == nil {

--- a/metal/internal/network/SPEC.md
+++ b/metal/internal/network/SPEC.md
@@ -58,8 +58,6 @@ guest -> tap0 -> namespace -> guest veth -> host veth -> uplink
 | `mesh` | yes | no | rejected |
 | `none` | no | no | rejected |
 
-`host` is a deprecated alias for `uplink`. An empty value reads as `uplink`. The API requires the field.
-
 ## Allocate
 
 Metal always creates the namespace, loopback, TAP, and gateway. `uplink` and `mesh` also create the veth pair and the transit addresses. `uplink` also creates the default route, forwarding, and NAT.
@@ -85,7 +83,7 @@ Each row is one add or remove against the current host state. `uplink <-> mesh` 
 
 `Request` supports private and public limits in Mbps. `0` leaves a traffic type unlimited. Metal applies `tc` policers to `vg-<user-id>`. Private traffic uses RFC 1918 and `fc00::/7`. Public traffic uses the remaining IPv4 addresses. `Update` changes the limits, egress, and public IPv4 rules without a restart.
 
-Atlas WG Mesh owns `vh-<user-id>`. Metal owns `vg-<user-id>` and keeps the limits there. `uplink` and `mesh` have a veth pair and receive the limits. A `mesh` VM has no internet path, so Metal rejects a public limit for it. `egress: none` applies no limits. Metal keeps the values and applies them when the veth pair returns.
+Atlas WG Mesh owns `vh-<user-id>`. Metal owns `vg-<user-id>` and keeps the limits there. `uplink` and `mesh` have a veth pair and receive the private limit. A `mesh` VM has no internet path, so Metal keeps a public limit and does not apply it. `egress: none` applies no limits. Metal keeps the values and applies them when the veth pair returns.
 
 ## Resolve and Release
 

--- a/metal/internal/network/SPEC.md
+++ b/metal/internal/network/SPEC.md
@@ -17,9 +17,10 @@ Package `network` creates isolated VM networks and manages host WireGuard peers.
 
 | Type | Role |
 |---|---|
-| `Allocator` | Allocates, resolves, and releases one VM network. |
+| `Allocator` | Allocates, updates, resolves, and releases one VM network. |
 | `LinuxAllocator` | Linux namespace, TAP, veth, route, and NAT implementation. |
-| `Request` | VM ID, egress mode, public IPv4, user ID, and group ID. |
+| `Request` | VM ID, egress mode, public IPv4, throughput limits, user ID, and group ID. |
+| `Egress` | Internet reachability mode: `uplink`, `mesh`, or `none`. |
 | `Interface` | Namespace path, TAP name, MAC address, guest address, and gateway. |
 
 `NewLinuxAllocator()` returns the concrete allocator. It keeps no mutable state.
@@ -40,18 +41,51 @@ The MAC address is `02:` plus five bytes from the VM ID SHA-256 value. The trans
 ## Topology and packet path
 
 ```text
-guest -> tap0 -> namespace -> optional guest veth -> host veth -> uplink
+guest -> tap0 -> namespace -> guest veth -> host veth -> uplink
+                              \___________________/     \______/
+                               uplink and mesh            uplink
 ```
 
-Host egress uses namespace NAT and the host uplink NAT rule. Public IPv4 uses tagged DNAT, SNAT, and forwarding rules.
+`uplink` uses namespace NAT and the host uplink NAT rule. Public IPv4 uses tagged DNAT, SNAT, and forwarding rules.
+
+## Egress modes
+
+`Egress` controls internet reachability only. The veth pair is the private network attachment.
+
+| Mode | veth pair | Default route and NAT | Public IPv4 |
+|---|---|---|---|
+| `uplink` | yes | yes | allowed |
+| `mesh` | yes | no | rejected |
+| `none` | no | no | rejected |
+
+`host` is a deprecated alias for `uplink`. An empty value reads as `uplink`. The API requires the field.
 
 ## Allocate
 
-Metal always creates the namespace, loopback, TAP, and gateway. Host egress also creates the veth pair, transit route, forwarding, and NAT.
+Metal always creates the namespace, loopback, TAP, and gateway. `uplink` and `mesh` also create the veth pair and the transit addresses. `uplink` also creates the default route, forwarding, and NAT.
 
-A public IPv4 address requires host egress. Metal adds tagged host and namespace forwarding rules.
+A public IPv4 address requires `uplink`. Metal adds tagged host and namespace forwarding rules.
 
 Allocation returns existing deterministic settings when the namespace already exists. Release removes tagged public IPv4 rules and then removes the namespace.
+
+## Update
+
+`Update` reconciles to the desired state. It does not enumerate the transitions between modes.
+
+```text
+                      veth pair      internet path    public IPv4
+desired uplink   ->   present        present          optional
+desired mesh     ->   present        absent           absent
+desired none     ->   absent         absent           absent
+```
+
+Each row is one add or remove against the current host state. `uplink <-> mesh` keeps the veth pair, so it does not disturb the Atlas WG Mesh hook on `vh-<user-id>`. A change to or from `none` adds or removes the interface.
+
+## Traffic control
+
+`Request` supports private and public limits in Mbps. `0` leaves a traffic type unlimited. Metal applies `tc` policers to `vg-<user-id>`. Private traffic uses RFC 1918 and `fc00::/7`. Public traffic uses the remaining IPv4 addresses. `Update` changes the limits, egress, and public IPv4 rules without a restart.
+
+Atlas WG Mesh owns `vh-<user-id>`. Metal owns `vg-<user-id>` and keeps the limits there. `uplink` and `mesh` have a veth pair and receive the limits. A `mesh` VM has no internet path, so Metal rejects a public limit for it. `egress: none` applies no limits. Metal keeps the values and applies them when the veth pair returns.
 
 ## Resolve and Release
 

--- a/metal/internal/network/allocator.go
+++ b/metal/internal/network/allocator.go
@@ -10,17 +10,38 @@ import (
 // Allocator manages virtual machine network resources.
 type Allocator interface {
 	Allocate(ctx context.Context, request Request) (Interface, error)
+	Update(ctx context.Context, request UpdateRequest) error
 	Resolve(virtualMachineID string) Interface
 	Release(ctx context.Context, virtualMachineID string) error
 }
 
+// UpdateRequest contains one live virtual machine network update.
+type UpdateRequest struct {
+	VirtualMachineID string
+	UserID           uint32
+	Previous         vm.Network
+	Desired          vm.Network
+}
+
 // Request contains one virtual machine network request.
 type Request struct {
-	VirtualMachineID string
-	Egress           vm.Egress
-	PublicIPv4       string
-	UserID           uint32
-	GroupID          uint32
+	VirtualMachineID             string
+	Egress                       vm.Egress
+	PublicIPv4                   string
+	PrivateNetworkThroughputMbps int
+	PublicNetworkThroughputMbps  int
+	UserID                       uint32
+	GroupID                      uint32
+}
+
+func (request Request) trafficControl() trafficControlRequest {
+	return trafficControlRequest{
+		VirtualMachineID:             request.VirtualMachineID,
+		UserID:                       request.UserID,
+		Egress:                       request.Egress,
+		PrivateNetworkThroughputMbps: request.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  request.PublicNetworkThroughputMbps,
+	}
 }
 
 // Interface contains one virtual machine network interface.

--- a/metal/internal/network/linux.go
+++ b/metal/internal/network/linux.go
@@ -31,6 +31,9 @@ func (allocator *LinuxAllocator) Allocate(ctx context.Context, request Request) 
 		return Interface{}, err
 	}
 	if exists {
+		if err := configureTrafficControl(ctx, request.trafficControl()); err != nil {
+			return Interface{}, fmt.Errorf("configure traffic control: %w", err)
+		}
 		return allocator.Resolve(request.VirtualMachineID), nil
 	}
 
@@ -53,17 +56,7 @@ func (allocator *LinuxAllocator) Allocate(ctx context.Context, request Request) 
 		egress = vm.EgressHost
 	}
 	if egress == vm.EgressHost {
-		steps = append(steps,
-			[]string{"ip", "link", "add", hostVirtualEthernet, "type", "veth", "peer", "name", guestVirtualEthernet},
-			[]string{"ip", "link", "set", guestVirtualEthernet, "netns", namespace},
-			[]string{"ip", "addr", "add", hostIPAddress + "/30", "dev", hostVirtualEthernet},
-			[]string{"ip", "link", "set", hostVirtualEthernet, "up"},
-			[]string{"ip", "-n", namespace, "addr", "add", namespaceIPAddress + "/30", "dev", guestVirtualEthernet},
-			[]string{"ip", "-n", namespace, "link", "set", guestVirtualEthernet, "up"},
-			[]string{"ip", "-n", namespace, "route", "add", "default", "via", hostIPAddress},
-			[]string{"ip", "netns", "exec", namespace, "sysctl", "-q", "-w", "net.ipv4.ip_forward=1"},
-			[]string{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
-		)
+		steps = append(steps, hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress)...)
 	}
 	if request.PublicIPv4 != "" {
 		if egress != vm.EgressHost {
@@ -78,7 +71,65 @@ func (allocator *LinuxAllocator) Allocate(ctx context.Context, request Request) 
 			return Interface{}, errors.Join(err, releaseError, linkError)
 		}
 	}
+	if err := configureTrafficControl(ctx, request.trafficControl()); err != nil {
+		releaseError := allocator.Release(ctx, request.VirtualMachineID)
+		return Interface{}, errors.Join(fmt.Errorf("configure traffic control: %w", err), releaseError)
+	}
 	return allocator.Resolve(request.VirtualMachineID), nil
+}
+
+// Update applies mutable network settings to an allocated virtual machine.
+func (allocator *LinuxAllocator) Update(ctx context.Context, request UpdateRequest) error {
+	if err := allocator.update(ctx, request); err != nil {
+		rollbackRequest := request
+		rollbackRequest.Previous, rollbackRequest.Desired = request.Desired, request.Previous
+		return errors.Join(err, allocator.update(ctx, rollbackRequest))
+	}
+	return nil
+}
+
+func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateRequest) error {
+	exists, err := networkNamespaceExists(ctx, request.VirtualMachineID)
+	if err != nil || !exists {
+		return err
+	}
+
+	previousEgress := effectiveEgress(request.Previous.Egress)
+	desiredEgress := effectiveEgress(request.Desired.Egress)
+	if request.Previous.PublicIPv4 != request.Desired.PublicIPv4 {
+		if err := removePublicIPv4Rules(ctx, request.VirtualMachineID); err != nil {
+			return err
+		}
+		if err := removePublicIPv4NamespaceRules(ctx, request.VirtualMachineID); err != nil {
+			return err
+		}
+	}
+	if previousEgress != desiredEgress {
+		if previousEgress == vm.EgressHost {
+			if err := removeHostEgress(ctx, request.VirtualMachineID, request.UserID); err != nil {
+				return err
+			}
+		}
+		if desiredEgress == vm.EgressHost {
+			if err := addHostEgress(ctx, request.VirtualMachineID, request.UserID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if request.Previous.PublicIPv4 != request.Desired.PublicIPv4 && request.Desired.PublicIPv4 != "" {
+		if err := addPublicIPv4(ctx, request.VirtualMachineID, request.UserID, request.Desired.PublicIPv4); err != nil {
+			return err
+		}
+	}
+
+	return configureTrafficControl(ctx, trafficControlRequest{
+		VirtualMachineID:             request.VirtualMachineID,
+		UserID:                       request.UserID,
+		Egress:                       desiredEgress,
+		PrivateNetworkThroughputMbps: request.Desired.PrivateNetworkThroughputMbps,
+		PublicNetworkThroughputMbps:  request.Desired.PublicNetworkThroughputMbps,
+	})
 }
 
 // Resolve returns network settings for one virtual machine.
@@ -103,9 +154,10 @@ func (allocator *LinuxAllocator) Release(ctx context.Context, virtualMachineID s
 	if !exists {
 		return rulesError
 	}
+	namespaceRulesError := removePublicIPv4NamespaceRules(ctx, virtualMachineID)
 
 	namespaceError := hostcmd.Run(ctx, "ip", "netns", "del", namespaceName(virtualMachineID))
-	return errors.Join(rulesError, namespaceError)
+	return errors.Join(rulesError, namespaceRulesError, namespaceError)
 }
 
 func namespaceName(virtualMachineID string) string { return "metal-" + virtualMachineID }
@@ -116,6 +168,58 @@ func namespacePath(virtualMachineID string) string {
 
 func virtualEthernetNames(userID uint32) (host, guest string) {
 	return fmt.Sprintf("vh-%d", userID), fmt.Sprintf("vg-%d", userID)
+}
+
+func effectiveEgress(egress vm.Egress) vm.Egress {
+	if egress == "" {
+		return vm.EgressHost
+	}
+	return egress
+}
+
+func hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress string) [][]string {
+	return [][]string{
+		{"ip", "link", "add", hostVirtualEthernet, "type", "veth", "peer", "name", guestVirtualEthernet},
+		{"ip", "link", "set", guestVirtualEthernet, "netns", namespace},
+		{"ip", "addr", "add", hostIPAddress + "/30", "dev", hostVirtualEthernet},
+		{"ip", "link", "set", hostVirtualEthernet, "up"},
+		{"ip", "-n", namespace, "addr", "add", namespaceIPAddress + "/30", "dev", guestVirtualEthernet},
+		{"ip", "-n", namespace, "link", "set", guestVirtualEthernet, "up"},
+		{"ip", "-n", namespace, "route", "add", "default", "via", hostIPAddress},
+		{"ip", "netns", "exec", namespace, "sysctl", "-q", "-w", "net.ipv4.ip_forward=1"},
+		{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
+	}
+}
+
+func addHostEgress(ctx context.Context, virtualMachineID string, userID uint32) error {
+	namespace := namespaceName(virtualMachineID)
+	hostVirtualEthernet, guestVirtualEthernet := virtualEthernetNames(userID)
+	hostIPAddress, namespaceIPAddress := transitAddresses(userID)
+	for _, step := range hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress) {
+		if err := hostcmd.Run(ctx, step[0], step[1:]...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeHostEgress(ctx context.Context, virtualMachineID string, userID uint32) error {
+	namespace := namespaceName(virtualMachineID)
+	hostVirtualEthernet, guestVirtualEthernet := virtualEthernetNames(userID)
+	_ = hostcmd.Run(ctx, "ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-D", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE")
+	return hostcmd.Run(ctx, "ip", "link", "del", hostVirtualEthernet)
+}
+
+func addPublicIPv4(ctx context.Context, virtualMachineID string, userID uint32, publicIPv4 string) error {
+	namespace := namespaceName(virtualMachineID)
+	_, guestVirtualEthernet := virtualEthernetNames(userID)
+	_, namespaceIPAddress := transitAddresses(userID)
+	for _, step := range publicIPv4Steps(virtualMachineID, namespace, guestVirtualEthernet, namespaceIPAddress, publicIPv4) {
+		if err := hostcmd.Run(ctx, step[0], step[1:]...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func transitAddresses(userID uint32) (hostIPAddress, namespaceIPAddress string) {
@@ -155,31 +259,53 @@ func publicIPv4Steps(virtualMachineID, namespace, guestVirtualEthernet, namespac
 }
 
 func removePublicIPv4Rules(ctx context.Context, virtualMachineID string) error {
+	return removePublicIPv4RulesFrom(ctx, nil, virtualMachineID)
+}
+
+func removePublicIPv4NamespaceRules(ctx context.Context, virtualMachineID string) error {
+	return removePublicIPv4RulesFrom(ctx, namespaceCommandPrefix(namespaceName(virtualMachineID)), virtualMachineID)
+}
+
+// namespaceCommandPrefix runs a host command inside one VM network namespace.
+func namespaceCommandPrefix(namespace string) []string {
+	return []string{"ip", "netns", "exec", namespace}
+}
+
+func removePublicIPv4RulesFrom(ctx context.Context, prefix []string, virtualMachineID string) error {
 	var cleanupErrors []error
 	for _, table := range []string{"nat", "filter"} {
-		output, err := hostcmd.Output(ctx, "iptables", "-t", table, "-S")
+		arguments := commandWithPrefix(prefix, "iptables", "-t", table, "-S")
+		output, err := hostcmd.Output(ctx, arguments[0], arguments[1:]...)
 		if err != nil {
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("list %s rules: %w", table, err))
 			continue
 		}
 		for _, line := range strings.Split(output, "\n") {
-			arguments := strings.Fields(line)
-			if !hasRuleComment(arguments, publicIPv4Comment(virtualMachineID)) {
+			ruleArguments := strings.Fields(line)
+			if !hasRuleComment(ruleArguments, publicIPv4Comment(virtualMachineID)) {
 				continue
 			}
-			if len(arguments) < 2 || arguments[0] != "-A" {
+			if len(ruleArguments) < 2 || ruleArguments[0] != "-A" {
 				continue
 			}
-			arguments[0] = "-D"
-			for index, argument := range arguments {
-				arguments[index] = strings.Trim(argument, "\"")
+			ruleArguments[0] = "-D"
+			for index, argument := range ruleArguments {
+				ruleArguments[index] = strings.Trim(argument, "\"")
 			}
-			if err := hostcmd.Run(ctx, "iptables", append([]string{"-t", table}, arguments...)...); err != nil {
+			arguments = commandWithPrefix(prefix, "iptables", "-t", table)
+			arguments = append(arguments, ruleArguments...)
+			if err := hostcmd.Run(ctx, arguments[0], arguments[1:]...); err != nil {
 				cleanupErrors = append(cleanupErrors, fmt.Errorf("remove %s rule: %w", table, err))
 			}
 		}
 	}
 	return errors.Join(cleanupErrors...)
+}
+
+func commandWithPrefix(prefix []string, command string, arguments ...string) []string {
+	result := append([]string(nil), prefix...)
+	result = append(result, command)
+	return append(result, arguments...)
 }
 
 func hasRuleComment(arguments []string, expected string) bool {

--- a/metal/internal/network/linux.go
+++ b/metal/internal/network/linux.go
@@ -52,15 +52,15 @@ func (allocator *LinuxAllocator) Allocate(ctx context.Context, request Request) 
 		{"ip", "-n", namespace, "link", "set", tapName, "up"},
 	}
 	egress := request.Egress
-	if egress == "" {
-		egress = vm.EgressHost
+	if egress.HasVirtualEthernet() {
+		steps = append(steps, virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress)...)
 	}
-	if egress == vm.EgressHost {
-		steps = append(steps, hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress)...)
+	if egress.HasInternetPath() {
+		steps = append(steps, internetPathSteps(namespace, guestVirtualEthernet, hostIPAddress)...)
 	}
 	if request.PublicIPv4 != "" {
-		if egress != vm.EgressHost {
-			return Interface{}, fmt.Errorf("public IPv4 requires host egress")
+		if !egress.HasInternetPath() {
+			return Interface{}, fmt.Errorf("public IPv4 requires %s egress", vm.EgressUplink)
 		}
 		steps = append(steps, publicIPv4Steps(request.VirtualMachineID, namespace, guestVirtualEthernet, namespaceIPAddress, request.PublicIPv4)...)
 	}
@@ -88,14 +88,20 @@ func (allocator *LinuxAllocator) Update(ctx context.Context, request UpdateReque
 	return nil
 }
 
+// update reconciles the host to the desired settings. It asks three independent
+// questions instead of enumerating the transitions between modes.
 func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateRequest) error {
 	exists, err := networkNamespaceExists(ctx, request.VirtualMachineID)
 	if err != nil || !exists {
 		return err
 	}
 
-	previousEgress := effectiveEgress(request.Previous.Egress)
-	desiredEgress := effectiveEgress(request.Desired.Egress)
+	previous, desired := request.Previous.Egress, request.Desired.Egress
+	if request.Desired.PublicIPv4 != "" && !desired.HasInternetPath() {
+		return fmt.Errorf("public IPv4 requires %s egress", vm.EgressUplink)
+	}
+
+	// Remove the public IPv4 rules first, while the interface still carries them.
 	if request.Previous.PublicIPv4 != request.Desired.PublicIPv4 {
 		if err := removePublicIPv4Rules(ctx, request.VirtualMachineID); err != nil {
 			return err
@@ -104,16 +110,20 @@ func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateReque
 			return err
 		}
 	}
-	if previousEgress != desiredEgress {
-		if previousEgress == vm.EgressHost {
-			if err := removeHostEgress(ctx, request.VirtualMachineID, request.UserID); err != nil {
-				return err
-			}
+
+	if previous.HasInternetPath() && !desired.HasInternetPath() {
+		if err := removeInternetPath(ctx, request.VirtualMachineID, request.UserID); err != nil {
+			return err
 		}
-		if desiredEgress == vm.EgressHost {
-			if err := addHostEgress(ctx, request.VirtualMachineID, request.UserID); err != nil {
-				return err
-			}
+	}
+	if previous.HasVirtualEthernet() != desired.HasVirtualEthernet() {
+		if err := setVirtualEthernet(ctx, request.VirtualMachineID, request.UserID, desired.HasVirtualEthernet()); err != nil {
+			return err
+		}
+	}
+	if desired.HasInternetPath() && !(previous.HasInternetPath() && previous.HasVirtualEthernet()) {
+		if err := addInternetPath(ctx, request.VirtualMachineID, request.UserID); err != nil {
+			return err
 		}
 	}
 
@@ -126,7 +136,7 @@ func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateReque
 	return configureTrafficControl(ctx, trafficControlRequest{
 		VirtualMachineID:             request.VirtualMachineID,
 		UserID:                       request.UserID,
-		Egress:                       desiredEgress,
+		Egress:                       desired,
 		PrivateNetworkThroughputMbps: request.Desired.PrivateNetworkThroughputMbps,
 		PublicNetworkThroughputMbps:  request.Desired.PublicNetworkThroughputMbps,
 	})
@@ -170,14 +180,9 @@ func virtualEthernetNames(userID uint32) (host, guest string) {
 	return fmt.Sprintf("vh-%d", userID), fmt.Sprintf("vg-%d", userID)
 }
 
-func effectiveEgress(egress vm.Egress) vm.Egress {
-	if egress == "" {
-		return vm.EgressHost
-	}
-	return egress
-}
-
-func hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress string) [][]string {
+// virtualEthernetSteps builds the private network attachment. Every mode except
+// EgressNone keeps it, so Atlas WG Mesh always finds the host end.
+func virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress string) [][]string {
 	return [][]string{
 		{"ip", "link", "add", hostVirtualEthernet, "type", "veth", "peer", "name", guestVirtualEthernet},
 		{"ip", "link", "set", guestVirtualEthernet, "netns", namespace},
@@ -185,41 +190,61 @@ func hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostI
 		{"ip", "link", "set", hostVirtualEthernet, "up"},
 		{"ip", "-n", namespace, "addr", "add", namespaceIPAddress + "/30", "dev", guestVirtualEthernet},
 		{"ip", "-n", namespace, "link", "set", guestVirtualEthernet, "up"},
+	}
+}
+
+// internetPathSteps builds the route out of the namespace. Only EgressUplink has it.
+func internetPathSteps(namespace, guestVirtualEthernet, hostIPAddress string) [][]string {
+	return [][]string{
 		{"ip", "-n", namespace, "route", "add", "default", "via", hostIPAddress},
 		{"ip", "netns", "exec", namespace, "sysctl", "-q", "-w", "net.ipv4.ip_forward=1"},
 		{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
 	}
 }
 
-func addHostEgress(ctx context.Context, virtualMachineID string, userID uint32) error {
+// setVirtualEthernet adds or removes the veth pair for one virtual machine.
+func setVirtualEthernet(ctx context.Context, virtualMachineID string, userID uint32, present bool) error {
 	namespace := namespaceName(virtualMachineID)
 	hostVirtualEthernet, guestVirtualEthernet := virtualEthernetNames(userID)
+	if !present {
+		return hostcmd.Run(ctx, "ip", "link", "del", hostVirtualEthernet)
+	}
+
 	hostIPAddress, namespaceIPAddress := transitAddresses(userID)
-	for _, step := range hostEgressSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress) {
+	return runSteps(ctx, virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress))
+}
+
+func addInternetPath(ctx context.Context, virtualMachineID string, userID uint32) error {
+	namespace := namespaceName(virtualMachineID)
+	_, guestVirtualEthernet := virtualEthernetNames(userID)
+	hostIPAddress, _ := transitAddresses(userID)
+	return runSteps(ctx, internetPathSteps(namespace, guestVirtualEthernet, hostIPAddress))
+}
+
+func removeInternetPath(ctx context.Context, virtualMachineID string, userID uint32) error {
+	namespace := namespaceName(virtualMachineID)
+	_, guestVirtualEthernet := virtualEthernetNames(userID)
+	hostIPAddress, _ := transitAddresses(userID)
+	return runSteps(ctx, [][]string{
+		{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-D", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
+		{"ip", "-n", namespace, "route", "del", "default", "via", hostIPAddress},
+	})
+}
+
+func runSteps(ctx context.Context, steps [][]string) error {
+	for _, step := range steps {
 		if err := hostcmd.Run(ctx, step[0], step[1:]...); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func removeHostEgress(ctx context.Context, virtualMachineID string, userID uint32) error {
-	namespace := namespaceName(virtualMachineID)
-	hostVirtualEthernet, guestVirtualEthernet := virtualEthernetNames(userID)
-	_ = hostcmd.Run(ctx, "ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-D", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE")
-	return hostcmd.Run(ctx, "ip", "link", "del", hostVirtualEthernet)
 }
 
 func addPublicIPv4(ctx context.Context, virtualMachineID string, userID uint32, publicIPv4 string) error {
 	namespace := namespaceName(virtualMachineID)
 	_, guestVirtualEthernet := virtualEthernetNames(userID)
 	_, namespaceIPAddress := transitAddresses(userID)
-	for _, step := range publicIPv4Steps(virtualMachineID, namespace, guestVirtualEthernet, namespaceIPAddress, publicIPv4) {
-		if err := hostcmd.Run(ctx, step[0], step[1:]...); err != nil {
-			return err
-		}
-	}
-	return nil
+	return runSteps(ctx, publicIPv4Steps(virtualMachineID, namespace, guestVirtualEthernet, namespaceIPAddress, publicIPv4))
 }
 
 func transitAddresses(userID uint32) (hostIPAddress, namespaceIPAddress string) {

--- a/metal/internal/network/linux.go
+++ b/metal/internal/network/linux.go
@@ -78,7 +78,8 @@ func (allocator *LinuxAllocator) Allocate(ctx context.Context, request Request) 
 	return allocator.Resolve(request.VirtualMachineID), nil
 }
 
-// Update applies mutable network settings to an allocated virtual machine.
+// Update applies mutable network settings to an allocated virtual machine. A
+// failure rolls back with the reverse transition, so every step is safe to repeat.
 func (allocator *LinuxAllocator) Update(ctx context.Context, request UpdateRequest) error {
 	if err := allocator.update(ctx, request); err != nil {
 		rollbackRequest := request
@@ -88,8 +89,7 @@ func (allocator *LinuxAllocator) Update(ctx context.Context, request UpdateReque
 	return nil
 }
 
-// update reconciles the host to the desired settings. It asks three independent
-// questions instead of enumerating the transitions between modes.
+// update reconciles the host to the desired settings.
 func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateRequest) error {
 	exists, err := networkNamespaceExists(ctx, request.VirtualMachineID)
 	if err != nil || !exists {
@@ -101,7 +101,6 @@ func (allocator *LinuxAllocator) update(ctx context.Context, request UpdateReque
 		return fmt.Errorf("public IPv4 requires %s egress", vm.EgressUplink)
 	}
 
-	// Remove the public IPv4 rules first, while the interface still carries them.
 	if request.Previous.PublicIPv4 != request.Desired.PublicIPv4 {
 		if err := removePublicIPv4Rules(ctx, request.VirtualMachineID); err != nil {
 			return err
@@ -180,8 +179,7 @@ func virtualEthernetNames(userID uint32) (host, guest string) {
 	return fmt.Sprintf("vh-%d", userID), fmt.Sprintf("vg-%d", userID)
 }
 
-// virtualEthernetSteps builds the private network attachment. Every mode except
-// EgressNone keeps it, so Atlas WG Mesh always finds the host end.
+// virtualEthernetSteps builds the private network attachment. Only EgressNone drops it.
 func virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress string) [][]string {
 	return [][]string{
 		{"ip", "link", "add", hostVirtualEthernet, "type", "veth", "peer", "name", guestVirtualEthernet},
@@ -195,17 +193,27 @@ func virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, 
 
 // internetPathSteps builds the route out of the namespace. Only EgressUplink has it.
 func internetPathSteps(namespace, guestVirtualEthernet, hostIPAddress string) [][]string {
+	return append(defaultRouteSteps(namespace, hostIPAddress),
+		[]string{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
+	)
+}
+
+// defaultRouteSteps builds the namespace route and forwarding.
+func defaultRouteSteps(namespace, hostIPAddress string) [][]string {
 	return [][]string{
-		{"ip", "-n", namespace, "route", "add", "default", "via", hostIPAddress},
+		{"ip", "-n", namespace, "route", "replace", "default", "via", hostIPAddress},
 		{"ip", "netns", "exec", namespace, "sysctl", "-q", "-w", "net.ipv4.ip_forward=1"},
-		{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-A", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
 	}
 }
 
-// setVirtualEthernet adds or removes the veth pair for one virtual machine.
+// setVirtualEthernet adds or removes the veth pair.
 func setVirtualEthernet(ctx context.Context, virtualMachineID string, userID uint32, present bool) error {
 	namespace := namespaceName(virtualMachineID)
 	hostVirtualEthernet, guestVirtualEthernet := virtualEthernetNames(userID)
+	exists, err := networkLinkExists(ctx, hostVirtualEthernet)
+	if err != nil || exists == present {
+		return err
+	}
 	if !present {
 		return hostcmd.Run(ctx, "ip", "link", "del", hostVirtualEthernet)
 	}
@@ -214,21 +222,75 @@ func setVirtualEthernet(ctx context.Context, virtualMachineID string, userID uin
 	return runSteps(ctx, virtualEthernetSteps(namespace, hostVirtualEthernet, guestVirtualEthernet, hostIPAddress, namespaceIPAddress))
 }
 
+// addInternetPath adds the namespace route and NAT rule.
 func addInternetPath(ctx context.Context, virtualMachineID string, userID uint32) error {
 	namespace := namespaceName(virtualMachineID)
 	_, guestVirtualEthernet := virtualEthernetNames(userID)
 	hostIPAddress, _ := transitAddresses(userID)
-	return runSteps(ctx, internetPathSteps(namespace, guestVirtualEthernet, hostIPAddress))
+	if err := runSteps(ctx, defaultRouteSteps(namespace, hostIPAddress)); err != nil {
+		return err
+	}
+	return setMasquerade(ctx, namespace, guestVirtualEthernet, true)
 }
 
+// removeInternetPath removes the NAT rule before the route.
 func removeInternetPath(ctx context.Context, virtualMachineID string, userID uint32) error {
 	namespace := namespaceName(virtualMachineID)
 	_, guestVirtualEthernet := virtualEthernetNames(userID)
-	hostIPAddress, _ := transitAddresses(userID)
-	return runSteps(ctx, [][]string{
-		{"ip", "netns", "exec", namespace, "iptables", "-t", "nat", "-D", "POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"},
-		{"ip", "-n", namespace, "route", "del", "default", "via", hostIPAddress},
-	})
+	if err := setMasquerade(ctx, namespace, guestVirtualEthernet, false); err != nil {
+		return err
+	}
+	return removeDefaultRoute(ctx, namespace)
+}
+
+// setMasquerade adds or removes the namespace NAT rule. iptables fails on a
+// duplicate add and on a delete for an absent rule, so it checks first.
+func setMasquerade(ctx context.Context, namespace, guestVirtualEthernet string, present bool) error {
+	prefix := namespaceCommandPrefix(namespace)
+	rule := []string{"POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"}
+
+	check := commandWithPrefix(prefix, "iptables", append([]string{"-t", "nat", "-C"}, rule...)...)
+	if exists := hostcmd.Run(ctx, check[0], check[1:]...) == nil; exists == present {
+		return nil
+	}
+
+	action := "-D"
+	if present {
+		action = "-A"
+	}
+	command := commandWithPrefix(prefix, "iptables", append([]string{"-t", "nat", action}, rule...)...)
+	return hostcmd.Run(ctx, command[0], command[1:]...)
+}
+
+// removeDefaultRoute removes the namespace default route when it is present.
+func removeDefaultRoute(ctx context.Context, namespace string) error {
+	output, err := hostcmd.Output(ctx, "ip", "-n", namespace, "route", "show", "default")
+	if err != nil {
+		return fmt.Errorf("show default route: %w", err)
+	}
+	if strings.TrimSpace(output) == "" {
+		return nil
+	}
+	return hostcmd.Run(ctx, "ip", "-n", namespace, "route", "del", "default")
+}
+
+// networkLinkExists reports whether one host network interface is present.
+func networkLinkExists(ctx context.Context, name string) (bool, error) {
+	output, err := hostcmd.Output(ctx, "ip", "-o", "link", "show")
+	if err != nil {
+		return false, fmt.Errorf("list network links: %w", err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		device := strings.SplitN(strings.TrimSuffix(fields[1], ":"), "@", 2)[0]
+		if device == name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func runSteps(ctx context.Context, steps [][]string) error {

--- a/metal/internal/network/linux.go
+++ b/metal/internal/network/linux.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/frappe/atlas/metal/internal/hostcmd"
@@ -250,8 +251,9 @@ func setMasquerade(ctx context.Context, namespace, guestVirtualEthernet string, 
 	rule := []string{"POSTROUTING", "-o", guestVirtualEthernet, "-j", "MASQUERADE"}
 
 	check := commandWithPrefix(prefix, "iptables", append([]string{"-t", "nat", "-C"}, rule...)...)
-	if exists := hostcmd.Run(ctx, check[0], check[1:]...) == nil; exists == present {
-		return nil
+	exists, err := ruleExists(ctx, check)
+	if err != nil || exists == present {
+		return err
 	}
 
 	action := "-D"
@@ -260,6 +262,21 @@ func setMasquerade(ctx context.Context, namespace, guestVirtualEthernet string, 
 	}
 	command := commandWithPrefix(prefix, "iptables", append([]string{"-t", "nat", action}, rule...)...)
 	return hostcmd.Run(ctx, command[0], command[1:]...)
+}
+
+// ruleExists runs an iptables check. Exit code 1 means absent. Any other failure
+// is an error, so a broken check does not read as absent.
+func ruleExists(ctx context.Context, check []string) (bool, error) {
+	err := hostcmd.Run(ctx, check[0], check[1:]...)
+	if err == nil {
+		return true, nil
+	}
+
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 // removeDefaultRoute removes the namespace default route when it is present.

--- a/metal/internal/network/linux_test.go
+++ b/metal/internal/network/linux_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -59,5 +60,33 @@ func TestVirtualEthernetNamesFitInterfaceLimit(t *testing.T) {
 		if len(name) > 15 {
 			t.Errorf("%q is %d characters, over the 15 character limit", name, len(name))
 		}
+	}
+}
+
+// A failed update rolls back by replaying the reverse transition, so every step
+// must be safe to repeat. A plain "route add" fails when the route is present.
+func TestDefaultRouteStepsAreSafeToRepeat(t *testing.T) {
+	steps := defaultRouteSteps("metal-vm-1", "10.0.0.1")
+
+	if !slices.Contains(steps[0], "replace") || slices.Contains(steps[0], "add") {
+		t.Fatalf("default route step = %v, want replace", steps[0])
+	}
+}
+
+// The internet path keeps the route steps, so one caller cannot drift from the other.
+func TestInternetPathStepsExtendTheDefaultRoute(t *testing.T) {
+	route := defaultRouteSteps("metal-vm-1", "10.0.0.1")
+	steps := internetPathSteps("metal-vm-1", "vg-1000", "10.0.0.1")
+
+	if len(steps) != len(route)+1 {
+		t.Fatalf("internet path steps = %d, want %d", len(steps), len(route)+1)
+	}
+	for index, step := range route {
+		if !slices.Equal(steps[index], step) {
+			t.Fatalf("step %d = %v, want %v", index, steps[index], step)
+		}
+	}
+	if !slices.Contains(steps[len(steps)-1], "MASQUERADE") {
+		t.Fatalf("last step = %v, want MASQUERADE", steps[len(steps)-1])
 	}
 }

--- a/metal/internal/network/traffic_control.go
+++ b/metal/internal/network/traffic_control.go
@@ -43,8 +43,7 @@ func (request trafficControlRequest) hasVirtualEthernet() bool {
 }
 
 // configureTrafficControl applies the policers to the namespace end of the veth.
-// The host end belongs to Atlas WG Mesh, which attaches a terminating
-// direct-action program there. A shared hook would let one of the two run.
+// The host end belongs to Atlas WG Mesh and its terminating direct-action program.
 func configureTrafficControl(ctx context.Context, request trafficControlRequest) error {
 	if !request.hasVirtualEthernet() {
 		return nil
@@ -80,13 +79,11 @@ func removeTrafficControl(ctx context.Context, namespace, interfaceName string) 
 }
 
 // trafficControlSteps builds the tc commands for the namespace end of the veth.
-// The private filters use the lower priority, so a private packet stops at the
-// private policer and never reaches the public filter, which matches every IPv4
-// address.
+// The private filters take the lower priority, so a private packet never reaches
+// the public filter, which matches every IPv4 address.
 //
-// The VM is inside the namespace, so egress carries traffic from the VM and the
-// remote end is the destination. Ingress carries traffic to the VM and the two
-// are reversed.
+// The VM is inside the namespace: egress carries traffic from it and matches the
+// destination, ingress carries traffic to it and matches the source.
 func trafficControlSteps(namespace, guestVirtualEthernet string, request trafficControlRequest) [][]string {
 	hasPublicLimit := request.PublicNetworkThroughputMbps > 0 && request.Egress.HasInternetPath()
 	if request.PrivateNetworkThroughputMbps == 0 && !hasPublicLimit {

--- a/metal/internal/network/traffic_control.go
+++ b/metal/internal/network/traffic_control.go
@@ -1,0 +1,140 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/frappe/atlas/metal/internal/hostcmd"
+	"github.com/frappe/atlas/metal/internal/vm"
+)
+
+const (
+	trafficControlBurst    = "1mb"
+	privateTrafficPriority = "10"
+	publicTrafficPriority  = "20"
+)
+
+// privatePrefixes are the address ranges that the private throughput limit
+// matches. The IPv4 ranges are RFC 1918. The IPv6 range is the unique local
+// address block, which contains every Atlas mesh prefix.
+var privatePrefixes = []struct {
+	Protocol string
+	Prefix   string
+}{
+	{"ip", "10.0.0.0/8"},
+	{"ip", "172.16.0.0/12"},
+	{"ip", "192.168.0.0/16"},
+	{"ipv6", "fc00::/7"},
+}
+
+// trafficControlRequest describes the throughput policers for one VM veth.
+type trafficControlRequest struct {
+	VirtualMachineID             string
+	UserID                       uint32
+	Egress                       vm.Egress
+	PrivateNetworkThroughputMbps int
+	PublicNetworkThroughputMbps  int
+}
+
+// hasVirtualEthernet reports whether the VM has a veth pair that can hold the policers.
+func (request trafficControlRequest) hasVirtualEthernet() bool {
+	return effectiveEgress(request.Egress) == vm.EgressHost
+}
+
+// configureTrafficControl applies the policers to the namespace end of the veth.
+// The host end belongs to Atlas WG Mesh, which attaches a terminating
+// direct-action program there. A shared hook would let one of the two run.
+func configureTrafficControl(ctx context.Context, request trafficControlRequest) error {
+	if !request.hasVirtualEthernet() {
+		return nil
+	}
+
+	namespace := namespaceName(request.VirtualMachineID)
+	_, guestVirtualEthernet := virtualEthernetNames(request.UserID)
+	if err := removeTrafficControl(ctx, namespace, guestVirtualEthernet); err != nil {
+		return err
+	}
+
+	for _, step := range trafficControlSteps(namespace, guestVirtualEthernet, request) {
+		if err := hostcmd.Run(ctx, step[0], step[1:]...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeTrafficControl(ctx context.Context, namespace, interfaceName string) error {
+	prefix := namespaceCommandPrefix(namespace)
+	show := commandWithPrefix(prefix, "tc", "qdisc", "show", "dev", interfaceName)
+	output, err := hostcmd.Output(ctx, show[0], show[1:]...)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(output, "qdisc clsact") {
+		return nil
+	}
+
+	remove := commandWithPrefix(prefix, "tc", "qdisc", "del", "dev", interfaceName, "clsact")
+	return hostcmd.Run(ctx, remove[0], remove[1:]...)
+}
+
+// trafficControlSteps builds the tc commands for the namespace end of the veth.
+// The private filters use the lower priority, so a private packet stops at the
+// private policer and never reaches the public filter, which matches every IPv4
+// address.
+//
+// The VM is inside the namespace, so egress carries traffic from the VM and the
+// remote end is the destination. Ingress carries traffic to the VM and the two
+// are reversed.
+func trafficControlSteps(namespace, guestVirtualEthernet string, request trafficControlRequest) [][]string {
+	if request.PrivateNetworkThroughputMbps == 0 && request.PublicNetworkThroughputMbps == 0 {
+		return nil
+	}
+
+	prefix := namespaceCommandPrefix(namespace)
+	steps := [][]string{commandWithPrefix(prefix, "tc", "qdisc", "add", "dev", guestVirtualEthernet, "clsact")}
+
+	if request.PrivateNetworkThroughputMbps > 0 {
+		privateRate := fmt.Sprintf("%dmbit", request.PrivateNetworkThroughputMbps)
+		for _, private := range privatePrefixes {
+			steps = append(steps,
+				commandWithPrefix(prefix,
+					"tc", "filter", "add", "dev", guestVirtualEthernet, "egress",
+					"protocol", private.Protocol, "prio", privateTrafficPriority,
+					"flower", "dst_ip", private.Prefix,
+					"action", "police", "rate", privateRate, "burst", trafficControlBurst,
+					"conform-exceed", "drop/ok",
+				),
+				commandWithPrefix(prefix,
+					"tc", "filter", "add", "dev", guestVirtualEthernet, "ingress",
+					"protocol", private.Protocol, "prio", privateTrafficPriority,
+					"flower", "src_ip", private.Prefix,
+					"action", "police", "rate", privateRate, "burst", trafficControlBurst,
+					"conform-exceed", "drop/ok",
+				),
+			)
+		}
+	}
+
+	if request.PublicNetworkThroughputMbps > 0 {
+		publicRate := fmt.Sprintf("%dmbit", request.PublicNetworkThroughputMbps)
+		steps = append(steps,
+			commandWithPrefix(prefix,
+				"tc", "filter", "add", "dev", guestVirtualEthernet, "egress",
+				"protocol", "ip", "prio", publicTrafficPriority,
+				"flower",
+				"action", "police", "rate", publicRate, "burst", trafficControlBurst,
+				"conform-exceed", "drop/ok",
+			),
+			commandWithPrefix(prefix,
+				"tc", "filter", "add", "dev", guestVirtualEthernet, "ingress",
+				"protocol", "ip", "prio", publicTrafficPriority,
+				"flower",
+				"action", "police", "rate", publicRate, "burst", trafficControlBurst,
+				"conform-exceed", "drop/ok",
+			),
+		)
+	}
+	return steps
+}

--- a/metal/internal/network/traffic_control.go
+++ b/metal/internal/network/traffic_control.go
@@ -39,7 +39,7 @@ type trafficControlRequest struct {
 
 // hasVirtualEthernet reports whether the VM has a veth pair that can hold the policers.
 func (request trafficControlRequest) hasVirtualEthernet() bool {
-	return effectiveEgress(request.Egress) == vm.EgressHost
+	return request.Egress.HasVirtualEthernet()
 }
 
 // configureTrafficControl applies the policers to the namespace end of the veth.
@@ -88,7 +88,8 @@ func removeTrafficControl(ctx context.Context, namespace, interfaceName string) 
 // remote end is the destination. Ingress carries traffic to the VM and the two
 // are reversed.
 func trafficControlSteps(namespace, guestVirtualEthernet string, request trafficControlRequest) [][]string {
-	if request.PrivateNetworkThroughputMbps == 0 && request.PublicNetworkThroughputMbps == 0 {
+	hasPublicLimit := request.PublicNetworkThroughputMbps > 0 && request.Egress.HasInternetPath()
+	if request.PrivateNetworkThroughputMbps == 0 && !hasPublicLimit {
 		return nil
 	}
 
@@ -117,7 +118,7 @@ func trafficControlSteps(namespace, guestVirtualEthernet string, request traffic
 		}
 	}
 
-	if request.PublicNetworkThroughputMbps > 0 {
+	if request.PublicNetworkThroughputMbps > 0 && request.Egress.HasInternetPath() {
 		publicRate := fmt.Sprintf("%dmbit", request.PublicNetworkThroughputMbps)
 		steps = append(steps,
 			commandWithPrefix(prefix,

--- a/metal/internal/network/traffic_control_test.go
+++ b/metal/internal/network/traffic_control_test.go
@@ -1,0 +1,86 @@
+package network
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/frappe/atlas/metal/internal/vm"
+)
+
+func TestTrafficControlStepsLimitPrivateAndPublicTraffic(t *testing.T) {
+	request := trafficControlRequest{
+		PrivateNetworkThroughputMbps: 100,
+		PublicNetworkThroughputMbps:  50,
+	}
+
+	got := trafficControlSteps("metal-vm-1", "vg-1000", request)
+	want := [][]string{
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "qdisc", "add", "dev", "vg-1000", "clsact"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "egress", "protocol", "ip", "prio", "10", "flower", "dst_ip", "10.0.0.0/8", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "ingress", "protocol", "ip", "prio", "10", "flower", "src_ip", "10.0.0.0/8", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "egress", "protocol", "ip", "prio", "10", "flower", "dst_ip", "172.16.0.0/12", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "ingress", "protocol", "ip", "prio", "10", "flower", "src_ip", "172.16.0.0/12", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "egress", "protocol", "ip", "prio", "10", "flower", "dst_ip", "192.168.0.0/16", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "ingress", "protocol", "ip", "prio", "10", "flower", "src_ip", "192.168.0.0/16", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "egress", "protocol", "ipv6", "prio", "10", "flower", "dst_ip", "fc00::/7", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "ingress", "protocol", "ipv6", "prio", "10", "flower", "src_ip", "fc00::/7", "action", "police", "rate", "100mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "egress", "protocol", "ip", "prio", "20", "flower", "action", "police", "rate", "50mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+		{"ip", "netns", "exec", "metal-vm-1", "tc", "filter", "add", "dev", "vg-1000", "ingress", "protocol", "ip", "prio", "20", "flower", "action", "police", "rate", "50mbit", "burst", "1mb", "conform-exceed", "drop/ok"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("traffic control steps = %#v, want %#v", got, want)
+	}
+}
+
+// The public filter matches every IPv4 address, so the private filters must keep
+// the lower priority to classify RFC 1918 traffic first.
+func TestPrivateFiltersOutrankThePublicFilter(t *testing.T) {
+	steps := trafficControlSteps("metal-vm-1", "vg-1000", trafficControlRequest{
+		PrivateNetworkThroughputMbps: 100,
+		PublicNetworkThroughputMbps:  50,
+	})
+
+	for _, step := range steps[1:] {
+		priority := step[slices.Index(step, "prio")+1]
+		hasPrefix := slices.Contains(step, "dst_ip") || slices.Contains(step, "src_ip")
+		if hasPrefix && priority != privateTrafficPriority {
+			t.Fatalf("private filter %v uses priority %s", step, priority)
+		}
+		if !hasPrefix && priority != publicTrafficPriority {
+			t.Fatalf("public filter %v uses priority %s", step, priority)
+		}
+	}
+	if privateTrafficPriority >= publicTrafficPriority {
+		t.Fatalf("private priority %s must sort before %s", privateTrafficPriority, publicTrafficPriority)
+	}
+}
+
+func TestTrafficControlStepsSkipUnlimitedTraffic(t *testing.T) {
+	if got := trafficControlSteps("metal-vm-1", "vg-1000", trafficControlRequest{}); got != nil {
+		t.Fatalf("traffic control steps = %#v, want none", got)
+	}
+}
+
+// A VM without host egress has no host veth, so it cannot hold the policers.
+func TestTrafficControlNeedsHostEgress(t *testing.T) {
+	limited := trafficControlRequest{PublicNetworkThroughputMbps: 50}
+	if !limited.hasVirtualEthernet() {
+		t.Fatal("empty egress must default to host")
+	}
+
+	limited.Egress = vm.EgressNone
+	if limited.hasVirtualEthernet() {
+		t.Fatal("egress none must skip traffic control")
+	}
+	limited.Egress = vm.EgressHost
+	if !limited.hasVirtualEthernet() {
+		t.Fatal("egress host must apply traffic control")
+	}
+}
+
+func TestEffectiveEgressDefaultsToHost(t *testing.T) {
+	if got := effectiveEgress(""); got != "host" {
+		t.Fatalf("effective egress = %q, want host", got)
+	}
+}

--- a/metal/internal/network/traffic_control_test.go
+++ b/metal/internal/network/traffic_control_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestTrafficControlStepsLimitPrivateAndPublicTraffic(t *testing.T) {
 	request := trafficControlRequest{
+		Egress:                       vm.EgressUplink,
 		PrivateNetworkThroughputMbps: 100,
 		PublicNetworkThroughputMbps:  50,
 	}
@@ -37,6 +38,7 @@ func TestTrafficControlStepsLimitPrivateAndPublicTraffic(t *testing.T) {
 // the lower priority to classify RFC 1918 traffic first.
 func TestPrivateFiltersOutrankThePublicFilter(t *testing.T) {
 	steps := trafficControlSteps("metal-vm-1", "vg-1000", trafficControlRequest{
+		Egress:                       vm.EgressUplink,
 		PrivateNetworkThroughputMbps: 100,
 		PublicNetworkThroughputMbps:  50,
 	})
@@ -62,25 +64,42 @@ func TestTrafficControlStepsSkipUnlimitedTraffic(t *testing.T) {
 	}
 }
 
-// A VM without host egress has no host veth, so it cannot hold the policers.
-func TestTrafficControlNeedsHostEgress(t *testing.T) {
-	limited := trafficControlRequest{PublicNetworkThroughputMbps: 50}
-	if !limited.hasVirtualEthernet() {
-		t.Fatal("empty egress must default to host")
-	}
-
-	limited.Egress = vm.EgressNone
-	if limited.hasVirtualEthernet() {
-		t.Fatal("egress none must skip traffic control")
-	}
-	limited.Egress = vm.EgressHost
-	if !limited.hasVirtualEthernet() {
-		t.Fatal("egress host must apply traffic control")
+// Only EgressNone removes the veth pair, so mesh VMs still hold the policers.
+func TestTrafficControlNeedsVirtualEthernet(t *testing.T) {
+	for _, testCase := range []struct {
+		egress vm.Egress
+		want   bool
+	}{
+		{vm.EgressUplink, true},
+		{vm.EgressMesh, true},
+		{vm.EgressNone, false},
+	} {
+		request := trafficControlRequest{Egress: testCase.egress}
+		if got := request.hasVirtualEthernet(); got != testCase.want {
+			t.Fatalf("egress %q has veth = %v, want %v", testCase.egress, got, testCase.want)
+		}
 	}
 }
 
-func TestEffectiveEgressDefaultsToHost(t *testing.T) {
-	if got := effectiveEgress(""); got != "host" {
-		t.Fatalf("effective egress = %q, want host", got)
+// A mesh VM has no internet path, so a public policer could never match.
+func TestTrafficControlSkipsThePublicLimitWithoutAnInternetPath(t *testing.T) {
+	request := trafficControlRequest{
+		Egress:                       vm.EgressMesh,
+		PrivateNetworkThroughputMbps: 100,
+		PublicNetworkThroughputMbps:  50,
+	}
+
+	for _, step := range trafficControlSteps("metal-vm-1", "vg-1000", request) {
+		if slices.Contains(step, "50mbit") {
+			t.Fatalf("mesh egress installed a public policer: %v", step)
+		}
+	}
+
+	// A public limit alone leaves nothing to install, not even the qdisc.
+	if got := trafficControlSteps("metal-vm-1", "vg-1000", trafficControlRequest{
+		Egress:                      vm.EgressMesh,
+		PublicNetworkThroughputMbps: 50,
+	}); got != nil {
+		t.Fatalf("mesh egress with only a public limit = %#v, want none", got)
 	}
 }

--- a/metal/internal/vm/driver.go
+++ b/metal/internal/vm/driver.go
@@ -11,6 +11,15 @@ type Driver interface {
 	SetDesiredState(ctx context.Context, id string, state State) error
 	ReplaceSSHKeys(ctx context.Context, id string, sshKeys []string) error
 	ReplaceMetadata(ctx context.Context, id string, metadata map[string]string) error
+	UpdateNetwork(ctx context.Context, id string, update NetworkUpdate) error
 	ResizeCompute(ctx context.Context, id string, virtualCPUCount, memoryMiB int) error
 	Reboot(ctx context.Context, id string) error
+}
+
+// NetworkUpdate contains mutable virtual machine network settings.
+type NetworkUpdate struct {
+	Egress                       Egress
+	PublicIPv4                   string
+	PrivateNetworkThroughputMbps int
+	PublicNetworkThroughputMbps  int
 }

--- a/metal/internal/vm/spec.go
+++ b/metal/internal/vm/spec.go
@@ -74,12 +74,36 @@ func (spec Spec) RefreshImageSource(other Spec) Spec {
 	return spec
 }
 
-// Egress controls VM access to the host uplink.
+// Egress controls internet reachability for a VM. It does not control mesh
+// reachability. A VM keeps its private network attachment for every mode except
+// EgressNone.
 type Egress string
 
 const (
-	// EgressHost routes VM traffic through the host.
-	EgressHost Egress = "host"
-	// EgressNone disables VM traffic through the host.
+	// EgressUplink routes VM traffic to the internet through the host uplink.
+	EgressUplink Egress = "uplink"
+	// EgressMesh keeps the private network attachment and gives no internet path.
+	EgressMesh Egress = "mesh"
+	// EgressNone removes the private network attachment and isolates the VM.
 	EgressNone Egress = "none"
 )
+
+// IsValid reports whether the value names one egress mode.
+func (egress Egress) IsValid() bool {
+	switch egress {
+	case EgressUplink, EgressMesh, EgressNone:
+		return true
+	default:
+		return false
+	}
+}
+
+// HasVirtualEthernet reports whether the mode keeps the private network attachment.
+func (egress Egress) HasVirtualEthernet() bool {
+	return egress == EgressUplink || egress == EgressMesh
+}
+
+// HasInternetPath reports whether the mode gives the VM a route to the internet.
+func (egress Egress) HasInternetPath() bool {
+	return egress == EgressUplink
+}

--- a/metal/internal/vm/spec.go
+++ b/metal/internal/vm/spec.go
@@ -41,9 +41,11 @@ type MemorySnapshotConfiguration struct {
 
 // Network contains the requested VM network configuration.
 type Network struct {
-	PublicIPv4        string
-	WireGuardMeshIPv6 string
-	Egress            Egress
+	PublicIPv4                   string
+	WireGuardMeshIPv6            string
+	PrivateNetworkThroughputMbps int
+	PublicNetworkThroughputMbps  int
+	Egress                       Egress
 }
 
 // SameReservation reports whether two specifications reserve the same VM.

--- a/metal/internal/vm/spec_test.go
+++ b/metal/internal/vm/spec_test.go
@@ -1,0 +1,35 @@
+package vm
+
+import "testing"
+
+func TestEgressCapabilities(t *testing.T) {
+	for _, testCase := range []struct {
+		egress          Egress
+		virtualEthernet bool
+		internetPath    bool
+	}{
+		{EgressUplink, true, true},
+		{EgressMesh, true, false},
+		{EgressNone, false, false},
+	} {
+		if got := testCase.egress.HasVirtualEthernet(); got != testCase.virtualEthernet {
+			t.Fatalf("egress %q veth = %v, want %v", testCase.egress, got, testCase.virtualEthernet)
+		}
+		if got := testCase.egress.HasInternetPath(); got != testCase.internetPath {
+			t.Fatalf("egress %q internet = %v, want %v", testCase.egress, got, testCase.internetPath)
+		}
+	}
+}
+
+func TestEgressIsValidRejectsUnknownModes(t *testing.T) {
+	for _, egress := range []Egress{EgressUplink, EgressMesh, EgressNone} {
+		if !egress.IsValid() {
+			t.Fatalf("egress %q must be valid", egress)
+		}
+	}
+	for _, egress := range []Egress{"", "host", "server"} {
+		if egress.IsValid() {
+			t.Fatalf("egress %q must not be valid", egress)
+		}
+	}
+}

--- a/metal/internal/vm/vm.go
+++ b/metal/internal/vm/vm.go
@@ -17,22 +17,24 @@ type VM interface {
 
 // Info describes a virtual machine.
 type Info struct {
-	ID                string
-	State             State
-	DesiredState      State
-	Error             string
-	VCPUs             int
-	MemoryMiB         int
-	DiskMiB           int
-	DiskUsedMiB       int
-	Image             ImageRef
-	SSHKeys           []string
-	Hostname          string
-	Metadata          map[string]string
-	MAC               string
-	PublicIPv4        string
-	WireGuardMeshIPv6 string
-	Egress            Egress
+	ID                           string
+	State                        State
+	DesiredState                 State
+	Error                        string
+	VCPUs                        int
+	MemoryMiB                    int
+	DiskMiB                      int
+	DiskUsedMiB                  int
+	Image                        ImageRef
+	SSHKeys                      []string
+	Hostname                     string
+	Metadata                     map[string]string
+	MAC                          string
+	PublicIPv4                   string
+	WireGuardMeshIPv6            string
+	PrivateNetworkThroughputMbps int
+	PublicNetworkThroughputMbps  int
+	Egress                       Egress
 }
 
 // ExitStatus describes a stopped virtual machine process.


### PR DESCRIPTION
- Add support for traffic bandwith limit for public and private internet
- Cleanup the egress options : limit it to `uplink`, `mesh` , `none` (isolated)
- Public IP attach/detach without vm restart