### PR TITLE
fix(metal): Preserve VMs across daemon restarts

### DIFF
--- a/atlas/docs/metal-server-lifecycle.md
+++ b/atlas/docs/metal-server-lifecycle.md
@@ -50,5 +50,22 @@ The existing whitelisted methods remain the public boundary:
 - `archive_server`
 - `sync_disks`
 - `install_metald`
+- `upgrade_metald`
 
 These methods check permissions and local state. Dedicated server objects perform the long operations.
+
+## Metald upgrade
+
+`install_metald` writes the host configuration and systemd units. It installs missing binaries and does not replace a running daemon.
+
+`upgrade_metald` downloads the metald build from Atlas Settings, saves the current binary at `/usr/bin/metald.previous`, installs the new binary, and restarts `metal.service`.
+
+Both methods use one job lock per server. Setup and upgrade cannot run together on the same host.
+
+A restart keeps systemd's console descriptors. The virtual machines stay up.
+
+If the descriptor store is empty, every virtual machine on the host stops during the upgrade. The script reports the descriptor count before the restart.
+
+The script checks the service five times. If the new binary fails, the script restores the earlier binary, restarts the service, and reports the failure.
+
+Run **Re-configure Metald** if the script reports an old unit. This action adds `FileDescriptorStorePreserve=yes`. A restart is safe before this update, but a service stop is not. The host systemd version must support this setting.

--- a/atlas/metal_server/core/host_installation.py
+++ b/atlas/metal_server/core/host_installation.py
@@ -88,6 +88,25 @@ class HostInstallation:
 		if not result or not result.is_success:
 			frappe.throw(_("Could not install metald on server {0}.").format(self.server.name))
 
+	def upgrade_metald(self) -> None:
+		"""Replace the metald binary and restart its daemon."""
+		settings = self.server.settings
+		if not settings.metald_binary_x86_64_file:
+			frappe.throw(_("Atlas Settings needs the metald binary."))
+
+		result = SSHTask.create_for_script_file(
+			target_type=self.server.doctype,
+			target=self.server.name,
+			script_path="upgrade-metald.sh",
+			environment={
+				"METALD_DOWNLOAD_URL": get_download_url(settings.metald_binary_x86_64_file),
+			},
+			timeout_seconds=METALD_INSTALL_TIMEOUT_SECONDS,
+			run_in_background=False,
+		).result
+		if not result or not result.is_success:
+			frappe.throw(_("Could not upgrade metald on server {0}.").format(self.server.name))
+
 	def set_wireguard_ip_address(self) -> None:
 		"""Set the WireGuard IP address if it is empty."""
 		if not self.server.wireguard_ip_address:

--- a/atlas/metal_server/doctype/metal_server/metal_server.js
+++ b/atlas/metal_server/doctype/metal_server/metal_server.js
@@ -36,6 +36,14 @@ frappe.ui.form.on("Metal Server", {
 				false,
 			],
 			[
+				__("Upgrade Metald"),
+				"upgrade_metald",
+				is_running,
+				__("Upgrading Metald..."),
+				__("Upgrade Metald on {0}?", [frm.doc.name.bold()]),
+				true,
+			],
+			[
 				__("Reboot"),
 				"reboot_server",
 				!is_deleted && !is_stopped,

--- a/atlas/metal_server/doctype/metal_server/metal_server.py
+++ b/atlas/metal_server/doctype/metal_server/metal_server.py
@@ -237,6 +237,11 @@ class MetalServer(Document):
 
 		DiskInventory(self).sync()
 
+	@property
+	def metald_job_id(self) -> str:
+		"""Return one job ID for each metald operation on this server."""
+		return f"atlas||server||metald||{self.name}"
+
 	@frappe.whitelist(methods=["POST"])
 	def install_metald(self) -> None:
 		"""Queue the metald setup for this server."""
@@ -244,15 +249,38 @@ class MetalServer(Document):
 		if self.status != "Running":
 			frappe.throw(_("Metal Server {0} is not running.").format(self.name))
 
-		job_id = f"atlas||server||install-metald||{self.name}"
+		job_id = self.metald_job_id
 
 		if is_job_enqueued(job_id):
-			frappe.throw(_("Metald setup already runs for {0}.").format(self.name))
+			frappe.throw(_("Another Metald operation already runs for {0}.").format(self.name))
 
 		frappe.enqueue_doc(
 			self.doctype,
 			self.name,
 			"_install_metald",
+			queue="long",
+			timeout=METALD_INSTALL_TIMEOUT_SECONDS,
+			job_id=job_id,
+			deduplicate=True,
+			enqueue_after_commit=True,
+		)
+
+	@frappe.whitelist(methods=["POST"])
+	def upgrade_metald(self) -> None:
+		"""Queue a metald binary upgrade for this server."""
+		frappe.only_for("System Manager")
+		if self.status != "Running":
+			frappe.throw(_("Metal Server {0} is not running.").format(self.name))
+
+		job_id = self.metald_job_id
+
+		if is_job_enqueued(job_id):
+			frappe.throw(_("Another Metald operation already runs for {0}.").format(self.name))
+
+		frappe.enqueue_doc(
+			self.doctype,
+			self.name,
+			"_upgrade_metald",
 			queue="long",
 			timeout=METALD_INSTALL_TIMEOUT_SECONDS,
 			job_id=job_id,
@@ -301,6 +329,10 @@ class MetalServer(Document):
 	def _install_metald(self) -> None:
 		"""Install metald and its host dependencies."""
 		HostInstallation(self).install_metal()
+
+	def _upgrade_metald(self) -> None:
+		"""Replace the metald binary and restart its daemon."""
+		HostInstallation(self).upgrade_metald()
 
 	def _configure_wireguard(self) -> None:
 		"""Configure WireGuard and store its public key."""

--- a/atlas/metal_server/doctype/metal_server/test_metal_server.py
+++ b/atlas/metal_server/doctype/metal_server/test_metal_server.py
@@ -279,7 +279,7 @@ class TestServer(UnitTestCase):
 			"_install_metald",
 			queue="long",
 			timeout=1200,
-			job_id="atlas||server||install-metald||node-test-00007",
+			job_id="atlas||server||metald||node-test-00007",
 			deduplicate=True,
 			enqueue_after_commit=True,
 		)
@@ -353,6 +353,102 @@ class TestServer(UnitTestCase):
 				"STORAGE_POOL_DEVICE": "/dev/md2",
 				"MESH_UPLINK_INTERFACE": "eno1.1878",
 			},
+		)
+
+	def test_upgrade_metald_queues_the_upgrade_job(self) -> None:
+		server = self._server(status="Running")
+
+		with (
+			patch("atlas.metal_server.doctype.metal_server.metal_server.frappe.only_for"),
+			patch("atlas.metal_server.doctype.metal_server.metal_server.is_job_enqueued", return_value=False),
+			patch("atlas.metal_server.doctype.metal_server.metal_server.frappe.enqueue_doc") as enqueue_doc,
+		):
+			MetalServer.upgrade_metald(server)
+
+		enqueue_doc.assert_called_once_with(
+			"Metal Server",
+			"node-test-00007",
+			"_upgrade_metald",
+			queue="long",
+			timeout=1200,
+			job_id="atlas||server||metald||node-test-00007",
+			deduplicate=True,
+			enqueue_after_commit=True,
+		)
+
+	def test_upgrade_metald_waits_for_a_running_metald_job(self) -> None:
+		"""Install and upgrade share one lock, so they never restart metald together."""
+		server = self._server(status="Running")
+
+		with (
+			patch("atlas.metal_server.doctype.metal_server.metal_server.frappe.only_for"),
+			patch("atlas.metal_server.doctype.metal_server.metal_server.is_job_enqueued", return_value=True),
+			patch(
+				"atlas.metal_server.doctype.metal_server.metal_server.frappe.throw", side_effect=ValueError
+			),
+			patch("atlas.metal_server.doctype.metal_server.metal_server.frappe.enqueue_doc") as enqueue_doc,
+		):
+			with self.assertRaises(ValueError):
+				MetalServer.upgrade_metald(server)
+
+		enqueue_doc.assert_not_called()
+
+	def test_upgrade_metald_rejects_a_server_that_is_not_running(self) -> None:
+		server = self._server(status="Stopped")
+
+		with (
+			patch("atlas.metal_server.doctype.metal_server.metal_server.frappe.only_for"),
+			patch(
+				"atlas.metal_server.doctype.metal_server.metal_server.frappe.throw", side_effect=ValueError
+			),
+			patch(
+				"atlas.metal_server.core.host_installation.SSHTask.create_for_script_file"
+			) as create_for_script_file,
+		):
+			with self.assertRaises(ValueError):
+				MetalServer.upgrade_metald(server)
+
+		create_for_script_file.assert_not_called()
+
+	def test_upgrade_metald_rejects_a_missing_binary(self) -> None:
+		server = self._server(status="Running")
+
+		with (
+			patch(
+				"atlas.metal_server.doctype.metal_server.metal_server.frappe.throw", side_effect=ValueError
+			),
+			patch(
+				"atlas.metal_server.core.host_installation.SSHTask.create_for_script_file"
+			) as create_for_script_file,
+		):
+			with self.assertRaises(ValueError):
+				MetalServer._upgrade_metald(server)
+
+		create_for_script_file.assert_not_called()
+
+	def test_upgrade_metald_worker_sends_only_the_download_url(self) -> None:
+		"""The upgrade replaces the binary. It does not rewrite host configuration."""
+		server = self._server(status="Running")
+		server.settings.metald_binary_x86_64_file = "metald-file"
+		task = SimpleNamespace(result=SimpleNamespace(is_success=True))
+
+		with (
+			patch(
+				"atlas.metal_server.core.host_installation.get_download_url",
+				return_value="https://atlas.test/files/metald-linux-amd64",
+			),
+			patch(
+				"atlas.metal_server.core.host_installation.SSHTask.create_for_script_file",
+				return_value=task,
+			) as create_for_script_file,
+		):
+			MetalServer._upgrade_metald(server)
+
+		arguments = create_for_script_file.call_args.kwargs
+		self.assertEqual(arguments["script_path"], "upgrade-metald.sh")
+		self.assertEqual(
+			arguments["environment"],
+			{"METALD_DOWNLOAD_URL": "https://atlas.test/files/metald-linux-amd64"},
 		)
 
 	def test_install_metald_worker_needs_a_private_network_interface(self) -> None:
@@ -648,6 +744,7 @@ class TestServer(UnitTestCase):
 			is_provisioning_completed=False,
 			setup_job_id="atlas||server-provision||node-test-00007",
 			wireguard_job_id="atlas||server-wireguard||node-test-00007",
+			metald_job_id="atlas||server||metald||node-test-00007",
 			wireguard_ip_address=None,
 			private_ipv4_address="10.0.0.7",
 			private_network_interface="eno1.1878",

--- a/atlas/scripts/install-metald.sh
+++ b/atlas/scripts/install-metald.sh
@@ -29,6 +29,17 @@ fi
 step() { echo "==> $*"; }
 skip() { echo "    $* is already installed"; }
 
+# kept_binaries lists existing tools that this script leaves in place.
+kept_binaries=""
+
+# reported_version returns a tool version or "unknown".
+reported_version() {
+	local tool_version
+	tool_version=$("$1" version 2>/dev/null | head -1) || tool_version=""
+	[ -n "$tool_version" ] || tool_version=unknown
+	echo "$tool_version"
+}
+
 
 step "install required packages"
 if ! command -v zpool >/dev/null || ! command -v curl >/dev/null || ! command -v iptables >/dev/null; then
@@ -74,10 +85,16 @@ fi
 # install_binary downloads one tool. An existing tool is left alone, because
 # replacing a running daemon is an upgrade and needs its own steps.
 install_binary() {
-	destination=$1
-	source_url=$2
+	local destination=$1
+	local source_url=$2
+	local binary_name binary_version download
+
 	if [ -x "$destination" ]; then
-		skip "$(basename "$destination")"
+		binary_name=$(basename "$destination")
+		binary_version=$(reported_version "$destination")
+		echo "    $binary_name is already installed; it reports: $binary_version"
+		kept_binaries="$kept_binaries$binary_name reports: $binary_version
+"
 		return
 	fi
 	download=$(mktemp)
@@ -194,9 +211,10 @@ ExecStartPre=/usr/local/lib/metal/network-setup
 ExecStart=/usr/bin/metald serve --config $config_file
 Restart=on-failure
 RestartSec=1
-# Keep PTY masters across a metald restart.
+# Keep PTY masters across a metald restart or stop.
 NotifyAccess=main
 FileDescriptorStoreMax=1024
+FileDescriptorStorePreserve=yes
 
 [Install]
 WantedBy=multi-user.target
@@ -232,3 +250,13 @@ systemctl daemon-reload
 systemctl enable metal.service
 systemctl restart metal.service
 systemctl is-active metal.service
+
+
+if [ -n "$kept_binaries" ]; then
+	step "binaries that this script did not upgrade"
+	printf '%s' "$kept_binaries" | while IFS= read -r kept_binary; do
+		echo "    $kept_binary"
+	done
+	echo "    This script installs a missing binary only. It does not upgrade an installed binary."
+	echo "    A tool that reports unknown has no version command. It can be an old build."
+fi

--- a/atlas/scripts/upgrade-metald.sh
+++ b/atlas/scripts/upgrade-metald.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Replace the metald binary on a provisioned host.
+
+set -eu
+
+: "${METALD_DOWNLOAD_URL:?METALD_DOWNLOAD_URL is required}"
+
+installed_binary=${METALD_BINARY_PATH:-/usr/bin/metald}
+previous_binary=$installed_binary.previous
+service=metal.service
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "upgrade-metald must run as root" >&2
+	exit 1
+fi
+
+if [ ! -x "$installed_binary" ]; then
+	echo "$installed_binary is not installed; run install-metald.sh first" >&2
+	exit 1
+fi
+
+step() { echo "==> $*"; }
+
+# reported_version returns a tool version or "unknown".
+reported_version() {
+	local tool_version
+	tool_version=$("$1" version 2>/dev/null | head -1) || tool_version=""
+	[ -n "$tool_version" ] || tool_version=unknown
+	echo "$tool_version"
+}
+
+# unit_property returns a systemd service property.
+unit_property() {
+	systemctl show "$service" -p "$1" --value 2>/dev/null || echo ""
+}
+
+# service_is_stable checks that the service stays active.
+service_is_stable() {
+	local checks_remaining=5
+
+	while [ "$checks_remaining" -gt 0 ]; do
+		systemctl is-active --quiet "$service" || return 1
+		checks_remaining=$((checks_remaining - 1))
+		[ "$checks_remaining" -eq 0 ] || sleep 1
+	done
+
+	return 0
+}
+
+staged_binary=$(mktemp "$installed_binary.staged.XXXXXX")
+trap 'rm -f "$staged_binary"' EXIT
+
+step "download metald"
+curl -fsSL -o "$staged_binary" "$METALD_DOWNLOAD_URL"
+chmod 0755 "$staged_binary"
+
+# Run the new binary before it replaces the running one.
+new_version=$(reported_version "$staged_binary")
+if [ "$new_version" = unknown ]; then
+	echo "the downloaded binary has no version command; it is not a metald build" >&2
+	exit 1
+fi
+
+current_version=$(reported_version "$installed_binary")
+step "upgrade metald from $current_version to $new_version"
+
+# A restart keeps the console descriptors that systemd holds, so the virtual
+# machines stay up. An empty store means that this metald never stored them.
+stored_console_count=$(unit_property NFileDescriptorStore)
+if [ "${stored_console_count:-0}" = "0" ]; then
+	echo "    systemd holds no console descriptor; running virtual machines stop during the restart"
+else
+	echo "    systemd holds $stored_console_count console descriptors; the virtual machines stay up"
+fi
+
+# Keep the running binary before anything changes, so every later step can undo.
+step "back up $current_version to $previous_binary"
+cp -a "$installed_binary" "$previous_binary"
+
+# Rename instead of overwrite. The running process keeps its own inode.
+step "install $installed_binary"
+if ! mv -f "$staged_binary" "$installed_binary"; then
+	echo "could not install $installed_binary; the running binary is unchanged" >&2
+	exit 1
+fi
+
+# Restart rather than stop and start. systemd keeps its descriptor store across a
+# restart even when the unit does not set FileDescriptorStorePreserve=yes.
+step "restart $service"
+if ! systemctl restart "$service" || ! service_is_stable; then
+	echo "    $service did not start; restoring $current_version" >&2
+	mv -f "$previous_binary" "$installed_binary"
+	if ! systemctl restart "$service" || ! service_is_stable; then
+		echo "    $service did not start with $current_version" >&2
+	fi
+	exit 1
+fi
+
+step "running metald $(reported_version "$installed_binary")"
+echo "    previous binary: $previous_binary"
+
+if [ "$(unit_property FileDescriptorStorePreserve)" != "yes" ]; then
+	echo "    warning: $service has no FileDescriptorStorePreserve=yes"
+	echo "    a stop of $service still stops every virtual machine"
+	echo "    run the Metal Server action Re-configure Metald to update the unit"
+fi
+
+step "virtual machines on this host"
+systemctl list-units "metal-vm@*" --all --no-legend --no-pager | cat

--- a/metal/cmd/metald/main.go
+++ b/metal/cmd/metald/main.go
@@ -2,6 +2,7 @@
 // drives firecracker microVMs.
 //
 //	metald serve [--config path]   run the server (default)
+//	metald version                 print the build version
 //
 // Use scripts/dev.sh to prepare a throwaway dev host before serve.
 package main
@@ -64,12 +65,16 @@ func main() {
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		cmd, args = args[0], args[1:]
 	}
+	if cmd == "version" {
+		fmt.Println(version)
+		return
+	}
 	configPath, err := parseFlags(cmd, args)
 	if err != nil {
 		os.Exit(2)
 	}
 	if cmd != "serve" {
-		fmt.Fprintf(os.Stderr, "usage: metald [serve] [--config path]\n")
+		fmt.Fprintf(os.Stderr, "usage: metald [serve] [--config path] | metald version\n")
 		os.Exit(2)
 	}
 	o, err := load(configPath)
@@ -155,12 +160,33 @@ func adoptConsoles(
 		return fmt.Errorf("list virtual machine units: %w", err)
 	}
 
+	adoptedConsoleCount := serialBroker.Adopt(runningVirtualMachineIDs)
 	logger.Info(
 		"adopted serial consoles",
-		"adopted_console_count", serialBroker.Adopt(runningVirtualMachineIDs),
+		"adopted_console_count", adoptedConsoleCount,
 		"running_unit_count", len(runningVirtualMachineIDs),
 		"descriptor_store_available", descriptorStoreAvailable,
 	)
+
+	// Without the store, metald holds the only PTY master. Its exit stops every VM.
+	if !descriptorStoreAvailable {
+		logger.Warn(
+			"descriptor store unavailable; a metald exit stops every running VM",
+			"running_unit_count", len(runningVirtualMachineIDs),
+			"required_unit_settings", "NotifyAccess=main, FileDescriptorStoreMax",
+		)
+
+		return nil
+	}
+
+	// A VM without an adopted console has no stored master. Its next metald exit stops it.
+	if adoptedConsoleCount < len(runningVirtualMachineIDs) {
+		logger.Warn(
+			"running VMs have no adopted console; a metald exit stops them",
+			"adopted_console_count", adoptedConsoleCount,
+			"running_unit_count", len(runningVirtualMachineIDs),
+		)
+	}
 
 	return nil
 }

--- a/metal/docs/operations.md
+++ b/metal/docs/operations.md
@@ -23,9 +23,27 @@ Use the virtual machine ID and operation ID to connect API state, JSON logs, sys
 ## Serial console is blank or unavailable
 
 - Symptom: The console closes, or it has no output.
-- Check: Confirm `/run/metal/consoles/<id>` exists. Check `TTYPath`, `StandardInput`, and `StandardOutput` for `metal-vm@<id>.service`. Check `NotifyAccess` and `FileDescriptorStoreMax` for `metal.service`.
-- Recovery: Correct the unit settings, run `systemctl daemon-reload`, then restart the VM through the API.
+- Check: Confirm `/run/metal/consoles/<id>` and the `TTYPath`, `StandardInput`, and `StandardOutput` settings.
+- Check: Read `NotifyAccess`, `FileDescriptorStoreMax`, and `FileDescriptorStorePreserve` for `metal.service`.
+- Check: Run `metald version`. The build must support the descriptor store.
+- Recovery: Correct the unit settings, run `systemctl daemon-reload`, and restart the VM through the API.
 - Do not: Do not restart `metal-vm@<id>.service` or remove a running guest's console link.
+
+## Virtual machines stop when metald stops
+
+- Symptom: Every VM on the host fails with exit code 156 when `metal.service` stops or restarts.
+- Cause: Firecracker holds the PTY slave as its controlling terminal. A closed PTY master sends SIGHUP to Firecracker.
+- Cause: systemd keeps the master in the descriptor store, so the PTY survives a metald exit.
+- Check: Run `systemctl show metal.service -p NFileDescriptorStore`. The count must be one for each running VM.
+- Check: A count of 0 means that systemd holds no console master. Read the metald start log. `descriptor_store_available` must be true, and `adopted_console_count` must equal `running_unit_count`.
+- Check: Confirm `NotifyAccess=main`, `FileDescriptorStoreMax`, and `FileDescriptorStorePreserve=yes` for `metal.service`.
+- Check: Run `systemd-analyze log-level debug` to see why systemd drops a descriptor.
+- Check: Start the VM through the API and read the journal for `Added fd` and `Received EPOLLHUP on stored fd`.
+- Check: Run `systemd-analyze log-level info` to restore the log level.
+- Recovery: Correct the unit settings and run `systemctl daemon-reload`.
+- Recovery: Start each VM again through the API.
+- Recovery: A running VM keeps its unprotected console until it starts again.
+- Do not: Do not start or restart `metal-vm@<id>.service` by hand.
 
 ## Disk usage or ZFS inspection fails
 

--- a/metal/internal/console/SPEC.md
+++ b/metal/internal/console/SPEC.md
@@ -34,9 +34,19 @@ Firecracker --writes--> PTY slave <--symlink-- <sockets>/consoles/<id>
                   ringBuffer   viewers --> API WebSocket
 ```
 
-`Open` stores the master and starts the drain. `Close` releases it. `Attach` adds a viewer. `Shutdown` releases the masters that this process holds. `Adopt` restores stored masters after metald restarts.
+`Open` allocates the master and starts the drain. `Persist` stores it. `Close` releases it. `Attach` adds a viewer. `Shutdown` releases local masters. `Adopt` restores stored masters.
 
-Linux destroys a PTY when its master closes. The systemd descriptor store keeps the masters until the next metald process adopts them. A master is non-blocking, so a release stops the drain read at once and one drain at a time reads a PTY. `NotifyAccess` and `FileDescriptorStoreMax` enable the store.
+Linux destroys a PTY when its master closes. The slave is the controlling terminal of Firecracker. A closed master therefore sends SIGHUP to the guest process and stops the VM.
+
+The systemd descriptor store holds the masters until the VM stops. systemd keeps its copy when it passes a master to the next metald process, so one console survives many restarts.
+
+A master is non-blocking. A release stops the drain read at once. One drain at a time reads a PTY.
+
+The unit needs `NotifyAccess`, `FileDescriptorStoreMax`, and `FileDescriptorStorePreserve=yes`. The first two enable the store. The third keeps it when metald stops.
+
+systemd watches each stored descriptor. It closes a descriptor that reports `EPOLLHUP`. A PTY master reports `EPOLLHUP` while no slave is open.
+
+`Open` keeps the master out of the store. `Persist` adds it after the unit holds the slave.
 
 ## Backpressure
 
@@ -49,6 +59,7 @@ A viewer that attaches receives the scrollback first, then live output. Scrollba
 ```text
 metald start               -> Adopt(running VM IDs)
 firecracker prepareLaunch  -> Open(id)
+firecracker prepareLaunch  -> Persist(id)   after the unit start
 api  GET /v1/vms/{id}/console?mode=tty -> Attach(id)   many, concurrent, capped
 firecracker stop or remove -> Close(id)
 metald shutdown            -> Shutdown()

--- a/metal/internal/console/serial_broker.go
+++ b/metal/internal/console/serial_broker.go
@@ -86,20 +86,38 @@ func (b *SerialBroker) Open(id string) error {
 		return err
 	}
 
-	// Keep one stored descriptor for each VM.
-	if err := b.descriptorStore.Remove(id); err != nil {
-		return b.closeFailedConsole(master, link, fmt.Errorf("clear stored console descriptor: %w", err))
-	}
-	if err := b.descriptorStore.Store(id, master); err != nil {
-		return b.closeFailedConsole(master, link, fmt.Errorf("store console descriptor: %w", err))
-	}
-
 	b.consoles[id] = newConsole(master, link, b.scrollbackBytes)
 
 	return nil
 }
 
-// Adopt restores consoles for running virtual machines.
+// Persist stores a VM's console master after the unit opens the PTY slave.
+// systemd drops a stored descriptor that reports EPOLLHUP.
+func (b *SerialBroker) Persist(id string) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	openConsole := b.consoles[id]
+	if openConsole == nil {
+		return ErrConsoleNotFound
+	}
+
+	return b.storeMaster(id, openConsole.master)
+}
+
+// storeMaster keeps one stored descriptor for each VM.
+func (b *SerialBroker) storeMaster(id string, master *os.File) error {
+	if err := b.descriptorStore.Remove(id); err != nil {
+		return fmt.Errorf("clear stored console descriptor: %w", err)
+	}
+	if err := b.descriptorStore.Store(id, master); err != nil {
+		return fmt.Errorf("store console descriptor: %w", err)
+	}
+
+	return nil
+}
+
+// Adopt restores consoles for running virtual machines without storing them again.
 func (b *SerialBroker) Adopt(runningVirtualMachineIDs []string) int {
 	runningVirtualMachines := make(map[string]struct{}, len(runningVirtualMachineIDs))
 	for _, virtualMachineID := range runningVirtualMachineIDs {
@@ -178,14 +196,6 @@ func newNonBlockingMaster(master *os.File) (*os.File, error) {
 	}
 
 	return os.NewFile(duplicate, master.Name()), nil
-}
-
-// closeFailedConsole removes a failed console setup.
-func (b *SerialBroker) closeFailedConsole(master *os.File, link string, cause error) error {
-	master.Close()
-	_ = os.Remove(link)
-
-	return cause
 }
 
 // removeStaleConsole releases a stale console and its master files.

--- a/metal/internal/console/serial_broker_test.go
+++ b/metal/internal/console/serial_broker_test.go
@@ -36,10 +36,20 @@ func (s *fakeDescriptorStore) Remove(name string) error {
 	return nil
 }
 
+// TakeFiles duplicates stored descriptors because systemd keeps its own copies.
 func (s *fakeDescriptorStore) TakeFiles() map[string][]*os.File {
-	storedDescriptors := s.descriptorsByName
-	s.descriptorsByName = make(map[string][]*os.File)
-	return storedDescriptors
+	passedDescriptors := make(map[string][]*os.File, len(s.descriptorsByName))
+	for name, storedFiles := range s.descriptorsByName {
+		for _, storedFile := range storedFiles {
+			duplicate, err := duplicateDescriptor(storedFile)
+			if err != nil {
+				panic(err)
+			}
+			passedDescriptors[name] = append(passedDescriptors[name], duplicate)
+		}
+	}
+
+	return passedDescriptors
 }
 
 // duplicateDescriptor copies a descriptor into an independent file.
@@ -83,6 +93,11 @@ func TestShutdownKeepsMastersSoAdoptRestoresRunningConsoles(t *testing.T) {
 	}
 	defer slave.Close()
 
+	// The unit holds the slave now, which is when the master can be stored.
+	if err := broker.Persist("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+
 	broker.Shutdown()
 
 	if _, err := slave.Write([]byte("output during restart\r\n")); err != nil {
@@ -96,6 +111,38 @@ func TestShutdownKeepsMastersSoAdoptRestoresRunningConsoles(t *testing.T) {
 	defer restarted.Shutdown()
 
 	expectConsoleOutput(t, restarted, "vm-1", "output during restart")
+}
+
+// Open must leave the master out of the store until the unit holds the slave.
+func TestOpenStoresNothingUntilPersist(t *testing.T) {
+	directory := t.TempDir()
+	descriptorStore := newFakeDescriptorStore()
+
+	broker := NewSerialBroker(directory, descriptorStore)
+	defer broker.Shutdown()
+
+	if err := broker.Open("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	if stored := len(descriptorStore.descriptorsByName); stored != 0 {
+		t.Fatalf("Open stored %d descriptors, want 0", stored)
+	}
+
+	if err := broker.Persist("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	if stored := len(descriptorStore.descriptorsByName["vm-1"]); stored != 1 {
+		t.Fatalf("Persist stored %d descriptors, want 1", stored)
+	}
+}
+
+// Persist reports a VM that has no console.
+func TestPersistWithoutAConsoleIsAnError(t *testing.T) {
+	broker := NewSerialBroker(t.TempDir(), newFakeDescriptorStore())
+
+	if err := broker.Persist("vm-missing"); !errors.Is(err, ErrConsoleNotFound) {
+		t.Fatalf("Persist error = %v, want %v", err, ErrConsoleNotFound)
+	}
 }
 
 // TestAdoptReleasesConsolesOfGuestsThatAreGone removes stale state.
@@ -122,6 +169,33 @@ func TestAdoptReleasesConsolesOfGuestsThatAreGone(t *testing.T) {
 	}
 }
 
+// A stored copy lets a console survive more than one metald restart.
+func TestAdoptKeepsTheDescriptorForTheNextRestart(t *testing.T) {
+	directory := t.TempDir()
+	descriptorStore := newFakeDescriptorStore()
+
+	broker := NewSerialBroker(directory, descriptorStore)
+	if err := broker.Open("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := broker.Persist("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	broker.Shutdown()
+
+	for restart := range 3 {
+		restarted := NewSerialBroker(directory, descriptorStore)
+		if adopted := restarted.Adopt([]string{"vm-1"}); adopted != 1 {
+			t.Fatalf("restart %d: adopted = %d, want 1", restart, adopted)
+		}
+		restarted.Shutdown()
+
+		if count := len(descriptorStore.descriptorsByName["vm-1"]); count != 1 {
+			t.Fatalf("restart %d: stored descriptors = %d, want 1", restart, count)
+		}
+	}
+}
+
 // TestAdoptRemovesLinksWithoutAConsole removes a stale link.
 func TestAdoptRemovesLinksWithoutAConsole(t *testing.T) {
 	directory := t.TempDir()
@@ -141,22 +215,33 @@ func TestAdoptRemovesLinksWithoutAConsole(t *testing.T) {
 	}
 }
 
-// TestOpenReplacesAStoredDescriptor keeps one descriptor per VM.
-func TestOpenReplacesAStoredDescriptor(t *testing.T) {
+// TestPersistReplacesAStoredDescriptor keeps one descriptor per VM across a
+// stop and a start of the same VM.
+func TestPersistReplacesAStoredDescriptor(t *testing.T) {
 	directory := t.TempDir()
 	descriptorStore := newFakeDescriptorStore()
 
 	broker := NewSerialBroker(directory, descriptorStore)
-	if err := broker.Open("vm-1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := broker.Close("vm-1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := broker.Open("vm-1"); err != nil {
-		t.Fatal(err)
-	}
 	defer broker.Shutdown()
+
+	for range 2 {
+		if err := broker.Open("vm-1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := broker.Persist("vm-1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := broker.Close("vm-1"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := broker.Open("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := broker.Persist("vm-1"); err != nil {
+		t.Fatal(err)
+	}
 
 	if count := len(descriptorStore.descriptorsByName["vm-1"]); count != 1 {
 		t.Fatalf("stored descriptors for vm-1 = %d, want 1", count)
@@ -169,6 +254,9 @@ func TestCloseRemovesTheStoredDescriptor(t *testing.T) {
 	broker := NewSerialBroker(t.TempDir(), descriptorStore)
 
 	if err := broker.Open("vm-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := broker.Persist("vm-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := broker.Close("vm-1"); err != nil {

--- a/metal/internal/firecracker/SPEC.md
+++ b/metal/internal/firecracker/SPEC.md
@@ -42,6 +42,7 @@ Cold and warm launch share one preparation step:
 write the jailer environment and the socket link
 open the console PTY          before the unit starts, so no output is lost
 start the systemd unit
+persist the console master    after the unit holds the PTY slave
 set unit resource limits
 wait for the API socket       the process belongs to systemd, so this is the only signal
     |

--- a/metal/internal/firecracker/launch.go
+++ b/metal/internal/firecracker/launch.go
@@ -65,6 +65,14 @@ func (runtime *Runtime) prepareLaunch(ctx context.Context, configuration vm.Runt
 	if err := runtime.units.Start(ctx, configuration.ID); err != nil {
 		return err
 	}
+	// The unit holds the slave now, so systemd can keep the master.
+	if err := runtime.serialBroker.Persist(configuration.ID); err != nil {
+		runtime.logger.Warn(
+			"console master not preserved; a metald exit stops this VM",
+			"virtual_machine_id", configuration.ID,
+			"error", err,
+		)
+	}
 	if err := runtime.units.SetLimits(ctx, configuration.ID, resourceLimits(configuration.Specification)); err != nil {
 		return err
 	}

--- a/metal/internal/firecracker/runtime.go
+++ b/metal/internal/firecracker/runtime.go
@@ -40,6 +40,7 @@ type imageStore interface {
 // serialBroker manages each VM's serial console PTY.
 type serialBroker interface {
 	Open(id string) error
+	Persist(id string) error
 	Close(id string) error
 }
 

--- a/metal/internal/firecracker/stop_test.go
+++ b/metal/internal/firecracker/stop_test.go
@@ -29,8 +29,9 @@ type stubUnits struct {
 
 type stubSerialBroker struct{}
 
-func (*stubSerialBroker) Open(string) error  { return nil }
-func (*stubSerialBroker) Close(string) error { return nil }
+func (*stubSerialBroker) Open(string) error    { return nil }
+func (*stubSerialBroker) Persist(string) error { return nil }
+func (*stubSerialBroker) Close(string) error   { return nil }
 
 func (s *stubUnits) shutdown() {
 	s.mu.Lock()

--- a/metal/internal/platform/SPEC.md
+++ b/metal/internal/platform/SPEC.md
@@ -47,14 +47,16 @@ The context cancels systemd waits and polling. The VM runtime maps the returned 
 
 ## File descriptor store
 
-systemd holds file descriptors across a service restart. `FileDescriptorStore` stores one with `FDSTORE=1`, removes one with `FDSTOREREMOVE=1`, and reads the descriptors systemd returns.
+systemd holds file descriptors across a restart or a stop of the service. `FileDescriptorStore` stores one with `FDSTORE=1`, removes one with `FDSTOREREMOVE=1`, and reads the descriptors that systemd returns.
 
 ```text
 metald run 1 --FDSTORE=1, FDNAME=<id>--> systemd --holds--> descriptor
 metald run 2 <--LISTEN_FDS, LISTEN_FDNAMES-- systemd
 ```
 
-The unit needs `NotifyAccess` and `FileDescriptorStoreMax`. Without the notification socket, `IsAvailable` is false and store operations do nothing.
+The unit needs `NotifyAccess`, `FileDescriptorStoreMax`, and `FileDescriptorStorePreserve=yes`. Without the notification socket, `IsAvailable` is false and store operations do nothing.
+
+Without `FileDescriptorStorePreserve=yes`, systemd releases the descriptors when the service stops.
 
 ## Related
 

--- a/metal/internal/platform/systemd_fdstore.go
+++ b/metal/internal/platform/systemd_fdstore.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"syscall"
@@ -17,7 +16,7 @@ const notificationSocketEnvironmentVariable = "NOTIFY_SOCKET"
 // ErrInvalidStoreName reports a descriptor name that systemd cannot accept.
 var ErrInvalidStoreName = errors.New("platform: invalid file descriptor store name")
 
-// FileDescriptorStore keeps file descriptors in systemd across a service restart.
+// FileDescriptorStore keeps service file descriptors in systemd.
 type FileDescriptorStore struct {
 	notificationSocketAddress string
 }
@@ -61,20 +60,18 @@ func (s *FileDescriptorStore) sendDescriptorStoreNotification(notificationMessag
 		return nil
 	}
 
-	// systemd uses "@" for an abstract socket address.
-	notificationSocketAddress := s.notificationSocketAddress
-	if strings.HasPrefix(notificationSocketAddress, "@") {
-		notificationSocketAddress = "\x00" + notificationSocketAddress[1:]
-	}
-
-	notificationConnection, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: notificationSocketAddress, Net: "unixgram"})
+	notificationSocket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_DGRAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
-		return fmt.Errorf("dial notification socket: %w", err)
+		return fmt.Errorf("open notification socket: %w", err)
 	}
-	defer notificationConnection.Close()
+	defer syscall.Close(notificationSocket)
+
+	notificationAddress := &syscall.SockaddrUnix{
+		Name: notificationSocketName(s.notificationSocketAddress),
+	}
 
 	if descriptorFile == nil {
-		if _, _, err := notificationConnection.WriteMsgUnix([]byte(notificationMessage), nil, nil); err != nil {
+		if _, err := syscall.SendmsgN(notificationSocket, []byte(notificationMessage), nil, notificationAddress, 0); err != nil {
 			return fmt.Errorf("send notification message: %w", err)
 		}
 
@@ -90,7 +87,13 @@ func (s *FileDescriptorStore) sendDescriptorStoreNotification(notificationMessag
 	var notificationError error
 	sendDescriptor := func(fileDescriptor uintptr) {
 		rights := syscall.UnixRights(int(fileDescriptor))
-		_, _, notificationError = notificationConnection.WriteMsgUnix([]byte(notificationMessage), rights, nil)
+		_, notificationError = syscall.SendmsgN(
+			notificationSocket,
+			[]byte(notificationMessage),
+			rights,
+			notificationAddress,
+			0,
+		)
 	}
 	if err := rawFileDescriptor.Control(sendDescriptor); err != nil {
 		return fmt.Errorf("access file descriptor: %w", err)
@@ -100,6 +103,15 @@ func (s *FileDescriptorStore) sendDescriptorStoreNotification(notificationMessag
 	}
 
 	return nil
+}
+
+// notificationSocketName converts the systemd abstract socket notation.
+func notificationSocketName(notificationSocketAddress string) string {
+	if strings.HasPrefix(notificationSocketAddress, "@") {
+		return "\x00" + notificationSocketAddress[1:]
+	}
+
+	return notificationSocketAddress
 }
 
 // validateDescriptorName rejects an invalid systemd descriptor name.

--- a/metal/internal/platform/systemd_fdstore_test.go
+++ b/metal/internal/platform/systemd_fdstore_test.go
@@ -1,0 +1,140 @@
+package platform
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// newNotificationReceiver returns a systemd notification socket and its address.
+func newNotificationReceiver(t *testing.T) (*net.UnixConn, string) {
+	t.Helper()
+
+	name := fmt.Sprintf("metald-test-%s-%d", t.Name(), os.Getpid())
+	receiver, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: "\x00" + name, Net: "unixgram"})
+	if err != nil {
+		t.Fatalf("listen on notification socket: %v", err)
+	}
+	t.Cleanup(func() { receiver.Close() })
+
+	return receiver, "@" + name
+}
+
+// readNotification returns the next message and the descriptors it carries.
+func readNotification(t *testing.T, receiver *net.UnixConn) (string, []int) {
+	t.Helper()
+
+	message := make([]byte, 4096)
+	control := make([]byte, 4096)
+	messageCount, controlCount, _, _, err := receiver.ReadMsgUnix(message, control)
+	if err != nil {
+		t.Fatalf("read notification: %v", err)
+	}
+	if controlCount == 0 {
+		return string(message[:messageCount]), nil
+	}
+
+	controlMessages, err := syscall.ParseSocketControlMessage(control[:controlCount])
+	if err != nil {
+		t.Fatalf("parse control message: %v", err)
+	}
+	descriptors, err := syscall.ParseUnixRights(&controlMessages[0])
+	if err != nil {
+		t.Fatalf("parse descriptor rights: %v", err)
+	}
+
+	return string(message[:messageCount]), descriptors
+}
+
+// Store must carry the file itself, not only its name.
+func TestStoreSendsTheDescriptor(t *testing.T) {
+	receiver, address := newNotificationReceiver(t)
+	t.Setenv(notificationSocketEnvironmentVariable, address)
+
+	payload := newDescriptorFile(t, "carried through the store")
+	if err := NewFileDescriptorStore().Store("vm-00010", payload); err != nil {
+		t.Fatalf("store descriptor: %v", err)
+	}
+
+	message, descriptors := readNotification(t, receiver)
+	if message != "FDSTORE=1\nFDNAME=vm-00010" {
+		t.Fatalf("unexpected message %q", message)
+	}
+	if len(descriptors) != 1 {
+		t.Fatalf("got %d descriptors, want 1", len(descriptors))
+	}
+
+	received := os.NewFile(uintptr(descriptors[0]), "received")
+	defer received.Close()
+	contents := make([]byte, 64)
+	count, _ := received.ReadAt(contents, 0)
+	if string(contents[:count]) != "carried through the store" {
+		t.Fatalf("descriptor holds %q", contents[:count])
+	}
+}
+
+func TestRemoveSendsTheName(t *testing.T) {
+	receiver, address := newNotificationReceiver(t)
+	t.Setenv(notificationSocketEnvironmentVariable, address)
+
+	if err := NewFileDescriptorStore().Remove("vm-00010"); err != nil {
+		t.Fatalf("remove descriptor: %v", err)
+	}
+
+	message, descriptors := readNotification(t, receiver)
+	if message != "FDSTOREREMOVE=1\nFDNAME=vm-00010" {
+		t.Fatalf("unexpected message %q", message)
+	}
+	if len(descriptors) != 0 {
+		t.Fatalf("got %d descriptors, want 0", len(descriptors))
+	}
+}
+
+// Without NOTIFY_SOCKET, store operations are no-ops.
+func TestStoreIsANoOperationWithoutASocket(t *testing.T) {
+	t.Setenv(notificationSocketEnvironmentVariable, "")
+
+	store := NewFileDescriptorStore()
+	if store.IsAvailable() {
+		t.Fatal("store reports available without NOTIFY_SOCKET")
+	}
+	if err := store.Store("vm-00010", os.Stdin); err != nil {
+		t.Fatalf("store descriptor: %v", err)
+	}
+	if err := store.Remove("vm-00010"); err != nil {
+		t.Fatalf("remove descriptor: %v", err)
+	}
+}
+
+func TestInvalidDescriptorNameIsRejected(t *testing.T) {
+	_, address := newNotificationReceiver(t)
+	t.Setenv(notificationSocketEnvironmentVariable, address)
+
+	store := NewFileDescriptorStore()
+	for _, name := range []string{"", "vm:00010", "vm\n00010"} {
+		if err := store.Store(name, os.Stdin); err == nil {
+			t.Fatalf("store accepted name %q", name)
+		}
+		if err := store.Remove(name); err == nil {
+			t.Fatalf("remove accepted name %q", name)
+		}
+	}
+}
+
+// newDescriptorFile returns a temporary file that holds contents.
+func newDescriptorFile(t *testing.T, contents string) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "descriptor")
+	if err != nil {
+		t.Fatalf("create temporary file: %v", err)
+	}
+	t.Cleanup(func() { file.Close() })
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatalf("write temporary file: %v", err)
+	}
+
+	return file
+}


### PR DESCRIPTION
## Problem

Every virtual machine on a host stopped when `metal.service` stopped or restarted.

Firecracker holds the PTY slave of its serial console as its controlling terminal, and metald holds the master. When metald exits, the master closes and the kernel sends SIGHUP to Firecracker, which exits with code 156.

The systemd file descriptor store prevents this, because it keeps the master open across a metald exit. It never worked. The unit did not enable the store, the store used a connected datagram socket that cannot carry a descriptor, and systemd dropped the descriptor at once because a PTY master reports `POLLHUP` while no slave is open.

## Solution

The console master now goes into the descriptor store at a point where systemd keeps it, and the unit holds the store through a stop. A guest survives a stop, a start, and a restart of metald.

metald reports at start when a running VM has no protected console, so a host in this state is visible instead of silent.