### PR TITLE
feat(api-clients): Generate the Python API clients

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           python -m venv "$RUNNER_TEMP/openapi-generator"
-          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1 ruff==0.16.6
           export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
           PYTHONPATH="$GITHUB_WORKSPACE" ./env/bin/python "$GITHUB_WORKSPACE/scripts/generate-api-client.py" atlas
           git -C "$GITHUB_WORKSPACE" add --all --intent-to-add clients

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -96,6 +96,17 @@ jobs:
         env:
           CI: 'Yes'
 
+      - name: Check the generated API client
+        working-directory: /home/runner/frappe-bench
+        run: |
+          python -m venv "$RUNNER_TEMP/openapi-generator"
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
+          export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
+          PYTHONPATH="$GITHUB_WORKSPACE" ./env/bin/python "$GITHUB_WORKSPACE/scripts/generate-api-client.py" atlas
+          git -C "$GITHUB_WORKSPACE" add --all --intent-to-add clients
+          git -C "$GITHUB_WORKSPACE" diff --exit-code -- clients \
+            || { echo "The committed client is stale. Run scripts/generate-api-client.py atlas and commit clients/."; exit 1; }
+
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
         run: |
@@ -103,3 +114,4 @@ jobs:
           bench --site test_site run-tests --app atlas
         env:
           TYPE: server
+

--- a/.github/workflows/http-proxy-tests.yml
+++ b/.github/workflows/http-proxy-tests.yml
@@ -46,10 +46,11 @@ jobs:
       - name: Check the generated API client
         working-directory: ${{ github.workspace }}
         run: |
+          control_python="$(command -v python)"
           python -m venv "$RUNNER_TEMP/openapi-generator"
-          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1 ruff==0.16.6
           export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
-          python scripts/generate-api-client.py atlas-http-proxy
+          "$control_python" scripts/generate-api-client.py atlas-http-proxy
           git add --all --intent-to-add clients
           git diff --exit-code -- clients \
             || { echo "The committed client is stale. Run scripts/generate-api-client.py atlas-http-proxy and commit clients/."; exit 1; }

--- a/.github/workflows/http-proxy-tests.yml
+++ b/.github/workflows/http-proxy-tests.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     paths:
       - "services/http-proxy/**"
+      - "scripts/generate-api-client.py"
+      - "clients/atlas-http-proxy/**"
+      - "clients/openapi/atlas-http-proxy.json"
   push:
     branches:
       - develop
     paths:
       - "services/http-proxy/**"
+      - "scripts/generate-api-client.py"
+      - "clients/atlas-http-proxy/**"
+      - "clients/openapi/atlas-http-proxy.json"
 
 permissions:
   contents: read
@@ -36,6 +42,17 @@ jobs:
 
       - name: Run control daemon unit tests
         run: python -m pytest -q control/tests
+
+      - name: Check the generated API client
+        working-directory: ${{ github.workspace }}
+        run: |
+          python -m venv "$RUNNER_TEMP/openapi-generator"
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
+          export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
+          python scripts/generate-api-client.py atlas-http-proxy
+          git add --all --intent-to-add clients
+          git diff --exit-code -- clients \
+            || { echo "The committed client is stale. Run scripts/generate-api-client.py atlas-http-proxy and commit clients/."; exit 1; }
 
       - name: Start test stack
         run: docker compose -f tests/docker/docker-compose.yml up --build -d

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+build/
 develop-eggs/
 dist/
 downloads/
@@ -57,6 +58,7 @@ jspm_packages/
 # Claude / tooling
 .claude
 .ruff_cache/
+.pdm-build/
 
 # Go build artifacts
 /metal/metald

--- a/SPEC.md
+++ b/SPEC.md
@@ -10,6 +10,7 @@ The root contains the Frappe app and three components. They are not separate Git
 
 ```text
 atlas/                         Frappe app
+clients/                       Generated API clients
 metal/                         VM management
 services/http-proxy/           HTTP proxy
 services/wg-mesh/              Private VM network
@@ -27,6 +28,8 @@ SPEC.md                        This file
 - [WG Mesh](services/wg-mesh/SPEC.md): Private VM network.
 
 Read the matching specification before you change a component.
+
+`clients/` holds the generated Python clients for the Atlas API and the HTTP proxy control API. See [API clients](docs/api-clients.md).
 
 Each component specification links back to this file.
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,36 @@
+# Atlas API clients
+
+`clients/atlas` and `clients/atlas-http-proxy` are generated. `scripts/generate-api-clients.sh` writes them. Read `docs/api-clients.md` for the generation steps.
+
+## Authentication
+
+The Atlas API reads two headers on each request. `X-Atlas-Central-Token` holds the token of the central issuer. `X-Tenant-ID` holds the tenant that owns the resource. The generated client sends the tenant header as the `x_tenant_id` argument. Give the token to the client as a default header.
+
+`scripts/dev-jwks-server.py` mints a token for a local site. Start it, set `central_jwks_url` in Atlas Settings to its `/jwks` URL, and type the `admin_audience_id` of the site to get a token.
+
+## Example: open a VM console
+
+The console token is single use and expires after 60 seconds. The console page reads it from the URL fragment, so the token stays out of the server logs and out of the `Referer` header.
+
+```python
+from atlas import Client
+from atlas.api.vm_actions import create_virtual_machine_console_token
+from atlas.models import ConsoleTokenPayload, ConsoleTokenPayloadMode
+
+BASE_URL = "https://atlas.localhost"
+client = Client(base_url=BASE_URL, headers={"X-Atlas-Central-Token": CENTRAL_TOKEN})
+
+with client as client:
+    console = create_virtual_machine_console_token.sync(
+        "vm-00010",
+        client=client,
+        body=ConsoleTokenPayload(mode=ConsoleTokenPayloadMode.TTY),
+        x_tenant_id=12,
+    )
+
+print(f"{BASE_URL}/vm_console?vm=vm-00010#token={console.token}")
+```
+
+`console.mode` is `tty` for the serial console and `ssh` for the SSH console. `console.expires_in` is the lifetime in seconds.
+
+Open the printed URL in a browser. The page connects to the Atlas realtime service and sends the token one time. A second use of the token fails, because the realtime service deletes the token when it opens the session.

--- a/clients/atlas-http-proxy/.gitignore
+++ b/clients/atlas-http-proxy/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/clients/atlas-http-proxy/README.md
+++ b/clients/atlas-http-proxy/README.md
@@ -1,0 +1,110 @@
+# atlas-http-proxy
+A client library for accessing Atlas proxy control
+
+## Usage
+First, create a client:
+
+```python
+from atlas_http_proxy import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from atlas_http_proxy import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from atlas_http_proxy.models import MyDataModel
+from atlas_http_proxy.api.my_tag import get_my_data_model
+from atlas_http_proxy.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from atlas_http_proxy.models import MyDataModel
+from atlas_http_proxy.api.my_tag import get_my_data_model
+from atlas_http_proxy.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `atlas_http_proxy.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from atlas_http_proxy import Client
+
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from atlas_http_proxy import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+

--- a/clients/atlas-http-proxy/atlas_http_proxy/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing Atlas proxy control"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/delete_domain.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/delete_domain.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    domain: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/domains/{domain}".format(
+            domain=quote(str(domain), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Remove domain route
+
+     Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
+    is absent.
+
+    Args:
+        domain (str): The complete custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        domain=domain,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Remove domain route
+
+     Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
+    is absent.
+
+    Args:
+        domain (str): The complete custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        domain=domain,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Remove domain route
+
+     Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
+    is absent.
+
+    Args:
+        domain (str): The complete custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        domain=domain,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Remove domain route
+
+     Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
+    is absent.
+
+    Args:
+        domain (str): The complete custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            domain=domain,
+            client=client,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/get_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/get_domains.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_domains_response_get_domains import GetDomainsResponseGetDomains
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/domains",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetDomainsResponseGetDomains | None:
+    if response.status_code == 200:
+        response_200 = GetDomainsResponseGetDomains.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetDomainsResponseGetDomains]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[GetDomainsResponseGetDomains]:
+    """List domain routes
+
+     Read custom-domain routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetDomainsResponseGetDomains]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> GetDomainsResponseGetDomains | None:
+    """List domain routes
+
+     Read custom-domain routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetDomainsResponseGetDomains
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[GetDomainsResponseGetDomains]:
+    """List domain routes
+
+     Read custom-domain routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetDomainsResponseGetDomains]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> GetDomainsResponseGetDomains | None:
+    """List domain routes
+
+     Read custom-domain routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetDomainsResponseGetDomains
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/patch_domain.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/patch_domain.py
@@ -1,0 +1,194 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.address_update import AddressUpdate
+from ...models.domain_mapping import DomainMapping
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    domain: str,
+    *,
+    body: AddressUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/v1/domains/{domain}".format(
+            domain=quote(str(domain), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> DomainMapping | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = DomainMapping.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[DomainMapping | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> Response[DomainMapping | HTTPValidationError]:
+    """Update domain route
+
+     Add or change one custom-domain route without changing other domains. Example: route
+    `www.example.com` to `2001:db8::20`.
+
+    Args:
+        domain (str): The complete custom domain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DomainMapping | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        domain=domain,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> DomainMapping | HTTPValidationError | None:
+    """Update domain route
+
+     Add or change one custom-domain route without changing other domains. Example: route
+    `www.example.com` to `2001:db8::20`.
+
+    Args:
+        domain (str): The complete custom domain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DomainMapping | HTTPValidationError
+    """
+
+    return sync_detailed(
+        domain=domain,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> Response[DomainMapping | HTTPValidationError]:
+    """Update domain route
+
+     Add or change one custom-domain route without changing other domains. Example: route
+    `www.example.com` to `2001:db8::20`.
+
+    Args:
+        domain (str): The complete custom domain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DomainMapping | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        domain=domain,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> DomainMapping | HTTPValidationError | None:
+    """Update domain route
+
+     Add or change one custom-domain route without changing other domains. Example: route
+    `www.example.com` to `2001:db8::20`.
+
+    Args:
+        domain (str): The complete custom domain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DomainMapping | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            domain=domain,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/replace_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/replace_domains.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.map_replaced import MapReplaced
+from ...models.replace_domains_values import ReplaceDomainsValues
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: ReplaceDomainsValues,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/domains",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MapReplaced | None:
+    if response.status_code == 200:
+        response_200 = MapReplaced.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MapReplaced]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceDomainsValues,
+) -> Response[HTTPValidationError | MapReplaced]:
+    """Sync domain routes
+
+     Replace every custom-domain route after a controller restart or full reconciliation. Example:
+    `www.example.com` routes to `2001:db8::20`.
+
+    Args:
+        body (ReplaceDomainsValues): The complete desired custom-domain map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MapReplaced]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceDomainsValues,
+) -> HTTPValidationError | MapReplaced | None:
+    """Sync domain routes
+
+     Replace every custom-domain route after a controller restart or full reconciliation. Example:
+    `www.example.com` routes to `2001:db8::20`.
+
+    Args:
+        body (ReplaceDomainsValues): The complete desired custom-domain map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MapReplaced
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceDomainsValues,
+) -> Response[HTTPValidationError | MapReplaced]:
+    """Sync domain routes
+
+     Replace every custom-domain route after a controller restart or full reconciliation. Example:
+    `www.example.com` routes to `2001:db8::20`.
+
+    Args:
+        body (ReplaceDomainsValues): The complete desired custom-domain map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MapReplaced]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceDomainsValues,
+) -> HTTPValidationError | MapReplaced | None:
+    """Sync domain routes
+
+     Replace every custom-domain route after a controller restart or full reconciliation. Example:
+    `www.example.com` routes to `2001:db8::20`.
+
+    Args:
+        body (ReplaceDomainsValues): The complete desired custom-domain map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MapReplaced
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/cluster_status.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/cluster_status.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.cluster_status_response_cluster_status import ClusterStatusResponseClusterStatus
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/cluster/status",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ClusterStatusResponseClusterStatus | None:
+    if response.status_code == 200:
+        response_200 = ClusterStatusResponseClusterStatus.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ClusterStatusResponseClusterStatus]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ClusterStatusResponseClusterStatus]:
+    """Cluster Status
+
+     Return the local cluster status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ClusterStatusResponseClusterStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> ClusterStatusResponseClusterStatus | None:
+    """Cluster Status
+
+     Return the local cluster status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ClusterStatusResponseClusterStatus
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ClusterStatusResponseClusterStatus]:
+    """Cluster Status
+
+     Return the local cluster status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ClusterStatusResponseClusterStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> ClusterStatusResponseClusterStatus | None:
+    """Cluster Status
+
+     Return the local cluster status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ClusterStatusResponseClusterStatus
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/healthz.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/healthz.py
@@ -1,0 +1,85 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/healthz",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
+    if response.status_code == 200:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Check traffic health
+
+     Use this route for the DNS health check. It checks OpenResty and the routes it holds.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Check traffic health
+
+     Use this route for the DNS health check. It checks OpenResty and the routes it holds.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/readyz.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/readyz.py
@@ -1,0 +1,85 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/readyz",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
+    if response.status_code == 200:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Check OpenResty readiness
+
+     Use this route before a controller sends routing updates. It checks the OpenResty admin API.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    """Check OpenResty readiness
+
+     Use this route before a controller sends routing updates. It checks the OpenResty admin API.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/delete_site.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/delete_site.py
@@ -1,0 +1,167 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    name: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/sites/{name}".format(
+            name=quote(str(name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Remove site route
+
+     Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
+
+    Args:
+        name (str): The site subdomain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Remove site route
+
+     Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
+
+    Args:
+        name (str): The site subdomain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | HTTPValidationError]:
+    """Remove site route
+
+     Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
+
+    Args:
+        name (str): The site subdomain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | HTTPValidationError | None:
+    """Remove site route
+
+     Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
+
+    Args:
+        name (str): The site subdomain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/get_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/get_sites.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_sites_response_get_sites import GetSitesResponseGetSites
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sites",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetSitesResponseGetSites | None:
+    if response.status_code == 200:
+        response_200 = GetSitesResponseGetSites.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetSitesResponseGetSites]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[GetSitesResponseGetSites]:
+    """List site routes
+
+     Read site routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetSitesResponseGetSites]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> GetSitesResponseGetSites | None:
+    """List site routes
+
+     Read site routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetSitesResponseGetSites
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[GetSitesResponseGetSites]:
+    """List site routes
+
+     Read site routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetSitesResponseGetSites]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> GetSitesResponseGetSites | None:
+    """List site routes
+
+     Read site routes during reconciliation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetSitesResponseGetSites
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/patch_site.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/patch_site.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.address_update import AddressUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...models.site_mapping import SiteMapping
+from ...types import Response
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    body: AddressUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/v1/sites/{name}".format(
+            name=quote(str(name), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SiteMapping | None:
+    if response.status_code == 200:
+        response_200 = SiteMapping.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SiteMapping]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> Response[HTTPValidationError | SiteMapping]:
+    """Update site route
+
+     Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
+
+    Args:
+        name (str): The site subdomain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SiteMapping]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> HTTPValidationError | SiteMapping | None:
+    """Update site route
+
+     Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
+
+    Args:
+        name (str): The site subdomain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SiteMapping
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> Response[HTTPValidationError | SiteMapping]:
+    """Update site route
+
+     Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
+
+    Args:
+        name (str): The site subdomain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SiteMapping]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: AuthenticatedClient,
+    body: AddressUpdate,
+) -> HTTPValidationError | SiteMapping | None:
+    """Update site route
+
+     Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
+
+    Args:
+        name (str): The site subdomain.
+        body (AddressUpdate): One address for one site or custom domain.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SiteMapping
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/replace_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/replace_sites.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.map_replaced import MapReplaced
+from ...models.replace_sites_values import ReplaceSitesValues
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: ReplaceSitesValues,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/sites",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MapReplaced | None:
+    if response.status_code == 200:
+        response_200 = MapReplaced.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MapReplaced]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceSitesValues,
+) -> Response[HTTPValidationError | MapReplaced]:
+    """Sync site routes
+
+     Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
+    `2001:db8::10`.
+
+    Args:
+        body (ReplaceSitesValues): The complete desired site map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MapReplaced]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceSitesValues,
+) -> HTTPValidationError | MapReplaced | None:
+    """Sync site routes
+
+     Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
+    `2001:db8::10`.
+
+    Args:
+        body (ReplaceSitesValues): The complete desired site map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MapReplaced
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceSitesValues,
+) -> Response[HTTPValidationError | MapReplaced]:
+    """Sync site routes
+
+     Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
+    `2001:db8::10`.
+
+    Args:
+        body (ReplaceSitesValues): The complete desired site map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MapReplaced]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: ReplaceSitesValues,
+) -> HTTPValidationError | MapReplaced | None:
+    """Sync site routes
+
+     Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
+    `2001:db8::10`.
+
+    Args:
+        body (ReplaceSitesValues): The complete desired site map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MapReplaced
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/client.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any, Self
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> Self:
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> Self:
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> Self:
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> Self:
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> Self:
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> Self:
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> Self:
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> Self:
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/clients/atlas-http-proxy/atlas_http_proxy/errors.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/__init__.py
@@ -1,0 +1,29 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .address_update import AddressUpdate
+from .cluster_status_response_cluster_status import ClusterStatusResponseClusterStatus
+from .domain_mapping import DomainMapping
+from .get_domains_response_get_domains import GetDomainsResponseGetDomains
+from .get_sites_response_get_sites import GetSitesResponseGetSites
+from .http_validation_error import HTTPValidationError
+from .map_replaced import MapReplaced
+from .replace_domains_values import ReplaceDomainsValues
+from .replace_sites_values import ReplaceSitesValues
+from .site_mapping import SiteMapping
+from .validation_error import ValidationError
+from .validation_error_context import ValidationErrorContext
+
+__all__ = (
+    "AddressUpdate",
+    "ClusterStatusResponseClusterStatus",
+    "DomainMapping",
+    "GetDomainsResponseGetDomains",
+    "GetSitesResponseGetSites",
+    "HTTPValidationError",
+    "MapReplaced",
+    "ReplaceDomainsValues",
+    "ReplaceSitesValues",
+    "SiteMapping",
+    "ValidationError",
+    "ValidationErrorContext",
+)

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/address_update.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/address_update.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="AddressUpdate")
+
+
+@_attrs_define
+class AddressUpdate:
+    """One address for one site or custom domain.
+
+    Attributes:
+        address (str): The backend IPv6 address. Use `-` only for a site to stop its traffic.
+    """
+
+    address: str
+
+    def to_dict(self) -> dict[str, Any]:
+        address = self.address
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "address": address,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        address = d.pop("address")
+
+        address_update = cls(
+            address=address,
+        )
+
+        return address_update

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/cluster_status_response_cluster_status.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/cluster_status_response_cluster_status.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ClusterStatusResponseClusterStatus")
+
+
+@_attrs_define
+class ClusterStatusResponseClusterStatus:
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        cluster_status_response_cluster_status = cls()
+
+        cluster_status_response_cluster_status.additional_properties = d
+        return cluster_status_response_cluster_status
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/domain_mapping.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/domain_mapping.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DomainMapping")
+
+
+@_attrs_define
+class DomainMapping:
+    """One custom domain as the proxy stored it.
+
+    Attributes:
+        address (str): The backend IPv6 address.
+        domain (str): The custom domain.
+    """
+
+    address: str
+    domain: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        address = self.address
+
+        domain = self.domain
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "address": address,
+                "domain": domain,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        address = d.pop("address")
+
+        domain = d.pop("domain")
+
+        domain_mapping = cls(
+            address=address,
+            domain=domain,
+        )
+
+        domain_mapping.additional_properties = d
+        return domain_mapping
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/get_domains_response_get_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/get_domains_response_get_domains.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GetDomainsResponseGetDomains")
+
+
+@_attrs_define
+class GetDomainsResponseGetDomains:
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        get_domains_response_get_domains = cls()
+
+        get_domains_response_get_domains.additional_properties = d
+        return get_domains_response_get_domains
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/get_sites_response_get_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/get_sites_response_get_sites.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GetSitesResponseGetSites")
+
+
+@_attrs_define
+class GetSitesResponseGetSites:
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        get_sites_response_get_sites = cls()
+
+        get_sites_response_get_sites.additional_properties = d
+        return get_sites_response_get_sites
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/http_validation_error.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/http_validation_error.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error import ValidationError
+
+
+T = TypeVar("T", bound="HTTPValidationError")
+
+
+@_attrs_define
+class HTTPValidationError:
+    """
+    Attributes:
+        detail (list[ValidationError] | Unset):
+    """
+
+    detail: list[ValidationError] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        detail: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.detail, Unset):
+            detail = []
+            for detail_item_data in self.detail:
+                detail_item = detail_item_data.to_dict()
+                detail.append(detail_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error import ValidationError  # noqa: PLC0415
+
+        d = dict(src_dict)
+        _detail = d.pop("detail", UNSET)
+        detail: list[ValidationError] | Unset = UNSET
+        if _detail is not UNSET:
+            detail = []
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
+
+                detail.append(detail_item)
+
+        http_validation_error = cls(
+            detail=detail,
+        )
+
+        http_validation_error.additional_properties = d
+        return http_validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/map_replaced.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/map_replaced.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MapReplaced")
+
+
+@_attrs_define
+class MapReplaced:
+    """Result of a full map replacement.
+
+    Attributes:
+        entries (int): Number of entries in the replacement map.
+        synced (bool): Whether the complete map was applied.
+    """
+
+    entries: int
+    synced: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        entries = self.entries
+
+        synced = self.synced
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "entries": entries,
+                "synced": synced,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        entries = d.pop("entries")
+
+        synced = d.pop("synced")
+
+        map_replaced = cls(
+            entries=entries,
+            synced=synced,
+        )
+
+        map_replaced.additional_properties = d
+        return map_replaced
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/replace_domains_values.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/replace_domains_values.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ReplaceDomainsValues")
+
+
+@_attrs_define
+class ReplaceDomainsValues:
+    """The complete desired custom-domain map."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        replace_domains_values = cls()
+
+        replace_domains_values.additional_properties = d
+        return replace_domains_values
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/replace_sites_values.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/replace_sites_values.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ReplaceSitesValues")
+
+
+@_attrs_define
+class ReplaceSitesValues:
+    """The complete desired site map."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        replace_sites_values = cls()
+
+        replace_sites_values.additional_properties = d
+        return replace_sites_values
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/site_mapping.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/site_mapping.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SiteMapping")
+
+
+@_attrs_define
+class SiteMapping:
+    """One site as the proxy stored it.
+
+    Attributes:
+        address (str): The backend IPv6 address.
+        site (str): The site subdomain.
+    """
+
+    address: str
+    site: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        address = self.address
+
+        site = self.site
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "address": address,
+                "site": site,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        address = d.pop("address")
+
+        site = d.pop("site")
+
+        site_mapping = cls(
+            address=address,
+            site=site,
+        )
+
+        site_mapping.additional_properties = d
+        return site_mapping
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error_context import ValidationErrorContext
+
+
+T = TypeVar("T", bound="ValidationError")
+
+
+@_attrs_define
+class ValidationError:
+    """
+    Attributes:
+        loc (list[int | str]):
+        msg (str):
+        type_ (str):
+        ctx (ValidationErrorContext | Unset):
+        input_ (Any | Unset):
+    """
+
+    loc: list[int | str]
+    msg: str
+    type_: str
+    ctx: ValidationErrorContext | Unset = UNSET
+    input_: Any | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        loc = []
+        for loc_item_data in self.loc:
+            loc_item: int | str
+            loc_item = loc_item_data
+            loc.append(loc_item)
+
+        msg = self.msg
+
+        type_ = self.type_
+
+        ctx: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.ctx, Unset):
+            ctx = self.ctx.to_dict()
+
+        input_ = self.input_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "loc": loc,
+                "msg": msg,
+                "type": type_,
+            }
+        )
+        if ctx is not UNSET:
+            field_dict["ctx"] = ctx
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error_context import ValidationErrorContext  # noqa: PLC0415
+
+        d = dict(src_dict)
+        loc = []
+        _loc = d.pop("loc")
+        for loc_item_data in _loc:
+
+            def _parse_loc_item(data: object) -> int | str:
+                return cast(int | str, data)
+
+            loc_item = _parse_loc_item(loc_item_data)
+
+            loc.append(loc_item)
+
+        msg = d.pop("msg")
+
+        type_ = d.pop("type")
+
+        _ctx = d.pop("ctx", UNSET)
+        ctx: ValidationErrorContext | Unset
+        if isinstance(_ctx, Unset):
+            ctx = UNSET
+        else:
+            ctx = ValidationErrorContext.from_dict(_ctx)
+
+        input_ = d.pop("input", UNSET)
+
+        validation_error = cls(
+            loc=loc,
+            msg=msg,
+            type_=type_,
+            ctx=ctx,
+            input_=input_,
+        )
+
+        validation_error.additional_properties = d
+        return validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error_context.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error_context.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ValidationErrorContext")
+
+
+@_attrs_define
+class ValidationErrorContext:
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        validation_error_context = cls()
+
+        validation_error_context.additional_properties = d
+        return validation_error_context
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas-http-proxy/atlas_http_proxy/py.typed
+++ b/clients/atlas-http-proxy/atlas_http_proxy/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/clients/atlas-http-proxy/atlas_http_proxy/types.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/clients/atlas-http-proxy/pyproject.toml
+++ b/clients/atlas-http-proxy/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "atlas-http-proxy"
+version = "0.1.0"
+description = "A client library for accessing Atlas proxy control"
+authors = []
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.23.1,<0.29.0",
+    "attrs>=22.2.0",
+]
+
+[tool.pdm]
+distribution = true
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]

--- a/clients/atlas/.gitignore
+++ b/clients/atlas/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/clients/atlas/README.md
+++ b/clients/atlas/README.md
@@ -1,0 +1,110 @@
+# atlas
+A client library for accessing Atlas API
+
+## Usage
+First, create a client:
+
+```python
+from atlas import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from atlas import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from atlas.models import MyDataModel
+from atlas.api.my_tag import get_my_data_model
+from atlas.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from atlas.models import MyDataModel
+from atlas.api.my_tag import get_my_data_model
+from atlas.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `atlas.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from atlas import Client
+
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from atlas import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+

--- a/clients/atlas/atlas/__init__.py
+++ b/clients/atlas/atlas/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing Atlas API"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/clients/atlas/atlas/api/__init__.py
+++ b/clients/atlas/atlas/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/clients/atlas/atlas/api/images/__init__.py
+++ b/clients/atlas/atlas/api/images/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas/atlas/api/images/delete_image.py
+++ b/clients/atlas/atlas/api/images/delete_image.py
@@ -1,0 +1,184 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.image_response import ImageResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    image_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/atlas/images/{image_id}".format(
+            image_id=quote(str(image_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | ImageResponse | None:
+    if response.status_code == 202:
+        response_202 = ImageResponse.from_dict(response.json())
+
+        return response_202
+
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | ImageResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[Any | ImageResponse]:
+    """Delete image
+
+     Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
+    remaining host snapshot data.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Any | ImageResponse | None:
+    """Delete image
+
+     Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
+    remaining host snapshot data.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ImageResponse
+    """
+
+    return sync_detailed(
+        image_id=image_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[Any | ImageResponse]:
+    """Delete image
+
+     Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
+    remaining host snapshot data.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Any | ImageResponse | None:
+    """Delete image
+
+     Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
+    remaining host snapshot data.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ImageResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            image_id=image_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/images/download_image.py
+++ b/clients/atlas/atlas/api/images/download_image.py
@@ -1,0 +1,204 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.download_image_artifact import DownloadImageArtifact
+from ...models.image_download_response import ImageDownloadResponse
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    image_id: str,
+    *,
+    artifact: DownloadImageArtifact,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    params: dict[str, Any] = {}
+
+    json_artifact = artifact.value
+    params["artifact"] = json_artifact
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/images/{image_id}/download".format(
+            image_id=quote(str(image_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageDownloadResponse | None:
+    if response.status_code == 200:
+        response_200 = ImageDownloadResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ImageDownloadResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    artifact: DownloadImageArtifact,
+    x_tenant_id: int,
+) -> Response[ImageDownloadResponse]:
+    """Download image
+
+     Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
+    size, SHA-256 value, and expiry time and cannot be cached.
+
+    Args:
+        image_id (str):
+        artifact (DownloadImageArtifact):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageDownloadResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        artifact=artifact,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    artifact: DownloadImageArtifact,
+    x_tenant_id: int,
+) -> ImageDownloadResponse | None:
+    """Download image
+
+     Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
+    size, SHA-256 value, and expiry time and cannot be cached.
+
+    Args:
+        image_id (str):
+        artifact (DownloadImageArtifact):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageDownloadResponse
+    """
+
+    return sync_detailed(
+        image_id=image_id,
+        client=client,
+        artifact=artifact,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    artifact: DownloadImageArtifact,
+    x_tenant_id: int,
+) -> Response[ImageDownloadResponse]:
+    """Download image
+
+     Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
+    size, SHA-256 value, and expiry time and cannot be cached.
+
+    Args:
+        image_id (str):
+        artifact (DownloadImageArtifact):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageDownloadResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        artifact=artifact,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    artifact: DownloadImageArtifact,
+    x_tenant_id: int,
+) -> ImageDownloadResponse | None:
+    """Download image
+
+     Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
+    size, SHA-256 value, and expiry time and cannot be cached.
+
+    Args:
+        image_id (str):
+        artifact (DownloadImageArtifact):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageDownloadResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            image_id=image_id,
+            client=client,
+            artifact=artifact,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/images/get_image.py
+++ b/clients/atlas/atlas/api/images/get_image.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.image_response import ImageResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    image_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/images/{image_id}".format(
+            image_id=quote(str(image_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageResponse | None:
+    if response.status_code == 200:
+        response_200 = ImageResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ImageResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[ImageResponse]:
+    """Get image
+
+     Returns one tenant image with its artifact metadata and transfer state.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> ImageResponse | None:
+    """Get image
+
+     Returns one tenant image with its artifact metadata and transfer state.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageResponse
+    """
+
+    return sync_detailed(
+        image_id=image_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[ImageResponse]:
+    """Get image
+
+     Returns one tenant image with its artifact metadata and transfer state.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        image_id=image_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    image_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> ImageResponse | None:
+    """Get image
+
+     Returns one tenant image with its artifact metadata and transfer state.
+
+    Args:
+        image_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            image_id=image_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/images/list_images.py
+++ b/clients/atlas/atlas/api/images/list_images.py
@@ -1,0 +1,195 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.page_image_response import PageImageResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    params: dict[str, Any] = {}
+
+    params["offset"] = offset
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/images",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> PageImageResponse | None:
+    if response.status_code == 200:
+        response_200 = PageImageResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[PageImageResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageImageResponse]:
+    """List images
+
+     Returns one page of System and Machine images owned by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageImageResponse | None:
+    """List images
+
+     Returns one page of System and Machine images owned by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageImageResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageImageResponse]:
+    """List images
+
+     Returns one page of System and Machine images owned by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageImageResponse | None:
+    """List images
+
+     Returns one page of System and Machine images owned by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageImageResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            offset=offset,
+            limit=limit,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/ip_addresses/__init__.py
+++ b/clients/atlas/atlas/api/ip_addresses/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas/atlas/api/ip_addresses/get_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/get_ip_address.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.ip_address_response import IPAddressResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    ip_address_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(
+            ip_address_id=quote(str(ip_address_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> IPAddressResponse | None:
+    if response.status_code == 200:
+        response_200 = IPAddressResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[IPAddressResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[IPAddressResponse]:
+    """Get IP address
+
+     Returns one tenant IP address with its attachment state and VM assignment.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[IPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        ip_address_id=ip_address_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> IPAddressResponse | None:
+    """Get IP address
+
+     Returns one tenant IP address with its attachment state and VM assignment.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        IPAddressResponse
+    """
+
+    return sync_detailed(
+        ip_address_id=ip_address_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[IPAddressResponse]:
+    """Get IP address
+
+     Returns one tenant IP address with its attachment state and VM assignment.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[IPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        ip_address_id=ip_address_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> IPAddressResponse | None:
+    """Get IP address
+
+     Returns one tenant IP address with its attachment state and VM assignment.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        IPAddressResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            ip_address_id=ip_address_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/ip_addresses/list_ip_addresses.py
+++ b/clients/atlas/atlas/api/ip_addresses/list_ip_addresses.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.page_ip_address_response import PageIPAddressResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    params: dict[str, Any] = {}
+
+    params["offset"] = offset
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/ip-addresses",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> PageIPAddressResponse | None:
+    if response.status_code == 200:
+        response_200 = PageIPAddressResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[PageIPAddressResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageIPAddressResponse]:
+    """List IP addresses
+
+     Returns one page of IP addresses reserved by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageIPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageIPAddressResponse | None:
+    """List IP addresses
+
+     Returns one page of IP addresses reserved by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageIPAddressResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageIPAddressResponse]:
+    """List IP addresses
+
+     Returns one page of IP addresses reserved by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageIPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageIPAddressResponse | None:
+    """List IP addresses
+
+     Returns one page of IP addresses reserved by the tenant in newest-first order.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageIPAddressResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            offset=offset,
+            limit=limit,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/ip_addresses/release_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/release_ip_address.py
@@ -1,0 +1,118 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs(
+    ip_address_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(
+            ip_address_id=quote(str(ip_address_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
+    if response.status_code == 204:
+        return None
+
+    if response.status_code == 409:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[Any]:
+    """Release IP address
+
+     Returns an unattached address to the shared pool and keeps its provider reservation. An attached or
+    detaching address cannot be released.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        ip_address_id=ip_address_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    ip_address_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[Any]:
+    """Release IP address
+
+     Returns an unattached address to the shared pool and keeps its provider reservation. An attached or
+    detaching address cannot be released.
+
+    Args:
+        ip_address_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        ip_address_id=ip_address_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/clients/atlas/atlas/api/ip_addresses/reserve_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/reserve_ip_address.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.ip_address_response import IPAddressResponse
+from ...models.reserve_ip_address_payload import ReserveIPAddressPayload
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: ReserveIPAddressPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/ip-addresses",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | IPAddressResponse | None:
+    if response.status_code == 201:
+        response_201 = IPAddressResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | IPAddressResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ReserveIPAddressPayload,
+    x_tenant_id: int,
+) -> Response[Any | IPAddressResponse]:
+    """Reserve IP address
+
+     Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
+    provider source creates a provider reservation.
+
+    Args:
+        x_tenant_id (int):
+        body (ReserveIPAddressPayload): Select the source of an IP address reservation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | IPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ReserveIPAddressPayload,
+    x_tenant_id: int,
+) -> Any | IPAddressResponse | None:
+    """Reserve IP address
+
+     Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
+    provider source creates a provider reservation.
+
+    Args:
+        x_tenant_id (int):
+        body (ReserveIPAddressPayload): Select the source of an IP address reservation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | IPAddressResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ReserveIPAddressPayload,
+    x_tenant_id: int,
+) -> Response[Any | IPAddressResponse]:
+    """Reserve IP address
+
+     Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
+    provider source creates a provider reservation.
+
+    Args:
+        x_tenant_id (int):
+        body (ReserveIPAddressPayload): Select the source of an IP address reservation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | IPAddressResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ReserveIPAddressPayload,
+    x_tenant_id: int,
+) -> Any | IPAddressResponse | None:
+    """Reserve IP address
+
+     Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
+    provider source creates a provider reservation.
+
+    Args:
+        x_tenant_id (int):
+        body (ReserveIPAddressPayload): Select the source of an IP address reservation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | IPAddressResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/__init__.py
+++ b/clients/atlas/atlas/api/vm_actions/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas/atlas/api/vm_actions/create_virtual_machine_console_token.py
+++ b/clients/atlas/atlas/api/vm_actions/create_virtual_machine_console_token.py
@@ -1,0 +1,200 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.console_token_payload import ConsoleTokenPayload
+from ...models.console_token_response import ConsoleTokenResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: ConsoleTokenPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/console-token".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ConsoleTokenResponse | None:
+    if response.status_code == 200:
+        response_200 = ConsoleTokenResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ConsoleTokenResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConsoleTokenPayload,
+    x_tenant_id: int,
+) -> Response[ConsoleTokenResponse]:
+    """Create console token
+
+     Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
+    seconds.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ConsoleTokenPayload): The console mode that the token opens.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConsoleTokenResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConsoleTokenPayload,
+    x_tenant_id: int,
+) -> ConsoleTokenResponse | None:
+    """Create console token
+
+     Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
+    seconds.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ConsoleTokenPayload): The console mode that the token opens.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConsoleTokenResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConsoleTokenPayload,
+    x_tenant_id: int,
+) -> Response[ConsoleTokenResponse]:
+    """Create console token
+
+     Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
+    seconds.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ConsoleTokenPayload): The console mode that the token opens.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConsoleTokenResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConsoleTokenPayload,
+    x_tenant_id: int,
+) -> ConsoleTokenResponse | None:
+    """Create console token
+
+     Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
+    seconds.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ConsoleTokenPayload): The console mode that the token opens.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConsoleTokenResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/create_virtual_machine_snapshot.py
+++ b/clients/atlas/atlas/api/vm_actions/create_virtual_machine_snapshot.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.image_response import ImageResponse
+from ...models.snapshot_payload import SnapshotPayload
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: SnapshotPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/snapshot".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageResponse | None:
+    if response.status_code == 201:
+        response_201 = ImageResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ImageResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SnapshotPayload,
+    x_tenant_id: int,
+) -> Response[ImageResponse]:
+    """Create snapshot
+
+     Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
+
+    If `memory_snapshot` is true, Atlas also records the VM shape for compatible warm starts.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SnapshotPayload): Values that create one Machine image from a virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SnapshotPayload,
+    x_tenant_id: int,
+) -> ImageResponse | None:
+    """Create snapshot
+
+     Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
+
+    If `memory_snapshot` is true, Atlas also records the VM shape for compatible warm starts.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SnapshotPayload): Values that create one Machine image from a virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SnapshotPayload,
+    x_tenant_id: int,
+) -> Response[ImageResponse]:
+    """Create snapshot
+
+     Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
+
+    If `memory_snapshot` is true, Atlas also records the VM shape for compatible warm starts.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SnapshotPayload): Values that create one Machine image from a virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ImageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SnapshotPayload,
+    x_tenant_id: int,
+) -> ImageResponse | None:
+    """Create snapshot
+
+     Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
+
+    If `memory_snapshot` is true, Atlas also records the VM shape for compatible warm starts.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SnapshotPayload): Values that create one Machine image from a virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ImageResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/pause_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/pause_virtual_machine.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/pause".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Pause VM
+
+     Pauses the VM without stopping it. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Pause VM
+
+     Pauses the VM without stopping it. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Pause VM
+
+     Pauses the VM without stopping it. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Pause VM
+
+     Pauses the VM without stopping it. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/restart_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/restart_virtual_machine.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/restart".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Restart VM
+
+     Requests an in-place restart. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Restart VM
+
+     Requests an in-place restart. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Restart VM
+
+     Requests an in-place restart. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Restart VM
+
+     Requests an in-place restart. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/resume_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/resume_virtual_machine.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/resume".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resume VM
+
+     Returns a paused VM to the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resume VM
+
+     Returns a paused VM to the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resume VM
+
+     Returns a paused VM to the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resume VM
+
+     Returns a paused VM to the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/start_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/start_virtual_machine.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/start".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Start VM
+
+     Requests the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Start VM
+
+     Requests the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Start VM
+
+     Requests the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Start VM
+
+     Requests the running state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_actions/stop_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/stop_virtual_machine.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/stop".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Stop VM
+
+     Requests the stopped state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Stop VM
+
+     Requests the stopped state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Stop VM
+
+     Requests the stopped state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Stop VM
+
+     Requests the stopped state. Poll the VM route to observe completion.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/__init__.py
+++ b/clients/atlas/atlas/api/vm_configuration/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas/atlas/api/vm_configuration/attach_virtual_machine_ip_address.py
+++ b/clients/atlas/atlas/api/vm_configuration/attach_virtual_machine_ip_address.py
@@ -1,0 +1,200 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.ip_address_assignment_payload import IPAddressAssignmentPayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: IPAddressAssignmentPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: IPAddressAssignmentPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Attach IP address
+
+     Attaches one available IP address that the tenant reserved. Detach the current address before you
+    attach a different one.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (IPAddressAssignmentPayload): The public IPv4 address to attach.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: IPAddressAssignmentPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Attach IP address
+
+     Attaches one available IP address that the tenant reserved. Detach the current address before you
+    attach a different one.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (IPAddressAssignmentPayload): The public IPv4 address to attach.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: IPAddressAssignmentPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Attach IP address
+
+     Attaches one available IP address that the tenant reserved. Detach the current address before you
+    attach a different one.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (IPAddressAssignmentPayload): The public IPv4 address to attach.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: IPAddressAssignmentPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Attach IP address
+
+     Attaches one available IP address that the tenant reserved. Detach the current address before you
+    attach a different one.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (IPAddressAssignmentPayload): The public IPv4 address to attach.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/detach_virtual_machine_ip_address.py
+++ b/clients/atlas/atlas/api/vm_configuration/detach_virtual_machine_ip_address.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Detach IP address
+
+     Detaches the public IP address from the VM and keeps its tenant reservation.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Detach IP address
+
+     Detaches the public IP address from the VM and keeps its tenant reservation.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Detach IP address
+
+     Detaches the public IP address from the VM and keeps its tenant reservation.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Detach IP address
+
+     Detaches the public IP address from the VM and keeps its tenant reservation.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_metadata.py
+++ b/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_metadata.py
@@ -1,0 +1,196 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.metadata_replacement_payload import MetadataReplacementPayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: MetadataReplacementPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/metadata".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetadataReplacementPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Replace metadata
+
+     Replaces the complete custom metadata map. Entries that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (MetadataReplacementPayload): The complete custom metadata map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetadataReplacementPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Replace metadata
+
+     Replaces the complete custom metadata map. Entries that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (MetadataReplacementPayload): The complete custom metadata map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetadataReplacementPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Replace metadata
+
+     Replaces the complete custom metadata map. Entries that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (MetadataReplacementPayload): The complete custom metadata map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MetadataReplacementPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Replace metadata
+
+     Replaces the complete custom metadata map. Entries that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (MetadataReplacementPayload): The complete custom metadata map.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_ssh_keys.py
+++ b/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_ssh_keys.py
@@ -1,0 +1,196 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.ssh_keys_replacement_payload import SSHKeysReplacementPayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: SSHKeysReplacementPayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ssh-keys".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SSHKeysReplacementPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Replace SSH keys
+
+     Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SSHKeysReplacementPayload): The complete authorized key list.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SSHKeysReplacementPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Replace SSH keys
+
+     Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SSHKeysReplacementPayload): The complete authorized key list.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SSHKeysReplacementPayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Replace SSH keys
+
+     Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SSHKeysReplacementPayload): The complete authorized key list.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SSHKeysReplacementPayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Replace SSH keys
+
+     Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (SSHKeysReplacementPayload): The complete authorized key list.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
@@ -1,0 +1,200 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.compute_update_payload import ComputeUpdatePayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: ComputeUpdatePayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/compute".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ComputeUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resize compute
+
+     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
+    change.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ComputeUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resize compute
+
+     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
+    change.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ComputeUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resize compute
+
+     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
+    change.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ComputeUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resize compute
+
+     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
+    change.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_disk.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_disk.py
@@ -1,0 +1,200 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.disk_update_payload import DiskUpdatePayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: DiskUpdatePayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/disk".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: DiskUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resize disk
+
+     Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
+    and a limit of 0 removes that limit.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (DiskUpdatePayload): New disk size and disk rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: DiskUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resize disk
+
+     Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
+    and a limit of 0 removes that limit.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (DiskUpdatePayload): New disk size and disk rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: DiskUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Resize disk
+
+     Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
+    and a limit of 0 removes that limit.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (DiskUpdatePayload): New disk size and disk rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: DiskUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Resize disk
+
+     Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
+    and a limit of 0 removes that limit.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (DiskUpdatePayload): New disk size and disk rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_network.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_network.py
@@ -1,0 +1,200 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.network_update_payload import NetworkUpdatePayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    body: NetworkUpdatePayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/network".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: NetworkUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Update network
+
+     Changes egress and network throughput limits. Egress controls internet reachability and does not
+    change mesh reachability.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (NetworkUpdatePayload): New egress mode and network rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: NetworkUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Update network
+
+     Changes egress and network throughput limits. Egress controls internet reachability and does not
+    change mesh reachability.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (NetworkUpdatePayload): New egress mode and network rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: NetworkUpdatePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Update network
+
+     Changes egress and network throughput limits. Egress controls internet reachability and does not
+    change mesh reachability.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (NetworkUpdatePayload): New egress mode and network rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: NetworkUpdatePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Update network
+
+     Changes egress and network throughput limits. Egress controls internet reachability and does not
+    change mesh reachability.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+        body (NetworkUpdatePayload): New egress mode and network rate limits.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/__init__.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/atlas/atlas/api/vm_lifecycle/create_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/create_virtual_machine.py
@@ -1,0 +1,184 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_virtual_machine_payload import CreateVirtualMachinePayload
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateVirtualMachinePayload,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/atlas/virtual-machines",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 201:
+        response_201 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateVirtualMachinePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Create VM
+
+     Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
+    configuration.
+
+    Args:
+        x_tenant_id (int):
+        body (CreateVirtualMachinePayload): Values that create one virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateVirtualMachinePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Create VM
+
+     Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
+    configuration.
+
+    Args:
+        x_tenant_id (int):
+        body (CreateVirtualMachinePayload): Values that create one virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateVirtualMachinePayload,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Create VM
+
+     Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
+    configuration.
+
+    Args:
+        x_tenant_id (int):
+        body (CreateVirtualMachinePayload): Values that create one virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateVirtualMachinePayload,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Create VM
+
+     Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
+    configuration.
+
+    Args:
+        x_tenant_id (int):
+        body (CreateVirtualMachinePayload): Values that create one virtual machine.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/delete_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/delete_virtual_machine.py
@@ -1,0 +1,182 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_response import VirtualMachineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
+    if response.status_code == 202:
+        response_202 = VirtualMachineResponse.from_dict(response.json())
+
+        return response_202
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Delete VM
+
+     Starts VM termination and detaches its public IP address without releasing the tenant reservation.
+    Poll the VM until cleanup removes the record and this route returns 404.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Delete VM
+
+     Starts VM termination and detaches its public IP address without releasing the tenant reservation.
+    Poll the VM until cleanup removes the record and this route returns 404.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineResponse]:
+    """Delete VM
+
+     Starts VM termination and detaches its public IP address without releasing the tenant reservation.
+    Poll the VM until cleanup removes the record and this route returns 404.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineResponse | None:
+    """Delete VM
+
+     Starts VM termination and detaches its public IP address without releasing the tenant reservation.
+    Poll the VM until cleanup removes the record and this route returns 404.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/get_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/get_virtual_machine.py
@@ -1,0 +1,180 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.virtual_machine_detail_response import VirtualMachineDetailResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    virtual_machine_id: str,
+    *,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(
+            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> VirtualMachineDetailResponse | None:
+    if response.status_code == 200:
+        response_200 = VirtualMachineDetailResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[VirtualMachineDetailResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineDetailResponse]:
+    """Get VM
+
+     Returns the stored VM record together with its desired state and current state.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineDetailResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineDetailResponse | None:
+    """Get VM
+
+     Returns the stored VM record together with its desired state and current state.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineDetailResponse
+    """
+
+    return sync_detailed(
+        virtual_machine_id=virtual_machine_id,
+        client=client,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> Response[VirtualMachineDetailResponse]:
+    """Get VM
+
+     Returns the stored VM record together with its desired state and current state.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[VirtualMachineDetailResponse]
+    """
+
+    kwargs = _get_kwargs(
+        virtual_machine_id=virtual_machine_id,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    virtual_machine_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    x_tenant_id: int,
+) -> VirtualMachineDetailResponse | None:
+    """Get VM
+
+     Returns the stored VM record together with its desired state and current state.
+
+    Args:
+        virtual_machine_id (str):
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        VirtualMachineDetailResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            virtual_machine_id=virtual_machine_id,
+            client=client,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.page_virtual_machine_response import PageVirtualMachineResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["X-Tenant-ID"] = str(x_tenant_id)
+
+    params: dict[str, Any] = {}
+
+    params["offset"] = offset
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/atlas/virtual-machines",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> PageVirtualMachineResponse | None:
+    if response.status_code == 200:
+        response_200 = PageVirtualMachineResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[PageVirtualMachineResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageVirtualMachineResponse]:
+    """List VMs
+
+     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageVirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageVirtualMachineResponse | None:
+    """List VMs
+
+     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageVirtualMachineResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> Response[PageVirtualMachineResponse]:
+    """List VMs
+
+     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PageVirtualMachineResponse]
+    """
+
+    kwargs = _get_kwargs(
+        offset=offset,
+        limit=limit,
+        x_tenant_id=x_tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    offset: int | Unset = 0,
+    limit: int | Unset = 20,
+    x_tenant_id: int,
+) -> PageVirtualMachineResponse | None:
+    """List VMs
+
+     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+
+    Args:
+        offset (int | Unset):  Default: 0.
+        limit (int | Unset):  Default: 20.
+        x_tenant_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PageVirtualMachineResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            offset=offset,
+            limit=limit,
+            x_tenant_id=x_tenant_id,
+        )
+    ).parsed

--- a/clients/atlas/atlas/client.py
+++ b/clients/atlas/atlas/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any, Self
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> Self:
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> Self:
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> Self:
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> Self:
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> Self:
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> Self:
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> Self:
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> Self:
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/clients/atlas/atlas/errors.py
+++ b/clients/atlas/atlas/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/clients/atlas/atlas/models/__init__.py
+++ b/clients/atlas/atlas/models/__init__.py
@@ -1,0 +1,61 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .compute_update_payload import ComputeUpdatePayload
+from .console_token_payload import ConsoleTokenPayload
+from .console_token_payload_mode import ConsoleTokenPayloadMode
+from .console_token_response import ConsoleTokenResponse
+from .console_token_response_mode import ConsoleTokenResponseMode
+from .create_virtual_machine_payload import CreateVirtualMachinePayload
+from .create_virtual_machine_payload_egress import CreateVirtualMachinePayloadEgress
+from .create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata
+from .disk_update_payload import DiskUpdatePayload
+from .download_image_artifact import DownloadImageArtifact
+from .image_download_response import ImageDownloadResponse
+from .image_download_response_artifact import ImageDownloadResponseArtifact
+from .image_response import ImageResponse
+from .ip_address_assignment_payload import IPAddressAssignmentPayload
+from .ip_address_response import IPAddressResponse
+from .metadata_replacement_payload import MetadataReplacementPayload
+from .metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata
+from .network_update_payload import NetworkUpdatePayload
+from .network_update_payload_egress_type_0 import NetworkUpdatePayloadEgressType0
+from .page_image_response import PageImageResponse
+from .page_ip_address_response import PageIPAddressResponse
+from .page_virtual_machine_response import PageVirtualMachineResponse
+from .reserve_ip_address_payload import ReserveIPAddressPayload
+from .reserve_ip_address_payload_source import ReserveIPAddressPayloadSource
+from .snapshot_payload import SnapshotPayload
+from .ssh_keys_replacement_payload import SSHKeysReplacementPayload
+from .virtual_machine_detail_response import VirtualMachineDetailResponse
+from .virtual_machine_response import VirtualMachineResponse
+
+__all__ = (
+    "ComputeUpdatePayload",
+    "ConsoleTokenPayload",
+    "ConsoleTokenPayloadMode",
+    "ConsoleTokenResponse",
+    "ConsoleTokenResponseMode",
+    "CreateVirtualMachinePayload",
+    "CreateVirtualMachinePayloadEgress",
+    "CreateVirtualMachinePayloadMetadata",
+    "DiskUpdatePayload",
+    "DownloadImageArtifact",
+    "ImageDownloadResponse",
+    "ImageDownloadResponseArtifact",
+    "ImageResponse",
+    "IPAddressAssignmentPayload",
+    "IPAddressResponse",
+    "MetadataReplacementPayload",
+    "MetadataReplacementPayloadMetadata",
+    "NetworkUpdatePayload",
+    "NetworkUpdatePayloadEgressType0",
+    "PageImageResponse",
+    "PageIPAddressResponse",
+    "PageVirtualMachineResponse",
+    "ReserveIPAddressPayload",
+    "ReserveIPAddressPayloadSource",
+    "SnapshotPayload",
+    "SSHKeysReplacementPayload",
+    "VirtualMachineDetailResponse",
+    "VirtualMachineResponse",
+)

--- a/clients/atlas/atlas/models/compute_update_payload.py
+++ b/clients/atlas/atlas/models/compute_update_payload.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ComputeUpdatePayload")
+
+
+@_attrs_define
+class ComputeUpdatePayload:
+    """New CPU and memory values for a stopped virtual machine.
+
+    Attributes:
+        memory_mib (int | None | Unset):
+        vcpus (int | None | Unset):
+    """
+
+    memory_mib: int | None | Unset = UNSET
+    vcpus: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        memory_mib: int | None | Unset
+        if isinstance(self.memory_mib, Unset):
+            memory_mib = UNSET
+        else:
+            memory_mib = self.memory_mib
+
+        vcpus: int | None | Unset
+        if isinstance(self.vcpus, Unset):
+            vcpus = UNSET
+        else:
+            vcpus = self.vcpus
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if memory_mib is not UNSET:
+            field_dict["memory_mib"] = memory_mib
+        if vcpus is not UNSET:
+            field_dict["vcpus"] = vcpus
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_memory_mib(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        memory_mib = _parse_memory_mib(d.pop("memory_mib", UNSET))
+
+        def _parse_vcpus(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        vcpus = _parse_vcpus(d.pop("vcpus", UNSET))
+
+        compute_update_payload = cls(
+            memory_mib=memory_mib,
+            vcpus=vcpus,
+        )
+
+        return compute_update_payload

--- a/clients/atlas/atlas/models/console_token_payload.py
+++ b/clients/atlas/atlas/models/console_token_payload.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..models.console_token_payload_mode import ConsoleTokenPayloadMode
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ConsoleTokenPayload")
+
+
+@_attrs_define
+class ConsoleTokenPayload:
+    """The console mode that the token opens.
+
+    Attributes:
+        mode (ConsoleTokenPayloadMode | Unset):  Default: ConsoleTokenPayloadMode.TTY.
+    """
+
+    mode: ConsoleTokenPayloadMode | Unset = ConsoleTokenPayloadMode.TTY
+
+    def to_dict(self) -> dict[str, Any]:
+        mode: str | Unset = UNSET
+        if not isinstance(self.mode, Unset):
+            mode = self.mode.value
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if mode is not UNSET:
+            field_dict["mode"] = mode
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        _mode = d.pop("mode", UNSET)
+        mode: ConsoleTokenPayloadMode | Unset
+        if isinstance(_mode, Unset):
+            mode = UNSET
+        else:
+            mode = ConsoleTokenPayloadMode(_mode)
+
+        console_token_payload = cls(
+            mode=mode,
+        )
+
+        return console_token_payload

--- a/clients/atlas/atlas/models/console_token_payload_mode.py
+++ b/clients/atlas/atlas/models/console_token_payload_mode.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class ConsoleTokenPayloadMode(StrEnum):
+    SSH = "ssh"
+    TTY = "tty"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/console_token_response.py
+++ b/clients/atlas/atlas/models/console_token_response.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.console_token_response_mode import ConsoleTokenResponseMode
+
+T = TypeVar("T", bound="ConsoleTokenResponse")
+
+
+@_attrs_define
+class ConsoleTokenResponse:
+    """A single-use console token.
+
+    Attributes:
+        expires_in (int):
+        mode (ConsoleTokenResponseMode):
+        token (str):
+    """
+
+    expires_in: int
+    mode: ConsoleTokenResponseMode
+    token: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        expires_in = self.expires_in
+
+        mode = self.mode.value
+
+        token = self.token
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "expires_in": expires_in,
+                "mode": mode,
+                "token": token,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        expires_in = d.pop("expires_in")
+
+        mode = ConsoleTokenResponseMode(d.pop("mode"))
+
+        token = d.pop("token")
+
+        console_token_response = cls(
+            expires_in=expires_in,
+            mode=mode,
+            token=token,
+        )
+
+        console_token_response.additional_properties = d
+        return console_token_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/console_token_response_mode.py
+++ b/clients/atlas/atlas/models/console_token_response_mode.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class ConsoleTokenResponseMode(StrEnum):
+    SSH = "ssh"
+    TTY = "tty"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/create_virtual_machine_payload.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.create_virtual_machine_payload_egress import CreateVirtualMachinePayloadEgress
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata
+
+
+T = TypeVar("T", bound="CreateVirtualMachinePayload")
+
+
+@_attrs_define
+class CreateVirtualMachinePayload:
+    """Values that create one virtual machine.
+
+    Attributes:
+        disk_mib (int):
+        image_id (str):
+        memory_mib (int):
+        vcpus (int):
+        disk_iops (int | Unset):  Default: 0.
+        disk_throughput_mibps (int | Unset):  Default: 0.
+        egress (CreateVirtualMachinePayloadEgress | Unset):  Default: CreateVirtualMachinePayloadEgress.UPLINK.
+        hostname (str | Unset):  Default: ''.
+        ip_address_id (None | str | Unset):
+        metadata (CreateVirtualMachinePayloadMetadata | Unset):
+        private_network_throughput_mibps (int | Unset):  Default: 0.
+        public_network_throughput_mibps (int | Unset):  Default: 0.
+        ssh_keys (list[str] | Unset):
+        user_data (str | Unset):  Default: ''.
+    """
+
+    disk_mib: int
+    image_id: str
+    memory_mib: int
+    vcpus: int
+    disk_iops: int | Unset = 0
+    disk_throughput_mibps: int | Unset = 0
+    egress: CreateVirtualMachinePayloadEgress | Unset = CreateVirtualMachinePayloadEgress.UPLINK
+    hostname: str | Unset = ""
+    ip_address_id: None | str | Unset = UNSET
+    metadata: CreateVirtualMachinePayloadMetadata | Unset = UNSET
+    private_network_throughput_mibps: int | Unset = 0
+    public_network_throughput_mibps: int | Unset = 0
+    ssh_keys: list[str] | Unset = UNSET
+    user_data: str | Unset = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        disk_mib = self.disk_mib
+
+        image_id = self.image_id
+
+        memory_mib = self.memory_mib
+
+        vcpus = self.vcpus
+
+        disk_iops = self.disk_iops
+
+        disk_throughput_mibps = self.disk_throughput_mibps
+
+        egress: str | Unset = UNSET
+        if not isinstance(self.egress, Unset):
+            egress = self.egress.value
+
+        hostname = self.hostname
+
+        ip_address_id: None | str | Unset
+        if isinstance(self.ip_address_id, Unset):
+            ip_address_id = UNSET
+        else:
+            ip_address_id = self.ip_address_id
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        private_network_throughput_mibps = self.private_network_throughput_mibps
+
+        public_network_throughput_mibps = self.public_network_throughput_mibps
+
+        ssh_keys: list[str] | Unset = UNSET
+        if not isinstance(self.ssh_keys, Unset):
+            ssh_keys = self.ssh_keys
+
+        user_data = self.user_data
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "disk_mib": disk_mib,
+                "image_id": image_id,
+                "memory_mib": memory_mib,
+                "vcpus": vcpus,
+            }
+        )
+        if disk_iops is not UNSET:
+            field_dict["disk_iops"] = disk_iops
+        if disk_throughput_mibps is not UNSET:
+            field_dict["disk_throughput_mibps"] = disk_throughput_mibps
+        if egress is not UNSET:
+            field_dict["egress"] = egress
+        if hostname is not UNSET:
+            field_dict["hostname"] = hostname
+        if ip_address_id is not UNSET:
+            field_dict["ip_address_id"] = ip_address_id
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if private_network_throughput_mibps is not UNSET:
+            field_dict["private_network_throughput_mibps"] = private_network_throughput_mibps
+        if public_network_throughput_mibps is not UNSET:
+            field_dict["public_network_throughput_mibps"] = public_network_throughput_mibps
+        if ssh_keys is not UNSET:
+            field_dict["ssh_keys"] = ssh_keys
+        if user_data is not UNSET:
+            field_dict["user_data"] = user_data
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.create_virtual_machine_payload_metadata import (
+            CreateVirtualMachinePayloadMetadata,  # noqa: PLC0415
+        )
+
+        d = dict(src_dict)
+        disk_mib = d.pop("disk_mib")
+
+        image_id = d.pop("image_id")
+
+        memory_mib = d.pop("memory_mib")
+
+        vcpus = d.pop("vcpus")
+
+        disk_iops = d.pop("disk_iops", UNSET)
+
+        disk_throughput_mibps = d.pop("disk_throughput_mibps", UNSET)
+
+        _egress = d.pop("egress", UNSET)
+        egress: CreateVirtualMachinePayloadEgress | Unset
+        if isinstance(_egress, Unset):
+            egress = UNSET
+        else:
+            egress = CreateVirtualMachinePayloadEgress(_egress)
+
+        hostname = d.pop("hostname", UNSET)
+
+        def _parse_ip_address_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        ip_address_id = _parse_ip_address_id(d.pop("ip_address_id", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: CreateVirtualMachinePayloadMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = CreateVirtualMachinePayloadMetadata.from_dict(_metadata)
+
+        private_network_throughput_mibps = d.pop("private_network_throughput_mibps", UNSET)
+
+        public_network_throughput_mibps = d.pop("public_network_throughput_mibps", UNSET)
+
+        ssh_keys = cast(list[str], d.pop("ssh_keys", UNSET))
+
+        user_data = d.pop("user_data", UNSET)
+
+        create_virtual_machine_payload = cls(
+            disk_mib=disk_mib,
+            image_id=image_id,
+            memory_mib=memory_mib,
+            vcpus=vcpus,
+            disk_iops=disk_iops,
+            disk_throughput_mibps=disk_throughput_mibps,
+            egress=egress,
+            hostname=hostname,
+            ip_address_id=ip_address_id,
+            metadata=metadata,
+            private_network_throughput_mibps=private_network_throughput_mibps,
+            public_network_throughput_mibps=public_network_throughput_mibps,
+            ssh_keys=ssh_keys,
+            user_data=user_data,
+        )
+
+        return create_virtual_machine_payload

--- a/clients/atlas/atlas/models/create_virtual_machine_payload_egress.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload_egress.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+
+class CreateVirtualMachinePayloadEgress(StrEnum):
+    MESH = "mesh"
+    NONE = "none"
+    UPLINK = "uplink"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/create_virtual_machine_payload_metadata.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload_metadata.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="CreateVirtualMachinePayloadMetadata")
+
+
+@_attrs_define
+class CreateVirtualMachinePayloadMetadata:
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        create_virtual_machine_payload_metadata = cls()
+
+        create_virtual_machine_payload_metadata.additional_properties = d
+        return create_virtual_machine_payload_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/disk_update_payload.py
+++ b/clients/atlas/atlas/models/disk_update_payload.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DiskUpdatePayload")
+
+
+@_attrs_define
+class DiskUpdatePayload:
+    """New disk size and disk rate limits.
+
+    Attributes:
+        disk_iops (int | None | Unset):
+        disk_mib (int | None | Unset):
+        disk_throughput_mibps (int | None | Unset):
+    """
+
+    disk_iops: int | None | Unset = UNSET
+    disk_mib: int | None | Unset = UNSET
+    disk_throughput_mibps: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        disk_iops: int | None | Unset
+        if isinstance(self.disk_iops, Unset):
+            disk_iops = UNSET
+        else:
+            disk_iops = self.disk_iops
+
+        disk_mib: int | None | Unset
+        if isinstance(self.disk_mib, Unset):
+            disk_mib = UNSET
+        else:
+            disk_mib = self.disk_mib
+
+        disk_throughput_mibps: int | None | Unset
+        if isinstance(self.disk_throughput_mibps, Unset):
+            disk_throughput_mibps = UNSET
+        else:
+            disk_throughput_mibps = self.disk_throughput_mibps
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if disk_iops is not UNSET:
+            field_dict["disk_iops"] = disk_iops
+        if disk_mib is not UNSET:
+            field_dict["disk_mib"] = disk_mib
+        if disk_throughput_mibps is not UNSET:
+            field_dict["disk_throughput_mibps"] = disk_throughput_mibps
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_disk_iops(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        disk_iops = _parse_disk_iops(d.pop("disk_iops", UNSET))
+
+        def _parse_disk_mib(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        disk_mib = _parse_disk_mib(d.pop("disk_mib", UNSET))
+
+        def _parse_disk_throughput_mibps(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        disk_throughput_mibps = _parse_disk_throughput_mibps(d.pop("disk_throughput_mibps", UNSET))
+
+        disk_update_payload = cls(
+            disk_iops=disk_iops,
+            disk_mib=disk_mib,
+            disk_throughput_mibps=disk_throughput_mibps,
+        )
+
+        return disk_update_payload

--- a/clients/atlas/atlas/models/download_image_artifact.py
+++ b/clients/atlas/atlas/models/download_image_artifact.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class DownloadImageArtifact(StrEnum):
+    KERNEL = "kernel"
+    ROOTFS = "rootfs"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/image_download_response.py
+++ b/clients/atlas/atlas/models/image_download_response.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.image_download_response_artifact import ImageDownloadResponseArtifact
+
+T = TypeVar("T", bound="ImageDownloadResponse")
+
+
+@_attrs_define
+class ImageDownloadResponse:
+    """Signed downloads for one image.
+
+    Attributes:
+        artifact (ImageDownloadResponseArtifact):
+        expires_at (int):
+        expires_in (int):
+        sha256 (str):
+        size_mib (int):
+        url (str):
+    """
+
+    artifact: ImageDownloadResponseArtifact
+    expires_at: int
+    expires_in: int
+    sha256: str
+    size_mib: int
+    url: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        artifact = self.artifact.value
+
+        expires_at = self.expires_at
+
+        expires_in = self.expires_in
+
+        sha256 = self.sha256
+
+        size_mib = self.size_mib
+
+        url = self.url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "artifact": artifact,
+                "expires_at": expires_at,
+                "expires_in": expires_in,
+                "sha256": sha256,
+                "size_mib": size_mib,
+                "url": url,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        artifact = ImageDownloadResponseArtifact(d.pop("artifact"))
+
+        expires_at = d.pop("expires_at")
+
+        expires_in = d.pop("expires_in")
+
+        sha256 = d.pop("sha256")
+
+        size_mib = d.pop("size_mib")
+
+        url = d.pop("url")
+
+        image_download_response = cls(
+            artifact=artifact,
+            expires_at=expires_at,
+            expires_in=expires_in,
+            sha256=sha256,
+            size_mib=size_mib,
+            url=url,
+        )
+
+        image_download_response.additional_properties = d
+        return image_download_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/image_download_response_artifact.py
+++ b/clients/atlas/atlas/models/image_download_response_artifact.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class ImageDownloadResponseArtifact(StrEnum):
+    KERNEL = "kernel"
+    ROOTFS = "rootfs"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/image_response.py
+++ b/clients/atlas/atlas/models/image_response.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ImageResponse")
+
+
+@_attrs_define
+class ImageResponse:
+    """A tenant virtual machine image.
+
+    Attributes:
+        cache_image (bool):
+        created_at (int):
+        enabled (bool):
+        id (str):
+        image_type (str):
+        kernel_size_mib (int):
+        memory_snapshot (bool):
+        operating_system (str):
+        operating_system_version (str):
+        platform (str):
+        rootfs_size_mib (int):
+        status (str):
+        supports_cloud_init (bool):
+        tenant_id (int):
+        title (str):
+        transfer_error (None | str):
+        transfer_progress (int):
+    """
+
+    cache_image: bool
+    created_at: int
+    enabled: bool
+    id: str
+    image_type: str
+    kernel_size_mib: int
+    memory_snapshot: bool
+    operating_system: str
+    operating_system_version: str
+    platform: str
+    rootfs_size_mib: int
+    status: str
+    supports_cloud_init: bool
+    tenant_id: int
+    title: str
+    transfer_error: None | str
+    transfer_progress: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        cache_image = self.cache_image
+
+        created_at = self.created_at
+
+        enabled = self.enabled
+
+        id = self.id
+
+        image_type = self.image_type
+
+        kernel_size_mib = self.kernel_size_mib
+
+        memory_snapshot = self.memory_snapshot
+
+        operating_system = self.operating_system
+
+        operating_system_version = self.operating_system_version
+
+        platform = self.platform
+
+        rootfs_size_mib = self.rootfs_size_mib
+
+        status = self.status
+
+        supports_cloud_init = self.supports_cloud_init
+
+        tenant_id = self.tenant_id
+
+        title = self.title
+
+        transfer_error: None | str
+        transfer_error = self.transfer_error
+
+        transfer_progress = self.transfer_progress
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "cache_image": cache_image,
+                "created_at": created_at,
+                "enabled": enabled,
+                "id": id,
+                "image_type": image_type,
+                "kernel_size_mib": kernel_size_mib,
+                "memory_snapshot": memory_snapshot,
+                "operating_system": operating_system,
+                "operating_system_version": operating_system_version,
+                "platform": platform,
+                "rootfs_size_mib": rootfs_size_mib,
+                "status": status,
+                "supports_cloud_init": supports_cloud_init,
+                "tenant_id": tenant_id,
+                "title": title,
+                "transfer_error": transfer_error,
+                "transfer_progress": transfer_progress,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        cache_image = d.pop("cache_image")
+
+        created_at = d.pop("created_at")
+
+        enabled = d.pop("enabled")
+
+        id = d.pop("id")
+
+        image_type = d.pop("image_type")
+
+        kernel_size_mib = d.pop("kernel_size_mib")
+
+        memory_snapshot = d.pop("memory_snapshot")
+
+        operating_system = d.pop("operating_system")
+
+        operating_system_version = d.pop("operating_system_version")
+
+        platform = d.pop("platform")
+
+        rootfs_size_mib = d.pop("rootfs_size_mib")
+
+        status = d.pop("status")
+
+        supports_cloud_init = d.pop("supports_cloud_init")
+
+        tenant_id = d.pop("tenant_id")
+
+        title = d.pop("title")
+
+        def _parse_transfer_error(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        transfer_error = _parse_transfer_error(d.pop("transfer_error"))
+
+        transfer_progress = d.pop("transfer_progress")
+
+        image_response = cls(
+            cache_image=cache_image,
+            created_at=created_at,
+            enabled=enabled,
+            id=id,
+            image_type=image_type,
+            kernel_size_mib=kernel_size_mib,
+            memory_snapshot=memory_snapshot,
+            operating_system=operating_system,
+            operating_system_version=operating_system_version,
+            platform=platform,
+            rootfs_size_mib=rootfs_size_mib,
+            status=status,
+            supports_cloud_init=supports_cloud_init,
+            tenant_id=tenant_id,
+            title=title,
+            transfer_error=transfer_error,
+            transfer_progress=transfer_progress,
+        )
+
+        image_response.additional_properties = d
+        return image_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/ip_address_assignment_payload.py
+++ b/clients/atlas/atlas/models/ip_address_assignment_payload.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="IPAddressAssignmentPayload")
+
+
+@_attrs_define
+class IPAddressAssignmentPayload:
+    """The public IPv4 address to attach.
+
+    Attributes:
+        ip_address_id (str):
+    """
+
+    ip_address_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        ip_address_id = self.ip_address_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "ip_address_id": ip_address_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        ip_address_id = d.pop("ip_address_id")
+
+        ip_address_assignment_payload = cls(
+            ip_address_id=ip_address_id,
+        )
+
+        return ip_address_assignment_payload

--- a/clients/atlas/atlas/models/ip_address_response.py
+++ b/clients/atlas/atlas/models/ip_address_response.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="IPAddressResponse")
+
+
+@_attrs_define
+class IPAddressResponse:
+    """A tenant public IPv4 address.
+
+    Attributes:
+        address (str):
+        created_at (int):
+        id (str):
+        state (str):
+        tenant_id (int):
+        virtual_machine_id (None | str):
+    """
+
+    address: str
+    created_at: int
+    id: str
+    state: str
+    tenant_id: int
+    virtual_machine_id: None | str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        address = self.address
+
+        created_at = self.created_at
+
+        id = self.id
+
+        state = self.state
+
+        tenant_id = self.tenant_id
+
+        virtual_machine_id: None | str
+        virtual_machine_id = self.virtual_machine_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "address": address,
+                "created_at": created_at,
+                "id": id,
+                "state": state,
+                "tenant_id": tenant_id,
+                "virtual_machine_id": virtual_machine_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        address = d.pop("address")
+
+        created_at = d.pop("created_at")
+
+        id = d.pop("id")
+
+        state = d.pop("state")
+
+        tenant_id = d.pop("tenant_id")
+
+        def _parse_virtual_machine_id(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        virtual_machine_id = _parse_virtual_machine_id(d.pop("virtual_machine_id"))
+
+        ip_address_response = cls(
+            address=address,
+            created_at=created_at,
+            id=id,
+            state=state,
+            tenant_id=tenant_id,
+            virtual_machine_id=virtual_machine_id,
+        )
+
+        ip_address_response.additional_properties = d
+        return ip_address_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/metadata_replacement_payload.py
+++ b/clients/atlas/atlas/models/metadata_replacement_payload.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata
+
+
+T = TypeVar("T", bound="MetadataReplacementPayload")
+
+
+@_attrs_define
+class MetadataReplacementPayload:
+    """The complete custom metadata map.
+
+    Attributes:
+        metadata (MetadataReplacementPayloadMetadata):
+    """
+
+    metadata: MetadataReplacementPayloadMetadata
+
+    def to_dict(self) -> dict[str, Any]:
+        metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "metadata": metadata,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata  # noqa: PLC0415
+
+        d = dict(src_dict)
+        metadata = MetadataReplacementPayloadMetadata.from_dict(d.pop("metadata"))
+
+        metadata_replacement_payload = cls(
+            metadata=metadata,
+        )
+
+        return metadata_replacement_payload

--- a/clients/atlas/atlas/models/metadata_replacement_payload_metadata.py
+++ b/clients/atlas/atlas/models/metadata_replacement_payload_metadata.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MetadataReplacementPayloadMetadata")
+
+
+@_attrs_define
+class MetadataReplacementPayloadMetadata:
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        metadata_replacement_payload_metadata = cls()
+
+        metadata_replacement_payload_metadata.additional_properties = d
+        return metadata_replacement_payload_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/network_update_payload.py
+++ b/clients/atlas/atlas/models/network_update_payload.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.network_update_payload_egress_type_0 import NetworkUpdatePayloadEgressType0
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NetworkUpdatePayload")
+
+
+@_attrs_define
+class NetworkUpdatePayload:
+    """New egress mode and network rate limits.
+
+    Attributes:
+        egress (NetworkUpdatePayloadEgressType0 | None | Unset):
+        private_network_throughput_mibps (int | None | Unset):
+        public_network_throughput_mibps (int | None | Unset):
+    """
+
+    egress: NetworkUpdatePayloadEgressType0 | None | Unset = UNSET
+    private_network_throughput_mibps: int | None | Unset = UNSET
+    public_network_throughput_mibps: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        egress: None | str | Unset
+        if isinstance(self.egress, Unset):
+            egress = UNSET
+        elif isinstance(self.egress, NetworkUpdatePayloadEgressType0):
+            egress = self.egress.value
+        else:
+            egress = self.egress
+
+        private_network_throughput_mibps: int | None | Unset
+        if isinstance(self.private_network_throughput_mibps, Unset):
+            private_network_throughput_mibps = UNSET
+        else:
+            private_network_throughput_mibps = self.private_network_throughput_mibps
+
+        public_network_throughput_mibps: int | None | Unset
+        if isinstance(self.public_network_throughput_mibps, Unset):
+            public_network_throughput_mibps = UNSET
+        else:
+            public_network_throughput_mibps = self.public_network_throughput_mibps
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if egress is not UNSET:
+            field_dict["egress"] = egress
+        if private_network_throughput_mibps is not UNSET:
+            field_dict["private_network_throughput_mibps"] = private_network_throughput_mibps
+        if public_network_throughput_mibps is not UNSET:
+            field_dict["public_network_throughput_mibps"] = public_network_throughput_mibps
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_egress(data: object) -> NetworkUpdatePayloadEgressType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                egress_type_0 = NetworkUpdatePayloadEgressType0(data)
+
+                return egress_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(NetworkUpdatePayloadEgressType0 | None | Unset, data)
+
+        egress = _parse_egress(d.pop("egress", UNSET))
+
+        def _parse_private_network_throughput_mibps(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        private_network_throughput_mibps = _parse_private_network_throughput_mibps(
+            d.pop("private_network_throughput_mibps", UNSET)
+        )
+
+        def _parse_public_network_throughput_mibps(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        public_network_throughput_mibps = _parse_public_network_throughput_mibps(
+            d.pop("public_network_throughput_mibps", UNSET)
+        )
+
+        network_update_payload = cls(
+            egress=egress,
+            private_network_throughput_mibps=private_network_throughput_mibps,
+            public_network_throughput_mibps=public_network_throughput_mibps,
+        )
+
+        return network_update_payload

--- a/clients/atlas/atlas/models/network_update_payload_egress_type_0.py
+++ b/clients/atlas/atlas/models/network_update_payload_egress_type_0.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+
+class NetworkUpdatePayloadEgressType0(StrEnum):
+    MESH = "mesh"
+    NONE = "none"
+    UPLINK = "uplink"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/page_image_response.py
+++ b/clients/atlas/atlas/models/page_image_response.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.image_response import ImageResponse
+
+
+T = TypeVar("T", bound="PageImageResponse")
+
+
+@_attrs_define
+class PageImageResponse:
+    """
+    Attributes:
+        has_more (bool):
+        items (list[ImageResponse]):
+        limit (int):
+        offset (int):
+    """
+
+    has_more: bool
+    items: list[ImageResponse]
+    limit: int
+    offset: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        has_more = self.has_more
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        limit = self.limit
+
+        offset = self.offset
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "has_more": has_more,
+                "items": items,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.image_response import ImageResponse  # noqa: PLC0415
+
+        d = dict(src_dict)
+        has_more = d.pop("has_more")
+
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ImageResponse.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        limit = d.pop("limit")
+
+        offset = d.pop("offset")
+
+        page_image_response = cls(
+            has_more=has_more,
+            items=items,
+            limit=limit,
+            offset=offset,
+        )
+
+        page_image_response.additional_properties = d
+        return page_image_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/page_ip_address_response.py
+++ b/clients/atlas/atlas/models/page_ip_address_response.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.ip_address_response import IPAddressResponse
+
+
+T = TypeVar("T", bound="PageIPAddressResponse")
+
+
+@_attrs_define
+class PageIPAddressResponse:
+    """
+    Attributes:
+        has_more (bool):
+        items (list[IPAddressResponse]):
+        limit (int):
+        offset (int):
+    """
+
+    has_more: bool
+    items: list[IPAddressResponse]
+    limit: int
+    offset: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        has_more = self.has_more
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        limit = self.limit
+
+        offset = self.offset
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "has_more": has_more,
+                "items": items,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.ip_address_response import IPAddressResponse  # noqa: PLC0415
+
+        d = dict(src_dict)
+        has_more = d.pop("has_more")
+
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = IPAddressResponse.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        limit = d.pop("limit")
+
+        offset = d.pop("offset")
+
+        page_ip_address_response = cls(
+            has_more=has_more,
+            items=items,
+            limit=limit,
+            offset=offset,
+        )
+
+        page_ip_address_response.additional_properties = d
+        return page_ip_address_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/page_virtual_machine_response.py
+++ b/clients/atlas/atlas/models/page_virtual_machine_response.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.virtual_machine_response import VirtualMachineResponse
+
+
+T = TypeVar("T", bound="PageVirtualMachineResponse")
+
+
+@_attrs_define
+class PageVirtualMachineResponse:
+    """
+    Attributes:
+        has_more (bool):
+        items (list[VirtualMachineResponse]):
+        limit (int):
+        offset (int):
+    """
+
+    has_more: bool
+    items: list[VirtualMachineResponse]
+    limit: int
+    offset: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        has_more = self.has_more
+
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        limit = self.limit
+
+        offset = self.offset
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "has_more": has_more,
+                "items": items,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.virtual_machine_response import VirtualMachineResponse  # noqa: PLC0415
+
+        d = dict(src_dict)
+        has_more = d.pop("has_more")
+
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = VirtualMachineResponse.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        limit = d.pop("limit")
+
+        offset = d.pop("offset")
+
+        page_virtual_machine_response = cls(
+            has_more=has_more,
+            items=items,
+            limit=limit,
+            offset=offset,
+        )
+
+        page_virtual_machine_response.additional_properties = d
+        return page_virtual_machine_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/reserve_ip_address_payload.py
+++ b/clients/atlas/atlas/models/reserve_ip_address_payload.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..models.reserve_ip_address_payload_source import ReserveIPAddressPayloadSource
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ReserveIPAddressPayload")
+
+
+@_attrs_define
+class ReserveIPAddressPayload:
+    """Select the source of an IP address reservation.
+
+    Attributes:
+        source (ReserveIPAddressPayloadSource | Unset):  Default: ReserveIPAddressPayloadSource.POOL.
+    """
+
+    source: ReserveIPAddressPayloadSource | Unset = ReserveIPAddressPayloadSource.POOL
+
+    def to_dict(self) -> dict[str, Any]:
+        source: str | Unset = UNSET
+        if not isinstance(self.source, Unset):
+            source = self.source.value
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if source is not UNSET:
+            field_dict["source"] = source
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        _source = d.pop("source", UNSET)
+        source: ReserveIPAddressPayloadSource | Unset
+        if isinstance(_source, Unset):
+            source = UNSET
+        else:
+            source = ReserveIPAddressPayloadSource(_source)
+
+        reserve_ip_address_payload = cls(
+            source=source,
+        )
+
+        return reserve_ip_address_payload

--- a/clients/atlas/atlas/models/reserve_ip_address_payload_source.py
+++ b/clients/atlas/atlas/models/reserve_ip_address_payload_source.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class ReserveIPAddressPayloadSource(StrEnum):
+    POOL = "pool"
+    PROVIDER = "provider"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/atlas/atlas/models/snapshot_payload.py
+++ b/clients/atlas/atlas/models/snapshot_payload.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SnapshotPayload")
+
+
+@_attrs_define
+class SnapshotPayload:
+    """Values that create one Machine image from a virtual machine.
+
+    Attributes:
+        title (str):
+        cache_image (bool | Unset):  Default: False.
+        memory_snapshot (bool | Unset):  Default: False.
+    """
+
+    title: str
+    cache_image: bool | Unset = False
+    memory_snapshot: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        cache_image = self.cache_image
+
+        memory_snapshot = self.memory_snapshot
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "title": title,
+            }
+        )
+        if cache_image is not UNSET:
+            field_dict["cache_image"] = cache_image
+        if memory_snapshot is not UNSET:
+            field_dict["memory_snapshot"] = memory_snapshot
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        cache_image = d.pop("cache_image", UNSET)
+
+        memory_snapshot = d.pop("memory_snapshot", UNSET)
+
+        snapshot_payload = cls(
+            title=title,
+            cache_image=cache_image,
+            memory_snapshot=memory_snapshot,
+        )
+
+        return snapshot_payload

--- a/clients/atlas/atlas/models/ssh_keys_replacement_payload.py
+++ b/clients/atlas/atlas/models/ssh_keys_replacement_payload.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="SSHKeysReplacementPayload")
+
+
+@_attrs_define
+class SSHKeysReplacementPayload:
+    """The complete authorized key list.
+
+    Attributes:
+        ssh_keys (list[str]):
+    """
+
+    ssh_keys: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        ssh_keys = self.ssh_keys
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "ssh_keys": ssh_keys,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        ssh_keys = cast(list[str], d.pop("ssh_keys"))
+
+        ssh_keys_replacement_payload = cls(
+            ssh_keys=ssh_keys,
+        )
+
+        return ssh_keys_replacement_payload

--- a/clients/atlas/atlas/models/virtual_machine_detail_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_detail_response.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VirtualMachineDetailResponse")
+
+
+@_attrs_define
+class VirtualMachineDetailResponse:
+    """A stored virtual machine with its live host state.
+
+    Attributes:
+        created_at (int):
+        current_state (str):
+        desired_state (None | str):
+        disk_mib (int):
+        id (str):
+        image_id (str):
+        memory_mib (int):
+        tenant_id (int):
+        vcpus (int):
+    """
+
+    created_at: int
+    current_state: str
+    desired_state: None | str
+    disk_mib: int
+    id: str
+    image_id: str
+    memory_mib: int
+    tenant_id: int
+    vcpus: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        created_at = self.created_at
+
+        current_state = self.current_state
+
+        desired_state: None | str
+        desired_state = self.desired_state
+
+        disk_mib = self.disk_mib
+
+        id = self.id
+
+        image_id = self.image_id
+
+        memory_mib = self.memory_mib
+
+        tenant_id = self.tenant_id
+
+        vcpus = self.vcpus
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "created_at": created_at,
+                "current_state": current_state,
+                "desired_state": desired_state,
+                "disk_mib": disk_mib,
+                "id": id,
+                "image_id": image_id,
+                "memory_mib": memory_mib,
+                "tenant_id": tenant_id,
+                "vcpus": vcpus,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        created_at = d.pop("created_at")
+
+        current_state = d.pop("current_state")
+
+        def _parse_desired_state(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        desired_state = _parse_desired_state(d.pop("desired_state"))
+
+        disk_mib = d.pop("disk_mib")
+
+        id = d.pop("id")
+
+        image_id = d.pop("image_id")
+
+        memory_mib = d.pop("memory_mib")
+
+        tenant_id = d.pop("tenant_id")
+
+        vcpus = d.pop("vcpus")
+
+        virtual_machine_detail_response = cls(
+            created_at=created_at,
+            current_state=current_state,
+            desired_state=desired_state,
+            disk_mib=disk_mib,
+            id=id,
+            image_id=image_id,
+            memory_mib=memory_mib,
+            tenant_id=tenant_id,
+            vcpus=vcpus,
+        )
+
+        virtual_machine_detail_response.additional_properties = d
+        return virtual_machine_detail_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/virtual_machine_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_response.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VirtualMachineResponse")
+
+
+@_attrs_define
+class VirtualMachineResponse:
+    """A stored tenant virtual machine.
+
+    Attributes:
+        created_at (int):
+        disk_mib (int):
+        id (str):
+        image_id (str):
+        memory_mib (int):
+        tenant_id (int):
+        vcpus (int):
+    """
+
+    created_at: int
+    disk_mib: int
+    id: str
+    image_id: str
+    memory_mib: int
+    tenant_id: int
+    vcpus: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        created_at = self.created_at
+
+        disk_mib = self.disk_mib
+
+        id = self.id
+
+        image_id = self.image_id
+
+        memory_mib = self.memory_mib
+
+        tenant_id = self.tenant_id
+
+        vcpus = self.vcpus
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "created_at": created_at,
+                "disk_mib": disk_mib,
+                "id": id,
+                "image_id": image_id,
+                "memory_mib": memory_mib,
+                "tenant_id": tenant_id,
+                "vcpus": vcpus,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        created_at = d.pop("created_at")
+
+        disk_mib = d.pop("disk_mib")
+
+        id = d.pop("id")
+
+        image_id = d.pop("image_id")
+
+        memory_mib = d.pop("memory_mib")
+
+        tenant_id = d.pop("tenant_id")
+
+        vcpus = d.pop("vcpus")
+
+        virtual_machine_response = cls(
+            created_at=created_at,
+            disk_mib=disk_mib,
+            id=id,
+            image_id=image_id,
+            memory_mib=memory_mib,
+            tenant_id=tenant_id,
+            vcpus=vcpus,
+        )
+
+        virtual_machine_response.additional_properties = d
+        return virtual_machine_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/py.typed
+++ b/clients/atlas/atlas/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/clients/atlas/atlas/types.py
+++ b/clients/atlas/atlas/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/clients/atlas/pyproject.toml
+++ b/clients/atlas/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "atlas"
+version = "1.0.0"
+description = "A client library for accessing Atlas API"
+authors = []
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.23.1,<0.29.0",
+    "attrs>=22.2.0",
+]
+
+[tool.pdm]
+distribution = true
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]

--- a/clients/openapi/atlas-http-proxy.json
+++ b/clients/openapi/atlas-http-proxy.json
@@ -1,0 +1,616 @@
+{
+  "components": {
+    "schemas": {
+      "AddressUpdate": {
+        "additionalProperties": false,
+        "description": "One address for one site or custom domain.",
+        "properties": {
+          "address": {
+            "description": "The backend IPv6 address. Use `-` only for a site to stop its traffic.",
+            "examples": [
+              "2001:db8::10"
+            ],
+            "minLength": 1,
+            "title": "Address",
+            "type": "string"
+          }
+        },
+        "required": [
+          "address"
+        ],
+        "title": "AddressUpdate",
+        "type": "object"
+      },
+      "DomainMapping": {
+        "description": "One custom domain as the proxy stored it.",
+        "properties": {
+          "address": {
+            "description": "The backend IPv6 address.",
+            "title": "Address",
+            "type": "string"
+          },
+          "domain": {
+            "description": "The custom domain.",
+            "title": "Domain",
+            "type": "string"
+          }
+        },
+        "required": [
+          "domain",
+          "address"
+        ],
+        "title": "DomainMapping",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "MapReplaced": {
+        "description": "Result of a full map replacement.",
+        "properties": {
+          "entries": {
+            "description": "Number of entries in the replacement map.",
+            "title": "Entries",
+            "type": "integer"
+          },
+          "synced": {
+            "description": "Whether the complete map was applied.",
+            "title": "Synced",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "synced",
+          "entries"
+        ],
+        "title": "MapReplaced",
+        "type": "object"
+      },
+      "SiteMapping": {
+        "description": "One site as the proxy stored it.",
+        "properties": {
+          "address": {
+            "description": "The backend IPv6 address.",
+            "title": "Address",
+            "type": "string"
+          },
+          "site": {
+            "description": "The site subdomain.",
+            "title": "Site",
+            "type": "string"
+          }
+        },
+        "required": [
+          "site",
+          "address"
+        ],
+        "title": "SiteMapping",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "bearerFormat": "password or JWT",
+        "description": "Use the regional proxy password or a valid JWT.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "Route sites and custom domains to backend IPv6 addresses. Sync all routes after a controller restart, or change one route when an address changes.",
+    "title": "Atlas proxy control",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/healthz": {
+      "get": {
+        "description": "Use this route for the DNS health check. It checks OpenResty and the routes it holds.",
+        "operationId": "healthz",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Check traffic health",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/readyz": {
+      "get": {
+        "description": "Use this route before a controller sends routing updates. It checks the OpenResty admin API.",
+        "operationId": "readyz",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Check OpenResty readiness",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/v1/cluster/status": {
+      "get": {
+        "description": "Return the local cluster status.",
+        "operationId": "cluster_status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Cluster Status",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Cluster Status",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/v1/domains": {
+      "get": {
+        "description": "Read custom-domain routes during reconciliation.",
+        "operationId": "get_domains",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Get Domains",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List domain routes",
+        "tags": [
+          "Domains"
+        ]
+      },
+      "put": {
+        "description": "Replace every custom-domain route after a controller restart or full reconciliation. Example: `www.example.com` routes to `2001:db8::20`.",
+        "operationId": "replace_domains",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "The complete desired custom-domain map.",
+                "examples": [
+                  {
+                    "www.example.com": "2001:db8::20"
+                  }
+                ],
+                "title": "Values",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapReplaced"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Sync domain routes",
+        "tags": [
+          "Domains"
+        ]
+      }
+    },
+    "/v1/domains/{domain}": {
+      "delete": {
+        "description": "Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain is absent.",
+        "operationId": "delete_domain",
+        "parameters": [
+          {
+            "description": "The complete custom domain.",
+            "in": "path",
+            "name": "domain",
+            "required": true,
+            "schema": {
+              "description": "The complete custom domain.",
+              "title": "Domain",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remove domain route",
+        "tags": [
+          "Domains"
+        ]
+      },
+      "patch": {
+        "description": "Add or change one custom-domain route without changing other domains. Example: route `www.example.com` to `2001:db8::20`.",
+        "operationId": "patch_domain",
+        "parameters": [
+          {
+            "description": "The complete custom domain.",
+            "in": "path",
+            "name": "domain",
+            "required": true,
+            "schema": {
+              "description": "The complete custom domain.",
+              "title": "Domain",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddressUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DomainMapping"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update domain route",
+        "tags": [
+          "Domains"
+        ]
+      }
+    },
+    "/v1/sites": {
+      "get": {
+        "description": "Read site routes during reconciliation.",
+        "operationId": "get_sites",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Get Sites",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List site routes",
+        "tags": [
+          "Sites"
+        ]
+      },
+      "put": {
+        "description": "Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to `2001:db8::10`.",
+        "operationId": "replace_sites",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "The complete desired site map.",
+                "examples": [
+                  {
+                    "erp": "2001:db8::10",
+                    "shop": "2001:db8::11"
+                  }
+                ],
+                "title": "Values",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapReplaced"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Sync site routes",
+        "tags": [
+          "Sites"
+        ]
+      }
+    },
+    "/v1/sites/{name}": {
+      "delete": {
+        "description": "Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.",
+        "operationId": "delete_site",
+        "parameters": [
+          {
+            "description": "The site subdomain.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "The site subdomain.",
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remove site route",
+        "tags": [
+          "Sites"
+        ]
+      },
+      "patch": {
+        "description": "Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.",
+        "operationId": "patch_site",
+        "parameters": [
+          {
+            "description": "The site subdomain.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "The site subdomain.",
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddressUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteMapping"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update site route",
+        "tags": [
+          "Sites"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Use these routes for liveness and readiness checks.",
+      "name": "Health"
+    },
+    {
+      "description": "Route wildcard subdomains to backend IPv6 addresses.",
+      "name": "Sites"
+    },
+    {
+      "description": "Route custom domains to backend IPv6 addresses.",
+      "name": "Domains"
+    }
+  ]
+}

--- a/clients/openapi/atlas.json
+++ b/clients/openapi/atlas.json
@@ -1,0 +1,2233 @@
+{
+  "components": {
+    "schemas": {
+      "ComputeUpdatePayload": {
+        "additionalProperties": false,
+        "description": "New CPU and memory values for a stopped virtual machine.",
+        "properties": {
+          "memory_mib": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Memory Mib"
+          },
+          "vcpus": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Vcpus"
+          }
+        },
+        "title": "ComputeUpdatePayload",
+        "type": "object"
+      },
+      "ConsoleTokenPayload": {
+        "additionalProperties": false,
+        "description": "The console mode that the token opens.",
+        "properties": {
+          "mode": {
+            "default": "tty",
+            "enum": [
+              "tty",
+              "ssh"
+            ],
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "title": "ConsoleTokenPayload",
+        "type": "object"
+      },
+      "ConsoleTokenResponse": {
+        "description": "A single-use console token.",
+        "examples": [
+          {
+            "expires_in": 60,
+            "mode": "tty",
+            "token": "console-token"
+          }
+        ],
+        "properties": {
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "mode": {
+            "enum": [
+              "tty",
+              "ssh"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "mode",
+          "expires_in"
+        ],
+        "title": "ConsoleTokenResponse",
+        "type": "object"
+      },
+      "CreateVirtualMachinePayload": {
+        "additionalProperties": false,
+        "description": "Values that create one virtual machine.",
+        "properties": {
+          "disk_iops": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Disk Iops",
+            "type": "integer"
+          },
+          "disk_mib": {
+            "exclusiveMinimum": 0,
+            "title": "Disk Mib",
+            "type": "integer"
+          },
+          "disk_throughput_mibps": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Disk Throughput Mibps",
+            "type": "integer"
+          },
+          "egress": {
+            "default": "uplink",
+            "enum": [
+              "uplink",
+              "mesh",
+              "none"
+            ],
+            "title": "Egress",
+            "type": "string"
+          },
+          "hostname": {
+            "default": "",
+            "title": "Hostname",
+            "type": "string"
+          },
+          "image_id": {
+            "minLength": 1,
+            "title": "Image Id",
+            "type": "string"
+          },
+          "ip_address_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ip Address Id"
+          },
+          "memory_mib": {
+            "exclusiveMinimum": 0,
+            "title": "Memory Mib",
+            "type": "integer"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Metadata",
+            "type": "object"
+          },
+          "private_network_throughput_mibps": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Private Network Throughput Mibps",
+            "type": "integer"
+          },
+          "public_network_throughput_mibps": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Public Network Throughput Mibps",
+            "type": "integer"
+          },
+          "ssh_keys": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Ssh Keys",
+            "type": "array"
+          },
+          "user_data": {
+            "default": "",
+            "title": "User Data",
+            "type": "string"
+          },
+          "vcpus": {
+            "exclusiveMinimum": 0,
+            "title": "Vcpus",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "image_id",
+          "vcpus",
+          "memory_mib",
+          "disk_mib"
+        ],
+        "title": "CreateVirtualMachinePayload",
+        "type": "object"
+      },
+      "DiskUpdatePayload": {
+        "additionalProperties": false,
+        "description": "New disk size and disk rate limits.",
+        "properties": {
+          "disk_iops": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Disk Iops"
+          },
+          "disk_mib": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Disk Mib"
+          },
+          "disk_throughput_mibps": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Disk Throughput Mibps"
+          }
+        },
+        "title": "DiskUpdatePayload",
+        "type": "object"
+      },
+      "IPAddressAssignmentPayload": {
+        "additionalProperties": false,
+        "description": "The public IPv4 address to attach.",
+        "properties": {
+          "ip_address_id": {
+            "minLength": 1,
+            "title": "Ip Address Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ip_address_id"
+        ],
+        "title": "IPAddressAssignmentPayload",
+        "type": "object"
+      },
+      "IPAddressResponse": {
+        "description": "A tenant public IPv4 address.",
+        "examples": [
+          {
+            "address": "203.0.113.10",
+            "created_at": 1788834165,
+            "id": "203.0.113.10",
+            "state": "reserved",
+            "tenant_id": 7,
+            "virtual_machine_id": null
+          }
+        ],
+        "properties": {
+          "address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "integer"
+          },
+          "virtual_machine_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Virtual Machine Id"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "address",
+          "state",
+          "virtual_machine_id",
+          "created_at"
+        ],
+        "title": "IPAddressResponse",
+        "type": "object"
+      },
+      "ImageDownloadResponse": {
+        "description": "Signed downloads for one image.",
+        "examples": [
+          {
+            "artifact": "rootfs",
+            "expires_at": 1788920565,
+            "expires_in": 86400,
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "size_mib": 20480,
+            "url": "https://storage.example/rootfs"
+          }
+        ],
+        "properties": {
+          "artifact": {
+            "enum": [
+              "rootfs",
+              "kernel"
+            ],
+            "title": "Artifact",
+            "type": "string"
+          },
+          "expires_at": {
+            "title": "Expires At",
+            "type": "integer"
+          },
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "sha256": {
+            "title": "Sha256",
+            "type": "string"
+          },
+          "size_mib": {
+            "title": "Size Mib",
+            "type": "integer"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact",
+          "url",
+          "size_mib",
+          "sha256",
+          "expires_in",
+          "expires_at"
+        ],
+        "title": "ImageDownloadResponse",
+        "type": "object"
+      },
+      "ImageResponse": {
+        "description": "A tenant virtual machine image.",
+        "examples": [
+          {
+            "cache_image": false,
+            "created_at": 1788834165,
+            "enabled": true,
+            "id": "8f1c2d3e4b5a6978",
+            "image_type": "machine",
+            "kernel_size_mib": 8,
+            "memory_snapshot": false,
+            "operating_system": "Ubuntu",
+            "operating_system_version": "24.04",
+            "platform": "amd64",
+            "rootfs_size_mib": 20480,
+            "status": "available",
+            "supports_cloud_init": true,
+            "tenant_id": 7,
+            "title": "Worker snapshot",
+            "transfer_error": null,
+            "transfer_progress": 100
+          }
+        ],
+        "properties": {
+          "cache_image": {
+            "title": "Cache Image",
+            "type": "boolean"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "image_type": {
+            "title": "Image Type",
+            "type": "string"
+          },
+          "kernel_size_mib": {
+            "title": "Kernel Size Mib",
+            "type": "integer"
+          },
+          "memory_snapshot": {
+            "title": "Memory Snapshot",
+            "type": "boolean"
+          },
+          "operating_system": {
+            "title": "Operating System",
+            "type": "string"
+          },
+          "operating_system_version": {
+            "title": "Operating System Version",
+            "type": "string"
+          },
+          "platform": {
+            "title": "Platform",
+            "type": "string"
+          },
+          "rootfs_size_mib": {
+            "title": "Rootfs Size Mib",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "supports_cloud_init": {
+            "title": "Supports Cloud Init",
+            "type": "boolean"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "transfer_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transfer Error"
+          },
+          "transfer_progress": {
+            "title": "Transfer Progress",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "title",
+          "image_type",
+          "platform",
+          "operating_system",
+          "operating_system_version",
+          "status",
+          "enabled",
+          "supports_cloud_init",
+          "cache_image",
+          "memory_snapshot",
+          "rootfs_size_mib",
+          "kernel_size_mib",
+          "transfer_progress",
+          "transfer_error",
+          "created_at"
+        ],
+        "title": "ImageResponse",
+        "type": "object"
+      },
+      "MetadataReplacementPayload": {
+        "additionalProperties": false,
+        "description": "The complete custom metadata map.",
+        "properties": {
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": [
+          "metadata"
+        ],
+        "title": "MetadataReplacementPayload",
+        "type": "object"
+      },
+      "NetworkUpdatePayload": {
+        "additionalProperties": false,
+        "description": "New egress mode and network rate limits.",
+        "properties": {
+          "egress": {
+            "anyOf": [
+              {
+                "enum": [
+                  "uplink",
+                  "mesh",
+                  "none"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Egress"
+          },
+          "private_network_throughput_mibps": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Private Network Throughput Mibps"
+          },
+          "public_network_throughput_mibps": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Public Network Throughput Mibps"
+          }
+        },
+        "title": "NetworkUpdatePayload",
+        "type": "object"
+      },
+      "Page[IPAddressResponse]": {
+        "examples": [
+          {
+            "has_more": false,
+            "items": [],
+            "limit": 20,
+            "offset": 0
+          }
+        ],
+        "properties": {
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/IPAddressResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "offset",
+          "limit",
+          "has_more"
+        ],
+        "title": "Page[IPAddressResponse]",
+        "type": "object"
+      },
+      "Page[ImageResponse]": {
+        "examples": [
+          {
+            "has_more": false,
+            "items": [],
+            "limit": 20,
+            "offset": 0
+          }
+        ],
+        "properties": {
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ImageResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "offset",
+          "limit",
+          "has_more"
+        ],
+        "title": "Page[ImageResponse]",
+        "type": "object"
+      },
+      "Page[VirtualMachineResponse]": {
+        "examples": [
+          {
+            "has_more": false,
+            "items": [],
+            "limit": 20,
+            "offset": 0
+          }
+        ],
+        "properties": {
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VirtualMachineResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "offset",
+          "limit",
+          "has_more"
+        ],
+        "title": "Page[VirtualMachineResponse]",
+        "type": "object"
+      },
+      "ReserveIPAddressPayload": {
+        "additionalProperties": false,
+        "description": "Select the source of an IP address reservation.",
+        "properties": {
+          "source": {
+            "default": "pool",
+            "enum": [
+              "pool",
+              "provider"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "title": "ReserveIPAddressPayload",
+        "type": "object"
+      },
+      "SSHKeysReplacementPayload": {
+        "additionalProperties": false,
+        "description": "The complete authorized key list.",
+        "properties": {
+          "ssh_keys": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Ssh Keys",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ssh_keys"
+        ],
+        "title": "SSHKeysReplacementPayload",
+        "type": "object"
+      },
+      "SnapshotPayload": {
+        "additionalProperties": false,
+        "description": "Values that create one Machine image from a virtual machine.",
+        "properties": {
+          "cache_image": {
+            "default": false,
+            "title": "Cache Image",
+            "type": "boolean"
+          },
+          "memory_snapshot": {
+            "default": false,
+            "title": "Memory Snapshot",
+            "type": "boolean"
+          },
+          "title": {
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "SnapshotPayload",
+        "type": "object"
+      },
+      "VirtualMachineDetailResponse": {
+        "description": "A stored virtual machine with its live host state.",
+        "examples": [
+          {
+            "created_at": 1788834165,
+            "current_state": "running",
+            "desired_state": "running",
+            "disk_mib": 20480,
+            "id": "vm-00001",
+            "image_id": "8f1c2d3e4b5a6978",
+            "memory_mib": 2048,
+            "tenant_id": 7,
+            "vcpus": 2
+          }
+        ],
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "current_state": {
+            "title": "Current State",
+            "type": "string"
+          },
+          "desired_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Desired State"
+          },
+          "disk_mib": {
+            "title": "Disk Mib",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "image_id": {
+            "title": "Image Id",
+            "type": "string"
+          },
+          "memory_mib": {
+            "title": "Memory Mib",
+            "type": "integer"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "integer"
+          },
+          "vcpus": {
+            "title": "Vcpus",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "image_id",
+          "vcpus",
+          "memory_mib",
+          "disk_mib",
+          "created_at",
+          "desired_state",
+          "current_state"
+        ],
+        "title": "VirtualMachineDetailResponse",
+        "type": "object"
+      },
+      "VirtualMachineResponse": {
+        "description": "A stored tenant virtual machine.",
+        "examples": [
+          {
+            "created_at": 1788834165,
+            "disk_mib": 20480,
+            "id": "vm-00001",
+            "image_id": "8f1c2d3e4b5a6978",
+            "memory_mib": 2048,
+            "tenant_id": 7,
+            "vcpus": 2
+          }
+        ],
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "disk_mib": {
+            "title": "Disk Mib",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "image_id": {
+            "title": "Image Id",
+            "type": "string"
+          },
+          "memory_mib": {
+            "title": "Memory Mib",
+            "type": "integer"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "integer"
+          },
+          "vcpus": {
+            "title": "Vcpus",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "image_id",
+          "vcpus",
+          "memory_mib",
+          "disk_mib",
+          "created_at"
+        ],
+        "title": "VirtualMachineResponse",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "Access Token Authentication": {
+        "bearerFormat": "token",
+        "description": "Use: Bearer <access_token>. [Learn more](https://docs.frappe.io/framework/user/en/api/rest#3-access-token)",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "Central Token Authentication": {
+        "description": "Use: X-Atlas-Central-Token <token>.",
+        "in": "header",
+        "name": "X-Atlas-Central-Token",
+        "type": "apiKey"
+      },
+      "Token Based Authentication": {
+        "description": "Use: token api_key:api_secret. [Learn more](https://docs.frappe.io/framework/user/en/api/rest#1-token-based-authentication)",
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "title": "Atlas API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/atlas/images": {
+      "get": {
+        "description": "Returns one page of System and Machine images owned by the tenant in newest-first order.",
+        "operationId": "list_images",
+        "parameters": [
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page[ImageResponse]"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List images",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/api/atlas/images/{image_id}": {
+      "delete": {
+        "description": "Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and remaining host snapshot data.",
+        "operationId": "delete_image",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageResponse"
+                }
+              }
+            },
+            "description": "Deletion started. Poll the image route."
+          },
+          "409": {
+            "description": "A virtual machine uses this image, or the image is not a Machine image."
+          }
+        },
+        "summary": "Delete image",
+        "tags": [
+          "Images"
+        ]
+      },
+      "get": {
+        "description": "Returns one tenant image with its artifact metadata and transfer state.",
+        "operationId": "get_image",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get image",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/api/atlas/images/{image_id}/download": {
+      "get": {
+        "description": "Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its size, SHA-256 value, and expiry time and cannot be cached.",
+        "operationId": "download_image",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "artifact",
+            "required": true,
+            "schema": {
+              "enum": [
+                "rootfs",
+                "kernel"
+              ],
+              "title": "Artifact",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageDownloadResponse"
+                }
+              }
+            },
+            "description": "A signed artifact URL that expires after 24 hours."
+          }
+        },
+        "summary": "Download image",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/api/atlas/ip-addresses": {
+      "get": {
+        "description": "Returns one page of IP addresses reserved by the tenant in newest-first order.",
+        "operationId": "list_ip_addresses",
+        "parameters": [
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page[IPAddressResponse]"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List IP addresses",
+        "tags": [
+          "IP Addresses"
+        ]
+      },
+      "post": {
+        "description": "Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the provider source creates a provider reservation.",
+        "operationId": "reserve_ip_address",
+        "parameters": [
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "source": "pool"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ReserveIPAddressPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IPAddressResponse"
+                }
+              }
+            },
+            "description": "The address is reserved for the tenant."
+          },
+          "409": {
+            "description": "The shared pool holds no free address."
+          }
+        },
+        "summary": "Reserve IP address",
+        "tags": [
+          "IP Addresses"
+        ]
+      }
+    },
+    "/api/atlas/ip-addresses/{ip_address_id}": {
+      "delete": {
+        "description": "Returns an unattached address to the shared pool and keeps its provider reservation. An attached or detaching address cannot be released.",
+        "operationId": "release_ip_address",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ip_address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The address is back in the shared pool."
+          },
+          "409": {
+            "description": "The address is attached or detaching."
+          }
+        },
+        "summary": "Release IP address",
+        "tags": [
+          "IP Addresses"
+        ]
+      },
+      "get": {
+        "description": "Returns one tenant IP address with its attachment state and VM assignment.",
+        "operationId": "get_ip_address",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ip_address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IPAddressResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get IP address",
+        "tags": [
+          "IP Addresses"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines": {
+      "get": {
+        "description": "Returns one page of tenant VM records in newest-first order. This request does not contact the host.",
+        "operationId": "list_virtual_machines",
+        "parameters": [
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page[VirtualMachineResponse]"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List VMs",
+        "tags": [
+          "VM Lifecycle"
+        ]
+      },
+      "post": {
+        "description": "Creates a tenant VM from an image and requests the specified compute, disk, network, and guest configuration.",
+        "operationId": "create_virtual_machine",
+        "parameters": [
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "disk_mib": 20480,
+                "hostname": "worker-1",
+                "image_id": "8f1c2d3e4b5a6978",
+                "memory_mib": 2048,
+                "ssh_keys": [
+                  "ssh-ed25519 AAAA"
+                ],
+                "vcpus": 2
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateVirtualMachinePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The virtual machine request is stored."
+          }
+        },
+        "summary": "Create VM",
+        "tags": [
+          "VM Lifecycle"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}": {
+      "delete": {
+        "description": "Starts VM termination and detaches its public IP address without releasing the tenant reservation. Poll the VM until cleanup removes the record and this route returns 404.",
+        "operationId": "delete_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "Termination started. Poll the virtual machine route."
+          }
+        },
+        "summary": "Delete VM",
+        "tags": [
+          "VM Lifecycle"
+        ]
+      },
+      "get": {
+        "description": "Returns the stored VM record together with its desired state and current state.",
+        "operationId": "get_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineDetailResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get VM",
+        "tags": [
+          "VM Lifecycle"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/console-token": {
+      "post": {
+        "description": "Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60 seconds.",
+        "operationId": "create_virtual_machine_console_token",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "mode": "tty"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ConsoleTokenPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleTokenResponse"
+                }
+              }
+            },
+            "description": "A single-use console token."
+          }
+        },
+        "summary": "Create console token",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/pause": {
+      "post": {
+        "description": "Pauses the VM without stopping it. Poll the VM route to observe completion.",
+        "operationId": "pause_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The request is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Pause VM",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/restart": {
+      "post": {
+        "description": "Requests an in-place restart. Poll the VM route to observe completion.",
+        "operationId": "restart_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The request is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Restart VM",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/resume": {
+      "post": {
+        "description": "Returns a paused VM to the running state. Poll the VM route to observe completion.",
+        "operationId": "resume_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The request is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Resume VM",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/snapshot": {
+      "post": {
+        "description": "Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.\n\nIf `memory_snapshot` is true, Atlas also records the VM shape for compatible warm starts.",
+        "operationId": "create_virtual_machine_snapshot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "cache_image": false,
+                "memory_snapshot": false,
+                "title": "worker-1 golden"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageResponse"
+                }
+              }
+            },
+            "description": "The Machine image record is created."
+          }
+        },
+        "summary": "Create snapshot",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/start": {
+      "post": {
+        "description": "Requests the running state. Poll the VM route to observe completion.",
+        "operationId": "start_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The request is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Start VM",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/actions/stop": {
+      "post": {
+        "description": "Requests the stopped state. Poll the VM route to observe completion.",
+        "operationId": "stop_virtual_machine",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The request is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Stop VM",
+        "tags": [
+          "VM Actions"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/compute": {
+      "patch": {
+        "description": "Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the change.",
+        "operationId": "update_virtual_machine_compute",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "vcpus": 4
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ComputeUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Resize compute",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/disk": {
+      "patch": {
+        "description": "Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease, and a limit of 0 removes that limit.",
+        "operationId": "update_virtual_machine_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "disk_mib": 40960,
+                "disk_throughput_mibps": 100
+              },
+              "schema": {
+                "$ref": "#/components/schemas/DiskUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Resize disk",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address": {
+      "delete": {
+        "description": "Detaches the public IP address from the VM and keeps its tenant reservation.",
+        "operationId": "detach_virtual_machine_ip_address",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Detach IP address",
+        "tags": [
+          "VM Configuration"
+        ]
+      },
+      "put": {
+        "description": "Attaches one available IP address that the tenant reserved. Detach the current address before you attach a different one.",
+        "operationId": "attach_virtual_machine_ip_address",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "ip_address_id": "203.0.113.10"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/IPAddressAssignmentPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Attach IP address",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/metadata": {
+      "put": {
+        "description": "Replaces the complete custom metadata map. Entries that are not in the request are removed.",
+        "operationId": "replace_virtual_machine_metadata",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "metadata": {
+                  "environment": "production"
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/MetadataReplacementPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Replace metadata",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/network": {
+      "patch": {
+        "description": "Changes egress and network throughput limits. Egress controls internet reachability and does not change mesh reachability.",
+        "operationId": "update_virtual_machine_network",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "egress": "uplink",
+                "public_network_throughput_mibps": 50
+              },
+              "schema": {
+                "$ref": "#/components/schemas/NetworkUpdatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Update network",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    },
+    "/api/atlas/virtual-machines/{virtual_machine_id}/ssh-keys": {
+      "put": {
+        "description": "Replaces the complete authorized SSH key list. Keys that are not in the request are removed.",
+        "operationId": "replace_virtual_machine_ssh_keys",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_machine_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant that owns the resource, from 1 through 4294967295.",
+            "in": "header",
+            "name": "X-Tenant-ID",
+            "required": true,
+            "schema": {
+              "maximum": 4294967295,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "ssh_keys": [
+                  "ssh-ed25519 AAAA"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SSHKeysReplacementPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualMachineResponse"
+                }
+              }
+            },
+            "description": "The change is accepted. Poll the virtual machine route."
+          }
+        },
+        "summary": "Replace SSH keys",
+        "tags": [
+          "VM Configuration"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "Token Based Authentication": []
+    },
+    {
+      "Access Token Authentication": []
+    },
+    {
+      "Central Token Authentication": []
+    }
+  ],
+  "tags": [
+    {
+      "description": "Tenant control plane for virtual machines, IP addresses, and images.",
+      "name": "Atlas"
+    },
+    {
+      "description": "Create, manage, and terminate tenant virtual machines.",
+      "kind": "nav",
+      "name": "Virtual Machines"
+    },
+    {
+      "description": "Create, read, and terminate virtual machines.",
+      "name": "VM Lifecycle",
+      "parent": "Virtual Machines"
+    },
+    {
+      "description": "Control virtual machine state and create snapshots and console tokens.",
+      "name": "VM Actions",
+      "parent": "Virtual Machines"
+    },
+    {
+      "description": "Change virtual machine compute, storage, network, and guest settings.",
+      "name": "VM Configuration",
+      "parent": "Virtual Machines"
+    },
+    {
+      "description": "Reserve and release public IPv4 addresses for one tenant.",
+      "name": "IP Addresses"
+    },
+    {
+      "description": "Read and delete tenant virtual machine images.",
+      "name": "Images"
+    }
+  ]
+}

--- a/docs/api-clients.md
+++ b/docs/api-clients.md
@@ -14,7 +14,7 @@ The `atlas` client package has the same name as the Frappe app package. Do not i
 `scripts/generate-api-client.py` writes the OpenAPI document and then the client. It imports the application and reads the specification in memory. A site, a database, and a running server are not necessary.
 
 ```bash
-pip install openapi-python-client==0.29.1
+pip install openapi-python-client==0.29.1 ruff==0.16.6
 ./scripts/generate-api-clients.sh
 ```
 
@@ -26,6 +26,8 @@ python scripts/generate-api-client.py atlas-http-proxy
 ```
 
 Commit the result. The `atlas` command needs `frappe` and the `atlas` app on the Python path, so run it from a bench environment. The `atlas-http-proxy` command needs the `atlas-proxy-control` package. It writes a temporary configuration file, because `proxy_control.main` loads its configuration at import time.
+
+The generator formats its output with the `ruff` that it finds on the path. Install the pinned version with the generator, or the result is different from the committed client.
 
 The client method names come from the OpenAPI operation IDs. Atlas uses the route function name. The HTTP proxy control daemon uses `generate_unique_id_function` to do the same.
 

--- a/docs/api-clients.md
+++ b/docs/api-clients.md
@@ -1,0 +1,34 @@
+# API clients
+
+`clients/` holds two generated Python clients and the OpenAPI documents that they come from. [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) generates them. The clients are in Git, so a user can install one directly.
+
+| Directory | Package | API |
+| --- | --- | --- |
+| `clients/atlas` | `atlas` | Atlas tenant API |
+| `clients/atlas-http-proxy` | `atlas_http_proxy` | HTTP proxy control API |
+
+The `atlas` client package has the same name as the Frappe app package. Do not install the client into a bench environment.
+
+## Regenerate
+
+`scripts/generate-api-client.py` writes the OpenAPI document and then the client. It imports the application and reads the specification in memory. A site, a database, and a running server are not necessary.
+
+```bash
+pip install openapi-python-client==0.29.1
+./scripts/generate-api-clients.sh
+```
+
+`scripts/generate-api-clients.sh` writes both clients. It runs the `atlas` client with the bench environment python, which it finds two directories above the repository, and it runs the `atlas-http-proxy` client with `uv`, which supplies the `atlas-proxy-control` package. Set `ATLAS_PYTHON` when the bench environment is in another location. To write one client, call the Python script directly.
+
+```bash
+python scripts/generate-api-client.py atlas
+python scripts/generate-api-client.py atlas-http-proxy
+```
+
+Commit the result. The `atlas` command needs `frappe` and the `atlas` app on the Python path, so run it from a bench environment. The `atlas-http-proxy` command needs the `atlas-proxy-control` package. It writes a temporary configuration file, because `proxy_control.main` loads its configuration at import time.
+
+The client method names come from the OpenAPI operation IDs. Atlas uses the route function name. The HTTP proxy control daemon uses `generate_unique_id_function` to do the same.
+
+## CI
+
+The `CI` workflow regenerates the `atlas` client, and the `Atlas HTTP proxy tests` workflow regenerates the `atlas-http-proxy` client. Each workflow fails when the result is different from the committed client. Regenerate the client in the same commit as an API change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = []
 [tool.ruff]
 line-length = 110
 target-version = "py314"
-extend-exclude = ["metal", "services/wg-mesh"]
+extend-exclude = ["metal", "services/wg-mesh", "clients"]
 
 [tool.ruff.lint]
 select = [

--- a/scripts/generate-api-client.py
+++ b/scripts/generate-api-client.py
@@ -1,0 +1,121 @@
+"""Write the OpenAPI document and the Python client of one component into clients/."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+CLIENTS = ROOT / "clients"
+GENERATOR = "openapi-python-client"
+
+PROXY_CONFIGURATION = """[control]
+domain = "proxy-001.example.com"
+
+[tls]
+wildcard_domain = "*.example.com"
+fullchain_pem = "leaf"
+private_key_pem = "key"
+"""
+
+
+def build_atlas_specification() -> dict[str, Any]:
+	"""Return the OpenAPI document of the Atlas tenant API."""
+	from atlas.api.core.docs import generate_specification
+	from atlas.api.router import atlas_router, register_atlas_api
+
+	register_atlas_api()
+	return generate_specification(atlas_router)
+
+
+def build_http_proxy_specification() -> dict[str, Any]:
+	"""Return the OpenAPI document of the HTTP proxy control daemon."""
+	with tempfile.TemporaryDirectory() as directory:
+		path = Path(directory) / "proxy-control.toml"
+		path.write_text(PROXY_CONFIGURATION)
+		os.environ["ATLAS_PROXY_CONTROL_CONFIG"] = str(path)
+
+		from proxy_control.main import app
+
+		return app.openapi()
+
+
+@dataclass(frozen=True)
+class Client:
+	"""One generated client and the specification that it comes from."""
+
+	name: str
+	package: str
+	build_specification: Callable[[], dict[str, Any]]
+
+	@property
+	def specification_path(self) -> Path:
+		"""Return the path of the OpenAPI document."""
+		return CLIENTS / "openapi" / f"{self.name}.json"
+
+	@property
+	def path(self) -> Path:
+		"""Return the path of the client package."""
+		return CLIENTS / self.name
+
+	def write_specification(self) -> None:
+		"""Write the OpenAPI document of the component."""
+		self.specification_path.parent.mkdir(parents=True, exist_ok=True)
+		document = json.dumps(self.build_specification(), indent=2, sort_keys=True)
+		self.specification_path.write_text(document + "\n")
+
+	def write_client(self) -> None:
+		"""Generate the Python client from the OpenAPI document."""
+		with tempfile.TemporaryDirectory() as directory:
+			configuration = Path(directory) / "config.yml"
+			configuration.write_text(
+				f"package_name_override: {self.package}\nproject_name_override: {self.name}\n"
+			)
+			subprocess.run(
+				[
+					GENERATOR,
+					"generate",
+					"--path",
+					str(self.specification_path),
+					"--output-path",
+					str(self.path),
+					"--config",
+					str(configuration),
+					"--meta",
+					"pdm",
+					"--overwrite",
+				],
+				check=True,
+			)
+
+
+CLIENTS_BY_NAME = {
+	client.name: client
+	for client in (
+		Client("atlas", "atlas", build_atlas_specification),
+		Client("atlas-http-proxy", "atlas_http_proxy", build_http_proxy_specification),
+	)
+}
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("client", choices=sorted(CLIENTS_BY_NAME))
+	arguments = parser.parse_args()
+
+	client = CLIENTS_BY_NAME[arguments.client]
+	client.write_specification()
+	client.write_client()
+	print(f"Wrote {client.specification_path.relative_to(ROOT)} and {client.path.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/generate-api-clients.sh
+++ b/scripts/generate-api-clients.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GENERATE="$ROOT/scripts/generate-api-client.py"
 GENERATOR_VERSION="0.29.1"
+RUFF_VERSION="0.16.6"
 ATLAS_PYTHON="${ATLAS_PYTHON:-$ROOT/../../env/bin/python}"
 
 if [ ! -x "$ATLAS_PYTHON" ]; then
@@ -12,7 +13,12 @@ if [ ! -x "$ATLAS_PYTHON" ]; then
 fi
 
 if ! command -v openapi-python-client >/dev/null; then
-	echo "Install openapi-python-client==$GENERATOR_VERSION." >&2
+	echo "Install openapi-python-client==$GENERATOR_VERSION and ruff==$RUFF_VERSION." >&2
+	exit 1
+fi
+
+if ! command -v ruff >/dev/null; then
+	echo "Install ruff==$RUFF_VERSION. The generator formats its output with it." >&2
 	exit 1
 fi
 

--- a/scripts/generate-api-clients.sh
+++ b/scripts/generate-api-clients.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GENERATE="$ROOT/scripts/generate-api-client.py"
+GENERATOR_VERSION="0.29.1"
+ATLAS_PYTHON="${ATLAS_PYTHON:-$ROOT/../../env/bin/python}"
+
+if [ ! -x "$ATLAS_PYTHON" ]; then
+	echo "Set ATLAS_PYTHON to a bench environment python that imports frappe and atlas." >&2
+	exit 1
+fi
+
+if ! command -v openapi-python-client >/dev/null; then
+	echo "Install openapi-python-client==$GENERATOR_VERSION." >&2
+	exit 1
+fi
+
+if ! command -v uv >/dev/null; then
+	echo "Install uv. It supplies the environment of the HTTP proxy control daemon." >&2
+	exit 1
+fi
+
+"$ATLAS_PYTHON" "$GENERATE" atlas
+uv run --no-project --with "$ROOT/services/http-proxy/control" python "$GENERATE" atlas-http-proxy

--- a/services/http-proxy/control/proxy_control/main.py
+++ b/services/http-proxy/control/proxy_control/main.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 import httpx
 from fastapi import Body, Depends, FastAPI, Header, Path, Response, status
+from fastapi.routing import APIRoute
 from pydantic import BaseModel, ConfigDict, Field
 
 from . import docs
@@ -84,10 +85,16 @@ async def lifespan(_: FastAPI):
 		await proxy.close()
 
 
+def operation_id(route: APIRoute) -> str:
+	"""Return the route function name as the OpenAPI operation ID."""
+	return route.name
+
+
 app = FastAPI(
 	title="Atlas proxy control",
 	description="Route sites and custom domains to backend IPv6 addresses. Sync all routes after a controller restart, or change one route when an address changes.",
 	lifespan=lifespan,
+	generate_unique_id_function=operation_id,
 	docs_url=None,
 	redoc_url=None,
 	openapi_url=None,


### PR DESCRIPTION
Related https://github.com/frappe/atlas/pull/206

`clients/` holds a generated Python client for the Atlas API and one for the HTTP proxy control API. The clients are in Git, so a user can install one directly. CI regenerates each client and fails when it is different from the committed client.

User need to run one command `./scripts/generate-api-clients.sh` to re-generate the config.