### PR TITLE
feat(vm): Add VM State Sync Support

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           python -m venv "$RUNNER_TEMP/openapi-generator"
-          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1 ruff==0.16.6
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
           export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
           PYTHONPATH="$GITHUB_WORKSPACE" ./env/bin/python "$GITHUB_WORKSPACE/scripts/generate-api-client.py" atlas
           git -C "$GITHUB_WORKSPACE" add --all --intent-to-add clients

--- a/.github/workflows/http-proxy-tests.yml
+++ b/.github/workflows/http-proxy-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           control_python="$(command -v python)"
           python -m venv "$RUNNER_TEMP/openapi-generator"
-          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1 ruff==0.16.6
+          "$RUNNER_TEMP/openapi-generator/bin/pip" install --quiet openapi-python-client==0.29.1
           export PATH="$RUNNER_TEMP/openapi-generator/bin:$PATH"
           "$control_python" scripts/generate-api-client.py atlas-http-proxy
           git add --all --intent-to-add clients

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: 'node_modules|.git'
+exclude: 'node_modules|.git|^clients/'
 default_stages: [pre-commit]
 fail_fast: false
 

--- a/atlas/api/models.py
+++ b/atlas/api/models.py
@@ -294,6 +294,15 @@ class ConsoleTokenPayload(StrictModel):
 	mode: Literal["tty", "ssh"] = "tty"
 
 
+def get_current_state(virtual_machine: VirtualMachine, reported_state: str | None) -> str:
+	"""Return the state a caller sees. An Atlas transition hides the host state."""
+	if virtual_machine.is_draft:
+		return "pending"
+	if virtual_machine.is_terminating:
+		return "terminating"
+	return reported_state or "unknown"
+
+
 class VirtualMachineResponse(BaseModel):
 	"""A stored tenant virtual machine."""
 
@@ -335,6 +344,37 @@ class VirtualMachineResponse(BaseModel):
 		)
 
 
+class VirtualMachineListResponse(VirtualMachineResponse):
+	"""A stored virtual machine with its last known host state."""
+
+	model_config = ConfigDict(
+		json_schema_extra={
+			"examples": [
+				{
+					**VirtualMachineResponse.model_config["json_schema_extra"]["examples"][0],
+					"last_known_state": "running",
+					"state_synced_at": 1788834165,
+				}
+			]
+		}
+	)
+
+	last_known_state: str
+	state_synced_at: int | None
+
+	@classmethod
+	def from_document_and_state(
+		cls, virtual_machine: VirtualMachine, state: Any | None
+	) -> VirtualMachineListResponse:
+		"""Build a list response from Atlas and the stored host state."""
+		stored = VirtualMachineResponse.from_document(virtual_machine)
+		return cls(
+			**stored.model_dump(),
+			last_known_state=get_current_state(virtual_machine, state.status if state else None),
+			state_synced_at=to_unix_timestamp(state.synced_at) if state else None,
+		)
+
+
 class VirtualMachineDetailResponse(VirtualMachineResponse):
 	"""A stored virtual machine with its live host state."""
 
@@ -359,18 +399,12 @@ class VirtualMachineDetailResponse(VirtualMachineResponse):
 	) -> VirtualMachineDetailResponse:
 		"""Build a detailed response from Atlas and Metal state."""
 		stored = VirtualMachineResponse.from_document(virtual_machine)
-		desired_state = information.desired.state if information else None
-		if virtual_machine.is_draft:
-			current_state = "unknown"
-		elif virtual_machine.is_terminating:
-			current_state = "terminating"
-		else:
-			current_state = information.observed.state if information else "unknown"
-
 		return cls(
 			**stored.model_dump(),
-			desired_state=desired_state,
-			current_state=current_state,
+			desired_state=information.desired.state if information else None,
+			current_state=get_current_state(
+				virtual_machine, information.observed.state if information else None
+			),
 		)
 
 

--- a/atlas/api/routes/virtual_machines.py
+++ b/atlas/api/routes/virtual_machines.py
@@ -28,6 +28,7 @@ from atlas.api.models import (
 	SnapshotPayload,
 	SSHKeysReplacementPayload,
 	VirtualMachineDetailResponse,
+	VirtualMachineListResponse,
 	VirtualMachineResponse,
 )
 from atlas.api.router import (
@@ -40,6 +41,7 @@ from atlas.api.routes.images import get_owned_image
 from atlas.api.routes.ip_addresses import get_owned_ip_address
 from atlas.auth.tenant import get_tenant_id
 from atlas.vm.core.console_token import CONSOLE_TOKEN_TTL_SECONDS
+from atlas.vm.core.vm_state import get_reported_state_rows
 from atlas.vm.doctype.virtual_machine.virtual_machine import create as create_virtual_machine_request
 
 if TYPE_CHECKING:
@@ -115,10 +117,10 @@ def create_virtual_machine(
 
 @virtual_machines.get("")
 @api_docs()
-def list_virtual_machines(query: ListQuery) -> Page[VirtualMachineResponse]:
+def list_virtual_machines(query: ListQuery) -> Page[VirtualMachineListResponse]:
 	"""List VMs.
 
-	Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+	Returns one page of tenant VM records in newest-first order, with the state each host last reported. This request does not contact the host.
 	"""
 	rows: list[VirtualMachine] = frappe.get_all(
 		"Virtual Machine",
@@ -138,7 +140,11 @@ def list_virtual_machines(query: ListQuery) -> Page[VirtualMachineResponse]:
 		start=query.offset,
 		limit=query.fetch_limit,
 	)
-	return build_page([VirtualMachineResponse.from_document(row) for row in rows], query)
+	states = get_reported_state_rows([row.name for row in rows])
+	return build_page(
+		[VirtualMachineListResponse.from_document_and_state(row, states.get(row.name)) for row in rows],
+		query,
+	)
 
 
 @virtual_machines.get("<virtual_machine_id>")

--- a/atlas/api/tests/test_virtual_machines.py
+++ b/atlas/api/tests/test_virtual_machines.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import frappe
 from frappe.tests import UnitTestCase
 
 from atlas.api.models import VirtualMachineDetailResponse, VirtualMachineResponse
@@ -48,6 +49,16 @@ def build_virtual_machine(tenant_id: int = TENANT_ID, **overrides) -> SimpleName
 	}
 	values.update(overrides)
 	return SimpleNamespace(**values)
+
+
+def stored_rows(rows: list[SimpleNamespace]):
+	"""Patch the Virtual Machine query and leave every other query alone."""
+	query = frappe.get_all
+
+	def get_all(doctype, *args, **kwargs):
+		return rows if doctype == "Virtual Machine" else query(doctype, *args, **kwargs)
+
+	return patch("atlas.api.routes.virtual_machines.frappe.get_all", side_effect=get_all)
 
 
 def owned_document(virtual_machine: SimpleNamespace, tenant_id: int = TENANT_ID):
@@ -141,7 +152,8 @@ class TestReadVirtualMachines(UnitTestCase):
 			api_request(
 				"GET", "/api/atlas/virtual-machines", tenant_id=TENANT_ID, query_string={"limit": "2"}
 			),
-			patch("atlas.api.routes.virtual_machines.frappe.get_all", return_value=rows) as get_all,
+			stored_rows(rows) as get_all,
+			patch("atlas.api.routes.virtual_machines.get_reported_state_rows", return_value={}),
 		):
 			status, body = call_route(list_virtual_machines)
 
@@ -150,6 +162,39 @@ class TestReadVirtualMachines(UnitTestCase):
 		self.assertEqual(get_all.call_args.kwargs["limit"], 3)
 		self.assertEqual(len(body["items"]), 2)
 		self.assertTrue(body["has_more"])
+
+	def test_list_adds_the_last_reported_state(self) -> None:
+		"""The list route reads stored state and does not contact the host."""
+		rows = [build_virtual_machine(), build_virtual_machine(name="vm-00002")]
+		state = SimpleNamespace(status="running", synced_at="2026-09-08 10:05:00")
+		with (
+			api_request("GET", "/api/atlas/virtual-machines", tenant_id=TENANT_ID),
+			stored_rows(rows),
+			patch(
+				"atlas.api.routes.virtual_machines.get_reported_state_rows",
+				return_value={"vm-00001": state},
+			),
+		):
+			status, body = call_route(list_virtual_machines)
+
+		self.assertEqual(status, 200)
+		self.assertEqual(body["items"][0]["last_known_state"], "running")
+		self.assertIsNotNone(body["items"][0]["state_synced_at"])
+		self.assertEqual(body["items"][1]["last_known_state"], "unknown")
+		self.assertIsNone(body["items"][1]["state_synced_at"])
+		rows[0].get_metal_vm_info.assert_not_called()
+
+	def test_list_shows_a_draft_as_pending(self) -> None:
+		rows = [build_virtual_machine(is_draft=1)]
+		with (
+			api_request("GET", "/api/atlas/virtual-machines", tenant_id=TENANT_ID),
+			stored_rows(rows),
+			patch("atlas.api.routes.virtual_machines.get_reported_state_rows", return_value={}),
+		):
+			status, body = call_route(list_virtual_machines)
+
+		self.assertEqual(status, 200)
+		self.assertEqual(body["items"][0]["last_known_state"], "pending")
 
 	def test_read_adds_the_live_host_state(self) -> None:
 		virtual_machine = build_virtual_machine()

--- a/atlas/auth/tenant.py
+++ b/atlas/auth/tenant.py
@@ -26,6 +26,7 @@ def parse_tenant_id(value: str) -> int:
 
 	if tenant_id == 0:
 		raise invalid_tenant("Tenant 0 is reserved.")
+
 	if not 1 <= tenant_id <= MAXIMUM_TENANT_ID:
 		raise invalid_tenant("The tenant ID must be an unsigned 32-bit integer.")
 	return tenant_id

--- a/atlas/docs/operations.md
+++ b/atlas/docs/operations.md
@@ -38,7 +38,7 @@ Use Frappe Desk Error Log and the named documents first. Keep the durable Atlas 
 
 ## Virtual machine stays unknown or failed
 
-- Symptom: The Atlas form shows `unknown` or `failed` after the normal reconcile interval.
+- Symptom: The Atlas form shows `unknown` or `failed` after the normal reconcile interval. A draft shows `pending`.
 - Owner: An uncertain Atlas create request or Metal runtime reconciliation.
 - Safe checks: Check whether the Atlas record is a draft. Read `GET /v1/vms/{id}`. Check the Metal log and `systemctl status metal-vm@<id>.service`.
 - Expected evidence: HTTP `404` confirms an absent draft. A present record reports desired state, observed state, and an error.

--- a/atlas/metal_server/doctype/metal_server/metal_server.json
+++ b/atlas/metal_server/doctype/metal_server/metal_server.json
@@ -208,9 +208,14 @@
    "group": "Logs",
    "link_doctype": "Metal Server Usage",
    "link_fieldname": "server"
+  },
+  {
+   "group": "Resources",
+   "link_doctype": "Virtual Machine",
+   "link_fieldname": "server"
   }
  ],
- "modified": "2026-09-03 22:00:13.169319",
+ "modified": "2026-09-09 16:54:30.933302",
  "modified_by": "Administrator",
  "module": "Metal Server",
  "name": "Metal Server",

--- a/atlas/metal_server/doctype/metal_server_usage/test_metal_server_usage.py
+++ b/atlas/metal_server/doctype/metal_server_usage/test_metal_server_usage.py
@@ -14,6 +14,16 @@ from atlas.metal_server.usage import (
 )
 from atlas.vm.core.metal_client import MetalClientError
 
+CAPACITY = {
+	"total_cpu_count": 8,
+	"available_cpu_count": 6,
+	"virtual_machine_count": 1,
+	"total_memory_mib": 16384,
+	"available_memory_mib": 8192,
+	"total_storage_mib": 102400,
+	"available_storage_mib": 51200,
+}
+
 
 class TestServerUsage(UnitTestCase):
 	def test_sync_logs_a_metal_connection_failure(self) -> None:
@@ -44,7 +54,23 @@ class TestServerUsage(UnitTestCase):
 		):
 			sync_server("server-1", [], [])
 
-		self.assertEqual(log_error.call_args.args[1], "Invalid capacity response from Server server-1")
+		self.assertEqual(log_error.call_args.args[1], "Invalid synchronization response from Server server-1")
+
+	def test_sync_logs_an_invalid_virtual_machine_response(self) -> None:
+		server = SimpleNamespace(name="server-1")
+		client = Mock()
+		client.sync.return_value = {"capacity": CAPACITY, "virtual_machines": {"vm-00001": {}}}
+
+		with (
+			patch("atlas.metal_server.usage.frappe.get_doc", return_value=server),
+			patch("atlas.metal_server.usage.MetalClient", return_value=client),
+			patch("atlas.metal_server.usage.get_desired_images", return_value=[]),
+			patch("atlas.metal_server.usage.store_reported_states", side_effect=ValueError("bad")),
+			patch("atlas.metal_server.usage.frappe.log_error") as log_error,
+		):
+			sync_server("server-1", [], [])
+
+		self.assertEqual(log_error.call_args.args[1], "Invalid synchronization response from Server server-1")
 
 	def test_enqueue_uses_one_exchange_per_server(self) -> None:
 		peers = [{"node": "server-1"}]

--- a/atlas/metal_server/usage.py
+++ b/atlas/metal_server/usage.py
@@ -8,6 +8,7 @@ from frappe.utils import now_datetime
 
 from atlas.atlas.core.mesh_address import get_virtual_machine_mesh_address
 from atlas.vm.core.metal_client import MetalClient, MetalClientError
+from atlas.vm.core.vm_state import store_reported_states
 
 if TYPE_CHECKING:
 	from atlas.metal_server.doctype.metal_server.metal_server import MetalServer
@@ -43,11 +44,12 @@ def sync_server(
 	wireguard_peers: list[dict[str, Any]],
 	privileged_vm_addresses: list[str],
 ) -> None:
-	"""Exchange state with one host and store its capacity."""
+	"""Exchange state with one host, then store its capacity and VM states."""
 	server = cast("MetalServer", frappe.get_doc("Metal Server", server_name))
 	try:
 		response = MetalClient(server).sync(wireguard_peers, get_desired_images(), privileged_vm_addresses)
 		values = get_usage_values(response.get("capacity"))
+		store_reported_states(server_name, response.get("virtual_machines"))
 	except MetalClientError:
 		frappe.log_error(
 			frappe.get_traceback(),
@@ -57,7 +59,7 @@ def sync_server(
 	except ValueError:
 		frappe.log_error(
 			frappe.get_traceback(),
-			f"Invalid capacity response from Server {server.name}",
+			f"Invalid synchronization response from Server {server.name}",
 		)
 		return
 

--- a/atlas/vm/SPEC.md
+++ b/atlas/vm/SPEC.md
@@ -16,6 +16,7 @@ The record name is the Metal VM ID. That single choice makes create idempotent, 
 |---|---|
 | `VirtualMachine` (DocType) | The reservation, permissions, and the whitelisted API. Runtime values read through. |
 | `VirtualMachineImage` (DocType) | The durable boot artifact and its immutable reference. |
+| `Virtual Machine State` (DocType) | The last status a host reported for one VM. The name is the VM name. |
 | `VirtualMachineService` | Every operation that spans an Atlas record and a Metal host. |
 | `PlacementService` | Choosing and locking the host for a new VM. |
 | `MetalClient` | `/v1` HTTP transport and error classification. |
@@ -23,6 +24,7 @@ The record name is the Metal VM ID. That single choice makes create idempotent, 
 | `VirtualMachineCreateRequest` | Validated create input. |
 | `vm_image_transfer`, `multipart_upload`, `image_builder` | Machine image movement and System image creation. |
 | `reconciliation` | Settling records whose Metal outcome was never confirmed. |
+| `vm_state` | The only writer of Virtual Machine State. The host sync job calls it. |
 
 ## Create
 
@@ -48,7 +50,10 @@ A sample older than the freshness limit is not used. Placement reports a synchro
 
 ## Reading state
 
-A Virtual Machine property calls Metal once per request and caches the result. A draft or a VM that Metal reports as absent reads as `unknown`. Any other Metal failure is raised, so a read fault is never shown as a state.
+A Virtual Machine property calls Metal once per request and caches the result. A draft reads as `pending`, and a VM that Metal reports as absent reads as `unknown`. Any other Metal failure is raised, so a read fault is never shown as a state.
+
+The list route does not call Metal. It returns `last_known_state` from Virtual Machine State, which holds the last status each host reported. `POST /v1/sync` carries that status for every VM on the host, so one exchange per host refreshes every record. The status is as fresh as the last host reconcile pass, and `state_synced_at` records when Atlas last stored it.
+
 
 ## Reconciliation
 

--- a/atlas/vm/core/test_vm_state.py
+++ b/atlas/vm/core/test_vm_state.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from frappe.tests import UnitTestCase
+
+from atlas.vm.core import vm_state
+
+
+class TestVirtualMachineState(UnitTestCase):
+	def store(self, names: list[str], stored: list[str], reported: dict) -> dict:
+		"""Store one reported state set against a stubbed database."""
+		results = [names, stored]
+
+		with (
+			patch.object(vm_state, "now_datetime", return_value=datetime(2026, 9, 9, 10, 0)),
+			patch.object(vm_state.frappe, "get_all", side_effect=results),
+			patch.object(vm_state, "insert_state") as insert_state,
+			patch.object(vm_state, "update_states") as update_states,
+			patch("atlas.vm.core.vm_state.frappe.db.delete") as delete,
+		):
+			vm_state.store_reported_states("metal-1", reported)
+
+		return {"insert": insert_state, "update": update_states, "delete": delete}
+
+	def test_a_first_report_inserts_and_a_later_report_updates(self) -> None:
+		calls = self.store(
+			names=["vm-00001", "vm-00002"],
+			stored=["vm-00002"],
+			reported={"vm-00001": {"status": "running"}, "vm-00002": {"status": "running"}},
+		)
+
+		self.assertEqual(calls["insert"].call_args.args[:2], ("vm-00001", "running"))
+		self.assertEqual(calls["update"].call_args.args[:2], (["vm-00002"], "running"))
+
+	def test_one_statement_updates_every_virtual_machine_of_one_status(self) -> None:
+		calls = self.store(
+			names=["vm-00001", "vm-00002", "vm-00003"],
+			stored=["vm-00001", "vm-00002", "vm-00003"],
+			reported={
+				"vm-00001": {"status": "running"},
+				"vm-00002": {"status": "running"},
+				"vm-00003": {"status": "stopped"},
+			},
+		)
+
+		self.assertEqual(calls["update"].call_count, 2)
+		statuses = {call.args[1]: call.args[0] for call in calls["update"].call_args_list}
+		self.assertEqual(statuses, {"running": ["vm-00001", "vm-00002"], "stopped": ["vm-00003"]})
+
+	def test_a_virtual_machine_the_host_stops_reporting_loses_its_state(self) -> None:
+		calls = self.store(
+			names=["vm-00001", "vm-00002"],
+			stored=["vm-00001", "vm-00002"],
+			reported={"vm-00001": {"status": "running"}},
+		)
+
+		calls["delete"].assert_called_once_with("Virtual Machine State", {"name": ["in", ["vm-00002"]]})
+
+	def test_a_host_without_virtual_machines_reads_nothing_more(self) -> None:
+		get_all = MagicMock(side_effect=[[]])
+
+		with patch.object(vm_state.frappe, "get_all", get_all):
+			vm_state.store_reported_states("metal-1", {})
+
+		get_all.assert_called_once()
+
+	def test_an_invalid_response_is_rejected(self) -> None:
+		for reported in ([], {"vm-00001": "running"}, {"vm-00001": {"status": ""}}, {"vm-00001": {}}):
+			with self.assertRaises(ValueError):
+				vm_state.get_reported_statuses(reported)

--- a/atlas/vm/core/vm_state.py
+++ b/atlas/vm/core/vm_state.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import frappe
+from frappe.utils import now_datetime
+
+
+def store_reported_states(server_name: str, reported: object) -> None:
+	"""Replace the stored virtual machine states of one host."""
+	statuses = get_reported_statuses(reported)
+	names = frappe.get_all("Virtual Machine", filters={"server": server_name}, pluck="name")
+	if not names:
+		return
+
+	stored = set(frappe.get_all("Virtual Machine State", filters={"name": ["in", names]}, pluck="name"))
+	synced_at = now_datetime()
+
+	updated_names: dict[str, list[str]] = {}
+	for name in names:
+		status = statuses.get(name)
+		if status is None:
+			continue
+		if name in stored:
+			updated_names.setdefault(status, []).append(name)
+		else:
+			insert_state(name, status, synced_at)
+
+	for status, group in updated_names.items():
+		update_states(group, status, synced_at)
+
+	absent = [name for name in names if name in stored and name not in statuses]
+	if absent:
+		frappe.db.delete("Virtual Machine State", {"name": ["in", absent]})
+
+
+def get_reported_statuses(reported: object) -> dict[str, str]:
+	"""Return the status of each virtual machine in a Metal sync response."""
+	if not isinstance(reported, dict):
+		raise ValueError("Metal virtual machine response must be an object")
+
+	statuses = {}
+	for name, state in reported.items():
+		status = state.get("status") if isinstance(state, dict) else None
+		if not isinstance(status, str) or not status:
+			raise ValueError("Metal virtual machine response has invalid values")
+		statuses[name] = status
+	return statuses
+
+
+def insert_state(name: str, status: str, synced_at: datetime) -> None:
+	"""Store the first reported state of one virtual machine."""
+	frappe.get_doc(
+		{
+			"doctype": "Virtual Machine State",
+			"virtual_machine": name,
+			"status": status,
+			"synced_at": synced_at,
+		}
+	).insert(ignore_permissions=True)
+
+
+def update_states(names: list[str], status: str, synced_at: datetime) -> None:
+	"""Store one status for every named virtual machine in one statement."""
+	table = frappe.qb.DocType("Virtual Machine State")
+	(
+		frappe.qb.update(table)
+		.set(table.status, status)
+		.set(table.synced_at, synced_at)
+		.where(table.name.isin(names))
+	).run()
+
+
+def get_reported_state_rows(names: list[str]) -> dict[str, Any]:
+	"""Return the stored state row of each named virtual machine."""
+	if not names:
+		return {}
+
+	rows = frappe.get_all(
+		"Virtual Machine State",
+		filters={"name": ["in", names]},
+		fields=["name", "status", "synced_at"],
+	)
+	return {row.name: row for row in rows}

--- a/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
@@ -797,19 +797,21 @@ class TestVirtualMachineNetwork(UnitTestCase):
 class TestVirtualMachineTrash(UnitTestCase):
 	"""Cover the cleanup that lets a terminated VM record be deleted."""
 
-	def test_trash_removes_the_ssh_tasks_of_the_machine(self) -> None:
-		"""SSH Task holds a dynamic link. Frappe refuses the delete while one exists."""
+	def test_trash_removes_dependent_records(self) -> None:
+		"""Dependent records must not prevent the virtual machine deletion."""
 		virtual_machine = Mock(doctype="Virtual Machine")
 		virtual_machine.name = "vm-00003"
 
 		with (
 			patch.object(virtual_machine_module, "VirtualMachineService") as service,
 			patch.object(virtual_machine_module, "delete_tasks_for_target") as delete_tasks,
+			patch.object(virtual_machine_module.frappe.db, "delete") as delete,
 		):
 			virtual_machine_module.VirtualMachine.on_trash(virtual_machine)
 
 		service.return_value.validate_deletion.assert_called_once()
 		delete_tasks.assert_called_once_with("Virtual Machine", "vm-00003")
+		delete.assert_called_once_with("Virtual Machine State", {"name": "vm-00003"})
 
 
 class TestReconcileTerminating(UnitTestCase):

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -146,9 +146,9 @@
    "label": "Tenant ID",
    "read_only": 1,
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1,
-   "show_description_on_click": 1,
-   "search_index": 1
+   "show_description_on_click": 1
   },
   {
    "default": "0",
@@ -251,9 +251,13 @@
   {
    "link_doctype": "SSH Task",
    "link_fieldname": "target"
+  },
+  {
+   "link_doctype": "Virtual Machine State",
+   "link_fieldname": "virtual_machine"
   }
  ],
- "modified": "2026-09-07 22:00:01.466665",
+ "modified": "2026-09-09 16:55:01.265692",
  "modified_by": "Administrator",
  "module": "VM",
  "name": "Virtual Machine",

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -68,12 +68,13 @@ class VirtualMachine(Document):
 		"""Delete only after Metal confirms that the VM is absent."""
 		VirtualMachineService(self).validate_deletion()
 		delete_tasks_for_target(self.doctype, self.name)
+		frappe.db.delete("Virtual Machine State", {"name": self.name})
 
 	@property
 	def current_state(self) -> str:
-		"""Return the state a user sees. A draft or an absent VM is unknown."""
+		"""Return the state a user sees. A draft is pending, an absent VM is unknown."""
 		if self.is_draft:
-			return "unknown"
+			return "pending"
 
 		if self.is_terminating:
 			return "terminating"

--- a/atlas/vm/doctype/virtual_machine_state/test_virtual_machine_state.py
+++ b/atlas/vm/doctype/virtual_machine_state/test_virtual_machine_state.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestVirtualMachineState(IntegrationTestCase):
+	"""
+	Integration tests for VirtualMachineState.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.js
+++ b/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Virtual Machine State", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.json
+++ b/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.json
@@ -1,0 +1,63 @@
+{
+ "actions": [],
+ "autoname": "field:virtual_machine",
+ "creation": "2026-09-09 10:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "virtual_machine",
+  "status",
+  "column_break_state",
+  "synced_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "virtual_machine",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Virtual Machine",
+   "options": "Virtual Machine",
+   "read_only": 1,
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_state",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "synced_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Synced At",
+   "read_only": 1,
+   "reqd": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-09-09 16:55:09.816290",
+ "modified_by": "Administrator",
+ "module": "VM",
+ "name": "Virtual Machine State",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "System Manager"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.py
+++ b/atlas/vm/doctype/virtual_machine_state/virtual_machine_state.py
@@ -1,0 +1,18 @@
+from frappe.model.document import Document
+
+
+class VirtualMachineState(Document):
+	"""The last state a Metal host reported for one virtual machine."""
+
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		status: DF.Data
+		synced_at: DF.Datetime
+		virtual_machine: DF.Link
+	# end: auto-generated types

--- a/clients/atlas-http-proxy/README.md
+++ b/clients/atlas-http-proxy/README.md
@@ -56,7 +56,11 @@ client = AuthenticatedClient(
 You can also disable certificate validation altogether, but beware that **this is a security risk**.
 
 ```python
-client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
 ```
 
 Things to know:
@@ -77,15 +81,12 @@ There are more settings on the generated `Client` class which let you control mo
 ```python
 from atlas_http_proxy import Client
 
-
 def log_request(request):
     print(f"Request event hook: {request.method} {request.url} - Waiting for response")
-
 
 def log_response(response):
     request = response.request
     print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
-
 
 client = Client(
     base_url="https://api.example.com",

--- a/clients/atlas-http-proxy/atlas_http_proxy/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/__init__.py
@@ -1,5 +1,5 @@
-"""A client library for accessing Atlas proxy control"""
 
+""" A client library for accessing Atlas proxy control """
 from .client import AuthenticatedClient, Client
 
 __all__ = (

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/__init__.py
@@ -1,1 +1,1 @@
-"""Contains methods for accessing the API"""
+""" Contains methods for accessing the API """

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/delete_domain.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/delete_domain.py
@@ -4,35 +4,44 @@ from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     domain: str,
+
 ) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/v1/domains/{domain}".format(
-            domain=quote(str(domain), safe=""),
-        ),
+        "url": "/v1/domains/{domain}".format(domain=quote(str(domain), safe=""),),
     }
+
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | HTTPValidationError | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | HTTPValidationError | None:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -42,9 +51,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | HTTPValidationError]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +64,9 @@ def sync_detailed(
     domain: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Response[Any | HTTPValidationError]:
-    """Remove domain route
+    """ Remove domain route
 
      Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
     is absent.
@@ -72,10 +80,12 @@ def sync_detailed(
 
     Returns:
         Response[Any | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         domain=domain,
+
     )
 
     response = client.get_httpx_client().request(
@@ -84,13 +94,13 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     domain: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Any | HTTPValidationError | None:
-    """Remove domain route
+    """ Remove domain route
 
      Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
     is absent.
@@ -104,20 +114,22 @@ def sync(
 
     Returns:
         Any | HTTPValidationError
-    """
+     """
+
 
     return sync_detailed(
         domain=domain,
-        client=client,
-    ).parsed
+client=client,
 
+    ).parsed
 
 async def asyncio_detailed(
     domain: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Response[Any | HTTPValidationError]:
-    """Remove domain route
+    """ Remove domain route
 
      Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
     is absent.
@@ -131,23 +143,27 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         domain=domain,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     domain: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Any | HTTPValidationError | None:
-    """Remove domain route
+    """ Remove domain route
 
      Remove one custom-domain route when it no longer needs proxy traffic. This succeeds when the domain
     is absent.
@@ -161,11 +177,11 @@ async def asyncio(
 
     Returns:
         Any | HTTPValidationError
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            domain=domain,
-            client=client,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        domain=domain,
+client=client,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/get_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/get_domains.py
@@ -1,29 +1,42 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.get_domains_response_get_domains import GetDomainsResponseGetDomains
-from ...types import Response
+from typing import cast
 
 
-def _get_kwargs() -> dict[str, Any]:
+
+def _get_kwargs(
+    
+) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/v1/domains",
     }
 
+
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> GetDomainsResponseGetDomains | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> GetDomainsResponseGetDomains | None:
     if response.status_code == 200:
         response_200 = GetDomainsResponseGetDomains.from_dict(response.json())
+
+
 
         return response_200
 
@@ -33,9 +46,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[GetDomainsResponseGetDomains]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[GetDomainsResponseGetDomains]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -47,8 +58,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[GetDomainsResponseGetDomains]:
-    """List domain routes
+    """ List domain routes
 
      Read custom-domain routes during reconciliation.
 
@@ -58,9 +70,12 @@ def sync_detailed(
 
     Returns:
         Response[GetDomainsResponseGetDomains]
-    """
+     """
 
-    kwargs = _get_kwargs()
+
+    kwargs = _get_kwargs(
+        
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -68,12 +83,12 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient,
+
 ) -> GetDomainsResponseGetDomains | None:
-    """List domain routes
+    """ List domain routes
 
      Read custom-domain routes during reconciliation.
 
@@ -83,18 +98,20 @@ def sync(
 
     Returns:
         GetDomainsResponseGetDomains
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-    ).parsed
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[GetDomainsResponseGetDomains]:
-    """List domain routes
+    """ List domain routes
 
      Read custom-domain routes during reconciliation.
 
@@ -104,20 +121,25 @@ async def asyncio_detailed(
 
     Returns:
         Response[GetDomainsResponseGetDomains]
-    """
+     """
 
-    kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    kwargs = _get_kwargs(
+        
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient,
+
 ) -> GetDomainsResponseGetDomains | None:
-    """List domain routes
+    """ List domain routes
 
      Read custom-domain routes during reconciliation.
 
@@ -127,10 +149,10 @@ async def asyncio(
 
     Returns:
         GetDomainsResponseGetDomains
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/patch_domain.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/patch_domain.py
@@ -1,29 +1,36 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.address_update import AddressUpdate
 from ...models.domain_mapping import DomainMapping
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     domain: str,
     *,
     body: AddressUpdate,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/v1/domains/{domain}".format(
-            domain=quote(str(domain), safe=""),
-        ),
+        "url": "/v1/domains/{domain}".format(domain=quote(str(domain), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -34,16 +41,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> DomainMapping | HTTPValidationError | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> DomainMapping | HTTPValidationError | None:
     if response.status_code == 200:
         response_200 = DomainMapping.from_dict(response.json())
+
+
 
         return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -53,9 +63,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[DomainMapping | HTTPValidationError]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[DomainMapping | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,8 +77,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> Response[DomainMapping | HTTPValidationError]:
-    """Update domain route
+    """ Update domain route
 
      Add or change one custom-domain route without changing other domains. Example: route
     `www.example.com` to `2001:db8::20`.
@@ -85,11 +94,13 @@ def sync_detailed(
 
     Returns:
         Response[DomainMapping | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         domain=domain,
-        body=body,
+body=body,
+
     )
 
     response = client.get_httpx_client().request(
@@ -98,14 +109,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     domain: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> DomainMapping | HTTPValidationError | None:
-    """Update domain route
+    """ Update domain route
 
      Add or change one custom-domain route without changing other domains. Example: route
     `www.example.com` to `2001:db8::20`.
@@ -120,22 +131,24 @@ def sync(
 
     Returns:
         DomainMapping | HTTPValidationError
-    """
+     """
+
 
     return sync_detailed(
         domain=domain,
-        client=client,
-        body=body,
-    ).parsed
+client=client,
+body=body,
 
+    ).parsed
 
 async def asyncio_detailed(
     domain: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> Response[DomainMapping | HTTPValidationError]:
-    """Update domain route
+    """ Update domain route
 
      Add or change one custom-domain route without changing other domains. Example: route
     `www.example.com` to `2001:db8::20`.
@@ -150,25 +163,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[DomainMapping | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         domain=domain,
-        body=body,
+body=body,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     domain: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> DomainMapping | HTTPValidationError | None:
-    """Update domain route
+    """ Update domain route
 
      Add or change one custom-domain route without changing other domains. Example: route
     `www.example.com` to `2001:db8::20`.
@@ -183,12 +200,12 @@ async def asyncio(
 
     Returns:
         DomainMapping | HTTPValidationError
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            domain=domain,
-            client=client,
-            body=body,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        domain=domain,
+client=client,
+body=body,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/domains/replace_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/domains/replace_domains.py
@@ -1,21 +1,31 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.http_validation_error import HTTPValidationError
 from ...models.map_replaced import MapReplaced
 from ...models.replace_domains_values import ReplaceDomainsValues
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     *,
     body: ReplaceDomainsValues,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "put",
@@ -30,16 +40,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | MapReplaced | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> HTTPValidationError | MapReplaced | None:
     if response.status_code == 200:
         response_200 = MapReplaced.from_dict(response.json())
+
+
 
         return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -49,9 +62,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | MapReplaced]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[HTTPValidationError | MapReplaced]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +75,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ReplaceDomainsValues,
+
 ) -> Response[HTTPValidationError | MapReplaced]:
-    """Sync domain routes
+    """ Sync domain routes
 
      Replace every custom-domain route after a controller restart or full reconciliation. Example:
     `www.example.com` routes to `2001:db8::20`.
@@ -79,10 +91,12 @@ def sync_detailed(
 
     Returns:
         Response[HTTPValidationError | MapReplaced]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
+
     )
 
     response = client.get_httpx_client().request(
@@ -91,13 +105,13 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient,
     body: ReplaceDomainsValues,
+
 ) -> HTTPValidationError | MapReplaced | None:
-    """Sync domain routes
+    """ Sync domain routes
 
      Replace every custom-domain route after a controller restart or full reconciliation. Example:
     `www.example.com` routes to `2001:db8::20`.
@@ -111,20 +125,22 @@ def sync(
 
     Returns:
         HTTPValidationError | MapReplaced
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        body=body,
-    ).parsed
+body=body,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ReplaceDomainsValues,
+
 ) -> Response[HTTPValidationError | MapReplaced]:
-    """Sync domain routes
+    """ Sync domain routes
 
      Replace every custom-domain route after a controller restart or full reconciliation. Example:
     `www.example.com` routes to `2001:db8::20`.
@@ -138,23 +154,27 @@ async def asyncio_detailed(
 
     Returns:
         Response[HTTPValidationError | MapReplaced]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ReplaceDomainsValues,
+
 ) -> HTTPValidationError | MapReplaced | None:
-    """Sync domain routes
+    """ Sync domain routes
 
      Replace every custom-domain route after a controller restart or full reconciliation. Example:
     `www.example.com` routes to `2001:db8::20`.
@@ -168,11 +188,11 @@ async def asyncio(
 
     Returns:
         HTTPValidationError | MapReplaced
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/cluster_status.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/cluster_status.py
@@ -1,29 +1,42 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.cluster_status_response_cluster_status import ClusterStatusResponseClusterStatus
-from ...types import Response
+from typing import cast
 
 
-def _get_kwargs() -> dict[str, Any]:
+
+def _get_kwargs(
+    
+) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/v1/cluster/status",
     }
 
+
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> ClusterStatusResponseClusterStatus | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ClusterStatusResponseClusterStatus | None:
     if response.status_code == 200:
         response_200 = ClusterStatusResponseClusterStatus.from_dict(response.json())
+
+
 
         return response_200
 
@@ -33,9 +46,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ClusterStatusResponseClusterStatus]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ClusterStatusResponseClusterStatus]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -47,8 +58,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[ClusterStatusResponseClusterStatus]:
-    """Cluster Status
+    """ Cluster Status
 
      Return the local cluster status.
 
@@ -58,9 +70,12 @@ def sync_detailed(
 
     Returns:
         Response[ClusterStatusResponseClusterStatus]
-    """
+     """
 
-    kwargs = _get_kwargs()
+
+    kwargs = _get_kwargs(
+        
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -68,12 +83,12 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient,
+
 ) -> ClusterStatusResponseClusterStatus | None:
-    """Cluster Status
+    """ Cluster Status
 
      Return the local cluster status.
 
@@ -83,18 +98,20 @@ def sync(
 
     Returns:
         ClusterStatusResponseClusterStatus
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-    ).parsed
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[ClusterStatusResponseClusterStatus]:
-    """Cluster Status
+    """ Cluster Status
 
      Return the local cluster status.
 
@@ -104,20 +121,25 @@ async def asyncio_detailed(
 
     Returns:
         Response[ClusterStatusResponseClusterStatus]
-    """
+     """
 
-    kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    kwargs = _get_kwargs(
+        
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient,
+
 ) -> ClusterStatusResponseClusterStatus | None:
-    """Cluster Status
+    """ Cluster Status
 
      Return the local cluster status.
 
@@ -127,10 +149,10 @@ async def asyncio(
 
     Returns:
         ClusterStatusResponseClusterStatus
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/healthz.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/healthz.py
@@ -1,21 +1,33 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
+from ... import errors
 
 
-def _get_kwargs() -> dict[str, Any]:
+
+
+def _get_kwargs(
+    
+) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/healthz",
     }
 
+
     return _kwargs
+
 
 
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
@@ -40,8 +52,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+
 ) -> Response[Any]:
-    """Check traffic health
+    """ Check traffic health
 
      Use this route for the DNS health check. It checks OpenResty and the routes it holds.
 
@@ -51,9 +64,12 @@ def sync_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
 
-    kwargs = _get_kwargs()
+
+    kwargs = _get_kwargs(
+        
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -65,8 +81,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+
 ) -> Response[Any]:
-    """Check traffic health
+    """ Check traffic health
 
      Use this route for the DNS health check. It checks OpenResty and the routes it holds.
 
@@ -76,10 +93,16 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
 
-    kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    kwargs = _get_kwargs(
+        
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
+

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/health/readyz.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/health/readyz.py
@@ -1,21 +1,33 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
+from ... import errors
 
 
-def _get_kwargs() -> dict[str, Any]:
+
+
+def _get_kwargs(
+    
+) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/readyz",
     }
 
+
     return _kwargs
+
 
 
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
@@ -40,8 +52,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+
 ) -> Response[Any]:
-    """Check OpenResty readiness
+    """ Check OpenResty readiness
 
      Use this route before a controller sends routing updates. It checks the OpenResty admin API.
 
@@ -51,9 +64,12 @@ def sync_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
 
-    kwargs = _get_kwargs()
+
+    kwargs = _get_kwargs(
+        
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -65,8 +81,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+
 ) -> Response[Any]:
-    """Check OpenResty readiness
+    """ Check OpenResty readiness
 
      Use this route before a controller sends routing updates. It checks the OpenResty admin API.
 
@@ -76,10 +93,16 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
 
-    kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    kwargs = _get_kwargs(
+        
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
+

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/delete_site.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/delete_site.py
@@ -4,35 +4,44 @@ from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     name: str,
+
 ) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/v1/sites/{name}".format(
-            name=quote(str(name), safe=""),
-        ),
+        "url": "/v1/sites/{name}".format(name=quote(str(name), safe=""),),
     }
+
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | HTTPValidationError | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | HTTPValidationError | None:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -42,9 +51,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | HTTPValidationError]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +64,9 @@ def sync_detailed(
     name: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Response[Any | HTTPValidationError]:
-    """Remove site route
+    """ Remove site route
 
      Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
 
@@ -71,10 +79,12 @@ def sync_detailed(
 
     Returns:
         Response[Any | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         name=name,
+
     )
 
     response = client.get_httpx_client().request(
@@ -83,13 +93,13 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     name: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Any | HTTPValidationError | None:
-    """Remove site route
+    """ Remove site route
 
      Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
 
@@ -102,20 +112,22 @@ def sync(
 
     Returns:
         Any | HTTPValidationError
-    """
+     """
+
 
     return sync_detailed(
         name=name,
-        client=client,
-    ).parsed
+client=client,
 
+    ).parsed
 
 async def asyncio_detailed(
     name: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Response[Any | HTTPValidationError]:
-    """Remove site route
+    """ Remove site route
 
      Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
 
@@ -128,23 +140,27 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any | HTTPValidationError]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         name=name,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     name: str,
     *,
     client: AuthenticatedClient,
+
 ) -> Any | HTTPValidationError | None:
-    """Remove site route
+    """ Remove site route
 
      Remove one site route when it no longer needs proxy traffic. This succeeds when the site is absent.
 
@@ -157,11 +173,11 @@ async def asyncio(
 
     Returns:
         Any | HTTPValidationError
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            name=name,
-            client=client,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        name=name,
+client=client,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/get_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/get_sites.py
@@ -1,29 +1,42 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.get_sites_response_get_sites import GetSitesResponseGetSites
-from ...types import Response
+from typing import cast
 
 
-def _get_kwargs() -> dict[str, Any]:
+
+def _get_kwargs(
+    
+) -> dict[str, Any]:
+    
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/v1/sites",
     }
 
+
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> GetSitesResponseGetSites | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> GetSitesResponseGetSites | None:
     if response.status_code == 200:
         response_200 = GetSitesResponseGetSites.from_dict(response.json())
+
+
 
         return response_200
 
@@ -33,9 +46,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[GetSitesResponseGetSites]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[GetSitesResponseGetSites]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -47,8 +58,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[GetSitesResponseGetSites]:
-    """List site routes
+    """ List site routes
 
      Read site routes during reconciliation.
 
@@ -58,9 +70,12 @@ def sync_detailed(
 
     Returns:
         Response[GetSitesResponseGetSites]
-    """
+     """
 
-    kwargs = _get_kwargs()
+
+    kwargs = _get_kwargs(
+        
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -68,12 +83,12 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient,
+
 ) -> GetSitesResponseGetSites | None:
-    """List site routes
+    """ List site routes
 
      Read site routes during reconciliation.
 
@@ -83,18 +98,20 @@ def sync(
 
     Returns:
         GetSitesResponseGetSites
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-    ).parsed
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+
 ) -> Response[GetSitesResponseGetSites]:
-    """List site routes
+    """ List site routes
 
      Read site routes during reconciliation.
 
@@ -104,20 +121,25 @@ async def asyncio_detailed(
 
     Returns:
         Response[GetSitesResponseGetSites]
-    """
+     """
 
-    kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    kwargs = _get_kwargs(
+        
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient,
+
 ) -> GetSitesResponseGetSites | None:
-    """List site routes
+    """ List site routes
 
      Read site routes during reconciliation.
 
@@ -127,10 +149,10 @@ async def asyncio(
 
     Returns:
         GetSitesResponseGetSites
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/patch_site.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/patch_site.py
@@ -1,29 +1,36 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.address_update import AddressUpdate
 from ...models.http_validation_error import HTTPValidationError
 from ...models.site_mapping import SiteMapping
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     name: str,
     *,
     body: AddressUpdate,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/v1/sites/{name}".format(
-            name=quote(str(name), safe=""),
-        ),
+        "url": "/v1/sites/{name}".format(name=quote(str(name), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -34,16 +41,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SiteMapping | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> HTTPValidationError | SiteMapping | None:
     if response.status_code == 200:
         response_200 = SiteMapping.from_dict(response.json())
+
+
 
         return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -53,9 +63,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SiteMapping]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[HTTPValidationError | SiteMapping]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,8 +77,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> Response[HTTPValidationError | SiteMapping]:
-    """Update site route
+    """ Update site route
 
      Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
 
@@ -84,11 +93,13 @@ def sync_detailed(
 
     Returns:
         Response[HTTPValidationError | SiteMapping]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         name=name,
-        body=body,
+body=body,
+
     )
 
     response = client.get_httpx_client().request(
@@ -97,14 +108,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     name: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> HTTPValidationError | SiteMapping | None:
-    """Update site route
+    """ Update site route
 
      Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
 
@@ -118,22 +129,24 @@ def sync(
 
     Returns:
         HTTPValidationError | SiteMapping
-    """
+     """
+
 
     return sync_detailed(
         name=name,
-        client=client,
-        body=body,
-    ).parsed
+client=client,
+body=body,
 
+    ).parsed
 
 async def asyncio_detailed(
     name: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> Response[HTTPValidationError | SiteMapping]:
-    """Update site route
+    """ Update site route
 
      Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
 
@@ -147,25 +160,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[HTTPValidationError | SiteMapping]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         name=name,
-        body=body,
+body=body,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     name: str,
     *,
     client: AuthenticatedClient,
     body: AddressUpdate,
+
 ) -> HTTPValidationError | SiteMapping | None:
-    """Update site route
+    """ Update site route
 
      Add or change one site route without changing other sites. Example: route `erp` to `2001:db8::10`.
 
@@ -179,12 +196,12 @@ async def asyncio(
 
     Returns:
         HTTPValidationError | SiteMapping
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            name=name,
-            client=client,
-            body=body,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        name=name,
+client=client,
+body=body,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/api/sites/replace_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/api/sites/replace_sites.py
@@ -1,21 +1,31 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.http_validation_error import HTTPValidationError
 from ...models.map_replaced import MapReplaced
 from ...models.replace_sites_values import ReplaceSitesValues
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     *,
     body: ReplaceSitesValues,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "put",
@@ -30,16 +40,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | MapReplaced | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> HTTPValidationError | MapReplaced | None:
     if response.status_code == 200:
         response_200 = MapReplaced.from_dict(response.json())
+
+
 
         return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
+
+
 
         return response_422
 
@@ -49,9 +62,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | MapReplaced]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[HTTPValidationError | MapReplaced]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +75,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ReplaceSitesValues,
+
 ) -> Response[HTTPValidationError | MapReplaced]:
-    """Sync site routes
+    """ Sync site routes
 
      Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
     `2001:db8::10`.
@@ -79,10 +91,12 @@ def sync_detailed(
 
     Returns:
         Response[HTTPValidationError | MapReplaced]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
+
     )
 
     response = client.get_httpx_client().request(
@@ -91,13 +105,13 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient,
     body: ReplaceSitesValues,
+
 ) -> HTTPValidationError | MapReplaced | None:
-    """Sync site routes
+    """ Sync site routes
 
      Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
     `2001:db8::10`.
@@ -111,20 +125,22 @@ def sync(
 
     Returns:
         HTTPValidationError | MapReplaced
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        body=body,
-    ).parsed
+body=body,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ReplaceSitesValues,
+
 ) -> Response[HTTPValidationError | MapReplaced]:
-    """Sync site routes
+    """ Sync site routes
 
      Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
     `2001:db8::10`.
@@ -138,23 +154,27 @@ async def asyncio_detailed(
 
     Returns:
         Response[HTTPValidationError | MapReplaced]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ReplaceSitesValues,
+
 ) -> HTTPValidationError | MapReplaced | None:
-    """Sync site routes
+    """ Sync site routes
 
      Replace every site route after a controller restart or full reconciliation. Example: `erp` routes to
     `2001:db8::10`.
@@ -168,11 +188,11 @@ async def asyncio(
 
     Returns:
         HTTPValidationError | MapReplaced
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+
+    )).parsed

--- a/clients/atlas-http-proxy/atlas_http_proxy/client.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/client.py
@@ -1,8 +1,11 @@
 import ssl
 from typing import Any, Self
 
+from attrs import define, field, evolve
 import httpx
-from attrs import define, evolve, field
+
+
+
 
 
 @define
@@ -33,7 +36,6 @@ class Client:
             status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
             argument to the constructor.
     """
-
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
@@ -266,3 +268,4 @@ class AuthenticatedClient:
     async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+

--- a/clients/atlas-http-proxy/atlas_http_proxy/errors.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/errors.py
@@ -1,5 +1,4 @@
-"""Contains shared errors types that can be raised from API functions"""
-
+""" Contains shared errors types that can be raised from API functions """
 
 class UnexpectedStatus(Exception):
     """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
@@ -11,6 +10,5 @@ class UnexpectedStatus(Exception):
         super().__init__(
             f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
         )
-
 
 __all__ = ["UnexpectedStatus"]

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/__init__.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/__init__.py
@@ -1,4 +1,4 @@
-"""Contains all the data models used in inputs/outputs"""
+""" Contains all the data models used in inputs/outputs """
 
 from .address_update import AddressUpdate
 from .cluster_status_response_cluster_status import ClusterStatusResponseClusterStatus

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/address_update.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/address_update.py
@@ -1,35 +1,50 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
 
 T = TypeVar("T", bound="AddressUpdate")
 
 
+
 @_attrs_define
 class AddressUpdate:
-    """One address for one site or custom domain.
+    """ One address for one site or custom domain.
 
-    Attributes:
-        address (str): The backend IPv6 address. Use `-` only for a site to stop its traffic.
-    """
+        Attributes:
+            address (str): The backend IPv6 address. Use `-` only for a site to stop its traffic.
+     """
 
     address: str
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         address = self.address
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "address": address,
-            }
-        )
+        field_dict.update({
+            "address": address,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -41,3 +56,4 @@ class AddressUpdate:
         )
 
         return address_update
+

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/cluster_status_response_cluster_status.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/cluster_status_response_cluster_status.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="ClusterStatusResponseClusterStatus")
+
 
 
 @_attrs_define
 class ClusterStatusResponseClusterStatus:
+    
+
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        cluster_status_response_cluster_status = cls()
+        cluster_status_response_cluster_status = cls(
+        )
+
 
         cluster_status_response_cluster_status.additional_properties = d
         return cluster_status_response_cluster_status

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/domain_mapping.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/domain_mapping.py
@@ -1,42 +1,56 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="DomainMapping")
+
 
 
 @_attrs_define
 class DomainMapping:
-    """One custom domain as the proxy stored it.
+    """ One custom domain as the proxy stored it.
 
-    Attributes:
-        address (str): The backend IPv6 address.
-        domain (str): The custom domain.
-    """
+        Attributes:
+            address (str): The backend IPv6 address.
+            domain (str): The custom domain.
+     """
 
     address: str
     domain: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         address = self.address
 
         domain = self.domain
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "address": address,
-                "domain": domain,
-            }
-        )
+        field_dict.update({
+            "address": address,
+            "domain": domain,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -49,6 +63,7 @@ class DomainMapping:
             address=address,
             domain=domain,
         )
+
 
         domain_mapping.additional_properties = d
         return domain_mapping

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/get_domains_response_get_domains.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/get_domains_response_get_domains.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="GetDomainsResponseGetDomains")
+
 
 
 @_attrs_define
 class GetDomainsResponseGetDomains:
+    
+
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        get_domains_response_get_domains = cls()
+        get_domains_response_get_domains = cls(
+        )
+
 
         get_domains_response_get_domains.additional_properties = d
         return get_domains_response_get_domains

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/get_sites_response_get_sites.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/get_sites_response_get_sites.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="GetSitesResponseGetSites")
+
 
 
 @_attrs_define
 class GetSitesResponseGetSites:
+    
+
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        get_sites_response_get_sites = cls()
+        get_sites_response_get_sites = cls(
+        )
+
 
         get_sites_response_get_sites.additional_properties = d
         return get_sites_response_get_sites

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/http_validation_error.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/http_validation_error.py
@@ -1,31 +1,43 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..types import UNSET, Unset
+from typing import cast
+
 if TYPE_CHECKING:
-    from ..models.validation_error import ValidationError
+  from ..models.validation_error import ValidationError
+
+
+
 
 
 T = TypeVar("T", bound="HTTPValidationError")
 
 
+
 @_attrs_define
 class HTTPValidationError:
-    """
-    Attributes:
-        detail (list[ValidationError] | Unset):
-    """
+    """ 
+        Attributes:
+            detail (list[ValidationError] | Unset):
+     """
 
     detail: list[ValidationError] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.validation_error import ValidationError # noqa: PLC0415
         detail: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.detail, Unset):
             detail = []
@@ -33,18 +45,23 @@ class HTTPValidationError:
                 detail_item = detail_item_data.to_dict()
                 detail.append(detail_item)
 
+
+
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update({})
+        field_dict.update({
+        })
         if detail is not UNSET:
             field_dict["detail"] = detail
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.validation_error import ValidationError  # noqa: PLC0415
-
+        from ..models.validation_error import ValidationError # noqa: PLC0415
         d = dict(src_dict)
         _detail = d.pop("detail", UNSET)
         detail: list[ValidationError] | Unset = UNSET
@@ -53,11 +70,15 @@ class HTTPValidationError:
             for detail_item_data in _detail:
                 detail_item = ValidationError.from_dict(detail_item_data)
 
+
+
                 detail.append(detail_item)
+
 
         http_validation_error = cls(
             detail=detail,
         )
+
 
         http_validation_error.additional_properties = d
         return http_validation_error

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/map_replaced.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/map_replaced.py
@@ -1,42 +1,56 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="MapReplaced")
+
 
 
 @_attrs_define
 class MapReplaced:
-    """Result of a full map replacement.
+    """ Result of a full map replacement.
 
-    Attributes:
-        entries (int): Number of entries in the replacement map.
-        synced (bool): Whether the complete map was applied.
-    """
+        Attributes:
+            entries (int): Number of entries in the replacement map.
+            synced (bool): Whether the complete map was applied.
+     """
 
     entries: int
     synced: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         entries = self.entries
 
         synced = self.synced
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "entries": entries,
-                "synced": synced,
-            }
-        )
+        field_dict.update({
+            "entries": entries,
+            "synced": synced,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -49,6 +63,7 @@ class MapReplaced:
             entries=entries,
             synced=synced,
         )
+
 
         map_replaced.additional_properties = d
         return map_replaced

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/replace_domains_values.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/replace_domains_values.py
@@ -1,31 +1,50 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="ReplaceDomainsValues")
+
 
 
 @_attrs_define
 class ReplaceDomainsValues:
-    """The complete desired custom-domain map."""
+    """ The complete desired custom-domain map.
+
+     """
 
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        replace_domains_values = cls()
+        replace_domains_values = cls(
+        )
+
 
         replace_domains_values.additional_properties = d
         return replace_domains_values

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/replace_sites_values.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/replace_sites_values.py
@@ -1,31 +1,50 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="ReplaceSitesValues")
+
 
 
 @_attrs_define
 class ReplaceSitesValues:
-    """The complete desired site map."""
+    """ The complete desired site map.
+
+     """
 
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        replace_sites_values = cls()
+        replace_sites_values = cls(
+        )
+
 
         replace_sites_values.additional_properties = d
         return replace_sites_values

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/site_mapping.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/site_mapping.py
@@ -1,42 +1,56 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="SiteMapping")
+
 
 
 @_attrs_define
 class SiteMapping:
-    """One site as the proxy stored it.
+    """ One site as the proxy stored it.
 
-    Attributes:
-        address (str): The backend IPv6 address.
-        site (str): The site subdomain.
-    """
+        Attributes:
+            address (str): The backend IPv6 address.
+            site (str): The site subdomain.
+     """
 
     address: str
     site: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         address = self.address
 
         site = self.site
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "address": address,
-                "site": site,
-            }
-        )
+        field_dict.update({
+            "address": address,
+            "site": site,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -49,6 +63,7 @@ class SiteMapping:
             address=address,
             site=site,
         )
+
 
         site_mapping.additional_properties = d
         return site_mapping

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error.py
@@ -1,30 +1,37 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..types import UNSET, Unset
+from typing import cast
+
 if TYPE_CHECKING:
-    from ..models.validation_error_context import ValidationErrorContext
+  from ..models.validation_error_context import ValidationErrorContext
+
+
+
 
 
 T = TypeVar("T", bound="ValidationError")
 
 
+
 @_attrs_define
 class ValidationError:
-    """
-    Attributes:
-        loc (list[int | str]):
-        msg (str):
-        type_ (str):
-        ctx (ValidationErrorContext | Unset):
-        input_ (Any | Unset):
-    """
+    """ 
+        Attributes:
+            loc (list[int | str]):
+            msg (str):
+            type_ (str):
+            ctx (ValidationErrorContext | Unset):
+            input_ (Any | Unset):
+     """
 
     loc: list[int | str]
     msg: str
@@ -33,12 +40,19 @@ class ValidationError:
     input_: Any | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.validation_error_context import ValidationErrorContext # noqa: PLC0415
         loc = []
         for loc_item_data in self.loc:
             loc_item: int | str
             loc_item = loc_item_data
             loc.append(loc_item)
+
+
 
         msg = self.msg
 
@@ -50,15 +64,14 @@ class ValidationError:
 
         input_ = self.input_
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "loc": loc,
-                "msg": msg,
-                "type": type_,
-            }
-        )
+        field_dict.update({
+            "loc": loc,
+            "msg": msg,
+            "type": type_,
+        })
         if ctx is not UNSET:
             field_dict["ctx"] = ctx
         if input_ is not UNSET:
@@ -66,15 +79,15 @@ class ValidationError:
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.validation_error_context import ValidationErrorContext  # noqa: PLC0415
-
+        from ..models.validation_error_context import ValidationErrorContext # noqa: PLC0415
         d = dict(src_dict)
         loc = []
         _loc = d.pop("loc")
-        for loc_item_data in _loc:
-
+        for loc_item_data in (_loc):
             def _parse_loc_item(data: object) -> int | str:
                 return cast(int | str, data)
 
@@ -82,16 +95,20 @@ class ValidationError:
 
             loc.append(loc_item)
 
+
         msg = d.pop("msg")
 
         type_ = d.pop("type")
 
         _ctx = d.pop("ctx", UNSET)
         ctx: ValidationErrorContext | Unset
-        if isinstance(_ctx, Unset):
+        if isinstance(_ctx,  Unset):
             ctx = UNSET
         else:
             ctx = ValidationErrorContext.from_dict(_ctx)
+
+
+
 
         input_ = d.pop("input", UNSET)
 
@@ -102,6 +119,7 @@ class ValidationError:
             ctx=ctx,
             input_=input_,
         )
+
 
         validation_error.additional_properties = d
         return validation_error

--- a/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error_context.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/models/validation_error_context.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="ValidationErrorContext")
+
 
 
 @_attrs_define
 class ValidationErrorContext:
+    
+
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        validation_error_context = cls()
+        validation_error_context = cls(
+        )
+
 
         validation_error_context.additional_properties = d
         return validation_error_context

--- a/clients/atlas-http-proxy/atlas_http_proxy/types.py
+++ b/clients/atlas-http-proxy/atlas_http_proxy/types.py
@@ -1,8 +1,8 @@
-"""Contains some shared types for properties"""
+""" Contains some shared types for properties """
 
 from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import IO, BinaryIO, Generic, Literal, TypeVar
+from typing import BinaryIO, Generic, TypeVar, Literal, IO
 
 from attrs import define
 
@@ -24,17 +24,16 @@ FileTypes = (
 )
 RequestFiles = list[tuple[str, FileTypes]]
 
-
 @define
 class File:
-    """Contains information for file uploads"""
+    """ Contains information for file uploads """
 
     payload: BinaryIO
     file_name: str | None = None
     mime_type: str | None = None
 
     def to_tuple(self) -> FileTypes:
-        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        """ Return a tuple representation that httpx will accept for multipart/form-data """
         return self.file_name, self.payload, self.mime_type
 
 
@@ -43,7 +42,7 @@ T = TypeVar("T")
 
 @define
 class Response(Generic[T]):
-    """A response from an endpoint"""
+    """ A response from an endpoint """
 
     status_code: HTTPStatus
     content: bytes

--- a/clients/atlas/README.md
+++ b/clients/atlas/README.md
@@ -56,7 +56,11 @@ client = AuthenticatedClient(
 You can also disable certificate validation altogether, but beware that **this is a security risk**.
 
 ```python
-client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
 ```
 
 Things to know:
@@ -77,15 +81,12 @@ There are more settings on the generated `Client` class which let you control mo
 ```python
 from atlas import Client
 
-
 def log_request(request):
     print(f"Request event hook: {request.method} {request.url} - Waiting for response")
-
 
 def log_response(response):
     request = response.request
     print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
-
 
 client = Client(
     base_url="https://api.example.com",

--- a/clients/atlas/atlas/__init__.py
+++ b/clients/atlas/atlas/__init__.py
@@ -1,5 +1,5 @@
-"""A client library for accessing Atlas API"""
 
+""" A client library for accessing Atlas API """
 from .client import AuthenticatedClient, Client
 
 __all__ = (

--- a/clients/atlas/atlas/api/__init__.py
+++ b/clients/atlas/atlas/api/__init__.py
@@ -1,1 +1,1 @@
-"""Contains methods for accessing the API"""
+""" Contains methods for accessing the API """

--- a/clients/atlas/atlas/api/images/__init__.py
+++ b/clients/atlas/atlas/api/images/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas/atlas/api/images/delete_image.py
+++ b/clients/atlas/atlas/api/images/delete_image.py
@@ -4,34 +4,47 @@ from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.image_response import ImageResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     image_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/api/atlas/images/{image_id}".format(
-            image_id=quote(str(image_id), safe=""),
-        ),
+        "url": "/api/atlas/images/{image_id}".format(image_id=quote(str(image_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | ImageResponse | None:
     if response.status_code == 202:
         response_202 = ImageResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -59,8 +72,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[Any | ImageResponse]:
-    """Delete image
+    """ Delete image
 
      Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
     remaining host snapshot data.
@@ -75,11 +89,13 @@ def sync_detailed(
 
     Returns:
         Response[Any | ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -88,14 +104,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Any | ImageResponse | None:
-    """Delete image
+    """ Delete image
 
      Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
     remaining host snapshot data.
@@ -110,22 +126,24 @@ def sync(
 
     Returns:
         Any | ImageResponse
-    """
+     """
+
 
     return sync_detailed(
         image_id=image_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[Any | ImageResponse]:
-    """Delete image
+    """ Delete image
 
      Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
     remaining host snapshot data.
@@ -140,25 +158,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any | ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Any | ImageResponse | None:
-    """Delete image
+    """ Delete image
 
      Starts deletion of an unused Available Machine image. A cleanup job removes its stored artifacts and
     remaining host snapshot data.
@@ -173,12 +195,12 @@ async def asyncio(
 
     Returns:
         Any | ImageResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            image_id=image_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        image_id=image_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/images/download_image.py
+++ b/clients/atlas/atlas/api/images/download_image.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.download_image_artifact import DownloadImageArtifact
 from ...models.image_download_response import ImageDownloadResponse
-from ...types import UNSET, Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,32 +19,42 @@ def _get_kwargs(
     *,
     artifact: DownloadImageArtifact,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
 
     params: dict[str, Any] = {}
 
     json_artifact = artifact.value
     params["artifact"] = json_artifact
 
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/atlas/images/{image_id}/download".format(
-            image_id=quote(str(image_id), safe=""),
-        ),
+        "url": "/api/atlas/images/{image_id}/download".format(image_id=quote(str(image_id), safe=""),),
         "params": params,
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageDownloadResponse | None:
     if response.status_code == 200:
         response_200 = ImageDownloadResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -51,9 +64,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ImageDownloadResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ImageDownloadResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,8 +79,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     artifact: DownloadImageArtifact,
     x_tenant_id: int,
+
 ) -> Response[ImageDownloadResponse]:
-    """Download image
+    """ Download image
 
      Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
     size, SHA-256 value, and expiry time and cannot be cached.
@@ -85,12 +97,14 @@ def sync_detailed(
 
     Returns:
         Response[ImageDownloadResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        artifact=artifact,
-        x_tenant_id=x_tenant_id,
+artifact=artifact,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -99,15 +113,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     artifact: DownloadImageArtifact,
     x_tenant_id: int,
+
 ) -> ImageDownloadResponse | None:
-    """Download image
+    """ Download image
 
      Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
     size, SHA-256 value, and expiry time and cannot be cached.
@@ -123,15 +137,16 @@ def sync(
 
     Returns:
         ImageDownloadResponse
-    """
+     """
+
 
     return sync_detailed(
         image_id=image_id,
-        client=client,
-        artifact=artifact,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+artifact=artifact,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     image_id: str,
@@ -139,8 +154,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     artifact: DownloadImageArtifact,
     x_tenant_id: int,
+
 ) -> Response[ImageDownloadResponse]:
-    """Download image
+    """ Download image
 
      Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
     size, SHA-256 value, and expiry time and cannot be cached.
@@ -156,18 +172,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[ImageDownloadResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        artifact=artifact,
-        x_tenant_id=x_tenant_id,
+artifact=artifact,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     image_id: str,
@@ -175,8 +194,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     artifact: DownloadImageArtifact,
     x_tenant_id: int,
+
 ) -> ImageDownloadResponse | None:
-    """Download image
+    """ Download image
 
      Returns a signed download URL for the selected rootfs or kernel artifact. The response includes its
     size, SHA-256 value, and expiry time and cannot be cached.
@@ -192,13 +212,13 @@ async def asyncio(
 
     Returns:
         ImageDownloadResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            image_id=image_id,
-            client=client,
-            artifact=artifact,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        image_id=image_id,
+client=client,
+artifact=artifact,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/images/get_image.py
+++ b/clients/atlas/atlas/api/images/get_image.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.image_response import ImageResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     image_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/atlas/images/{image_id}".format(
-            image_id=quote(str(image_id), safe=""),
-        ),
+        "url": "/api/atlas/images/{image_id}".format(image_id=quote(str(image_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageResponse | None:
     if response.status_code == 200:
         response_200 = ImageResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -55,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[ImageResponse]:
-    """Get image
+    """ Get image
 
      Returns one tenant image with its artifact metadata and transfer state.
 
@@ -70,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -83,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> ImageResponse | None:
-    """Get image
+    """ Get image
 
      Returns one tenant image with its artifact metadata and transfer state.
 
@@ -104,22 +120,24 @@ def sync(
 
     Returns:
         ImageResponse
-    """
+     """
+
 
     return sync_detailed(
         image_id=image_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[ImageResponse]:
-    """Get image
+    """ Get image
 
      Returns one tenant image with its artifact metadata and transfer state.
 
@@ -133,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         image_id=image_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     image_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> ImageResponse | None:
-    """Get image
+    """ Get image
 
      Returns one tenant image with its artifact metadata and transfer state.
 
@@ -165,12 +187,12 @@ async def asyncio(
 
     Returns:
         ImageResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            image_id=image_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        image_id=image_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/images/list_images.py
+++ b/clients/atlas/atlas/api/images/list_images.py
@@ -1,12 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.page_image_response import PageImageResponse
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Unset
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -14,9 +19,15 @@ def _get_kwargs(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
 
     params: dict[str, Any] = {}
 
@@ -24,7 +35,9 @@ def _get_kwargs(
 
     params["limit"] = limit
 
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -32,13 +45,17 @@ def _get_kwargs(
         "params": params,
     }
 
+
     _kwargs["headers"] = headers
     return _kwargs
+
 
 
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> PageImageResponse | None:
     if response.status_code == 200:
         response_200 = PageImageResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -63,8 +80,9 @@ def sync_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageImageResponse]:
-    """List images
+    """ List images
 
      Returns one page of System and Machine images owned by the tenant in newest-first order.
 
@@ -79,12 +97,14 @@ def sync_detailed(
 
     Returns:
         Response[PageImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -93,15 +113,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageImageResponse | None:
-    """List images
+    """ List images
 
      Returns one page of System and Machine images owned by the tenant in newest-first order.
 
@@ -116,15 +136,16 @@ def sync(
 
     Returns:
         PageImageResponse
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
@@ -132,8 +153,9 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageImageResponse]:
-    """List images
+    """ List images
 
      Returns one page of System and Machine images owned by the tenant in newest-first order.
 
@@ -148,18 +170,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[PageImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
@@ -167,8 +192,9 @@ async def asyncio(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageImageResponse | None:
-    """List images
+    """ List images
 
      Returns one page of System and Machine images owned by the tenant in newest-first order.
 
@@ -183,13 +209,13 @@ async def asyncio(
 
     Returns:
         PageImageResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            offset=offset,
-            limit=limit,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/ip_addresses/__init__.py
+++ b/clients/atlas/atlas/api/ip_addresses/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas/atlas/api/ip_addresses/get_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/get_ip_address.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.ip_address_response import IPAddressResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     ip_address_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(
-            ip_address_id=quote(str(ip_address_id), safe=""),
-        ),
+        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(ip_address_id=quote(str(ip_address_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> IPAddressResponse | None:
     if response.status_code == 200:
         response_200 = IPAddressResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -55,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[IPAddressResponse]:
-    """Get IP address
+    """ Get IP address
 
      Returns one tenant IP address with its attachment state and VM assignment.
 
@@ -70,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[IPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         ip_address_id=ip_address_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -83,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     ip_address_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> IPAddressResponse | None:
-    """Get IP address
+    """ Get IP address
 
      Returns one tenant IP address with its attachment state and VM assignment.
 
@@ -104,22 +120,24 @@ def sync(
 
     Returns:
         IPAddressResponse
-    """
+     """
+
 
     return sync_detailed(
         ip_address_id=ip_address_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     ip_address_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[IPAddressResponse]:
-    """Get IP address
+    """ Get IP address
 
      Returns one tenant IP address with its attachment state and VM assignment.
 
@@ -133,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[IPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         ip_address_id=ip_address_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     ip_address_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> IPAddressResponse | None:
-    """Get IP address
+    """ Get IP address
 
      Returns one tenant IP address with its attachment state and VM assignment.
 
@@ -165,12 +187,12 @@ async def asyncio(
 
     Returns:
         IPAddressResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            ip_address_id=ip_address_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        ip_address_id=ip_address_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/ip_addresses/list_ip_addresses.py
+++ b/clients/atlas/atlas/api/ip_addresses/list_ip_addresses.py
@@ -1,12 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.page_ip_address_response import PageIPAddressResponse
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Unset
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -14,9 +19,15 @@ def _get_kwargs(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
 
     params: dict[str, Any] = {}
 
@@ -24,7 +35,9 @@ def _get_kwargs(
 
     params["limit"] = limit
 
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -32,13 +45,17 @@ def _get_kwargs(
         "params": params,
     }
 
+
     _kwargs["headers"] = headers
     return _kwargs
+
 
 
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> PageIPAddressResponse | None:
     if response.status_code == 200:
         response_200 = PageIPAddressResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -48,9 +65,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[PageIPAddressResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[PageIPAddressResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,8 +80,9 @@ def sync_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageIPAddressResponse]:
-    """List IP addresses
+    """ List IP addresses
 
      Returns one page of IP addresses reserved by the tenant in newest-first order.
 
@@ -81,12 +97,14 @@ def sync_detailed(
 
     Returns:
         Response[PageIPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +113,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageIPAddressResponse | None:
-    """List IP addresses
+    """ List IP addresses
 
      Returns one page of IP addresses reserved by the tenant in newest-first order.
 
@@ -118,15 +136,16 @@ def sync(
 
     Returns:
         PageIPAddressResponse
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
@@ -134,8 +153,9 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageIPAddressResponse]:
-    """List IP addresses
+    """ List IP addresses
 
      Returns one page of IP addresses reserved by the tenant in newest-first order.
 
@@ -150,18 +170,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[PageIPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
@@ -169,8 +192,9 @@ async def asyncio(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageIPAddressResponse | None:
-    """List IP addresses
+    """ List IP addresses
 
      Returns one page of IP addresses reserved by the tenant in newest-first order.
 
@@ -185,13 +209,13 @@ async def asyncio(
 
     Returns:
         PageIPAddressResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            offset=offset,
-            limit=limit,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/ip_addresses/release_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/release_ip_address.py
@@ -1,31 +1,41 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
+from ... import errors
+
+
 
 
 def _get_kwargs(
     ip_address_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(
-            ip_address_id=quote(str(ip_address_id), safe=""),
-        ),
+        "url": "/api/atlas/ip-addresses/{ip_address_id}".format(ip_address_id=quote(str(ip_address_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
+
 
 
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | None:
@@ -55,8 +65,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[Any]:
-    """Release IP address
+    """ Release IP address
 
      Returns an unattached address to the shared pool and keeps its provider reservation. An attached or
     detaching address cannot be released.
@@ -71,11 +82,13 @@ def sync_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         ip_address_id=ip_address_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -90,8 +103,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[Any]:
-    """Release IP address
+    """ Release IP address
 
      Returns an unattached address to the shared pool and keeps its provider reservation. An attached or
     detaching address cannot be released.
@@ -106,13 +120,18 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         ip_address_id=ip_address_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
+

--- a/clients/atlas/atlas/api/ip_addresses/reserve_ip_address.py
+++ b/clients/atlas/atlas/api/ip_addresses/reserve_ip_address.py
@@ -1,22 +1,34 @@
 from http import HTTPStatus
 from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.ip_address_response import IPAddressResponse
 from ...models.reserve_ip_address_payload import ReserveIPAddressPayload
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     *,
     body: ReserveIPAddressPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -31,11 +43,12 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | IPAddressResponse | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Any | IPAddressResponse | None:
     if response.status_code == 201:
         response_201 = IPAddressResponse.from_dict(response.json())
+
+
 
         return response_201
 
@@ -49,9 +62,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | IPAddressResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any | IPAddressResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,8 +76,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: ReserveIPAddressPayload,
     x_tenant_id: int,
+
 ) -> Response[Any | IPAddressResponse]:
-    """Reserve IP address
+    """ Reserve IP address
 
      Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
     provider source creates a provider reservation.
@@ -81,11 +93,13 @@ def sync_detailed(
 
     Returns:
         Response[Any | IPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -94,14 +108,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient | Client,
     body: ReserveIPAddressPayload,
     x_tenant_id: int,
+
 ) -> Any | IPAddressResponse | None:
-    """Reserve IP address
+    """ Reserve IP address
 
      Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
     provider source creates a provider reservation.
@@ -116,22 +130,24 @@ def sync(
 
     Returns:
         Any | IPAddressResponse
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: ReserveIPAddressPayload,
     x_tenant_id: int,
+
 ) -> Response[Any | IPAddressResponse]:
-    """Reserve IP address
+    """ Reserve IP address
 
      Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
     provider source creates a provider reservation.
@@ -146,25 +162,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[Any | IPAddressResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: ReserveIPAddressPayload,
     x_tenant_id: int,
+
 ) -> Any | IPAddressResponse | None:
-    """Reserve IP address
+    """ Reserve IP address
 
      Reserves an IP address for the tenant. The pool source claims an unowned Atlas address, and the
     provider source creates a provider reservation.
@@ -179,12 +199,12 @@ async def asyncio(
 
     Returns:
         Any | IPAddressResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/__init__.py
+++ b/clients/atlas/atlas/api/vm_actions/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas/atlas/api/vm_actions/create_virtual_machine_console_token.py
+++ b/clients/atlas/atlas/api/vm_actions/create_virtual_machine_console_token.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.console_token_payload import ConsoleTokenPayload
 from ...models.console_token_response import ConsoleTokenResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: ConsoleTokenPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/console-token".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/console-token".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ConsoleTokenResponse | None:
     if response.status_code == 200:
         response_200 = ConsoleTokenResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[ConsoleTokenResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[ConsoleTokenResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: ConsoleTokenPayload,
     x_tenant_id: int,
+
 ) -> Response[ConsoleTokenResponse]:
-    """Create console token
+    """ Create console token
 
      Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
     seconds.
@@ -81,12 +92,14 @@ def sync_detailed(
 
     Returns:
         Response[ConsoleTokenResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +108,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: ConsoleTokenPayload,
     x_tenant_id: int,
+
 ) -> ConsoleTokenResponse | None:
-    """Create console token
+    """ Create console token
 
      Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
     seconds.
@@ -119,15 +132,16 @@ def sync(
 
     Returns:
         ConsoleTokenResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +149,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: ConsoleTokenPayload,
     x_tenant_id: int,
+
 ) -> Response[ConsoleTokenResponse]:
-    """Create console token
+    """ Create console token
 
      Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
     seconds.
@@ -152,18 +167,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[ConsoleTokenResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -171,8 +189,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: ConsoleTokenPayload,
     x_tenant_id: int,
+
 ) -> ConsoleTokenResponse | None:
-    """Create console token
+    """ Create console token
 
      Returns a single-use token for the Atlas realtime TTY or SSH console. The token expires after 60
     seconds.
@@ -188,13 +207,13 @@ async def asyncio(
 
     Returns:
         ConsoleTokenResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/create_virtual_machine_snapshot.py
+++ b/clients/atlas/atlas/api/vm_actions/create_virtual_machine_snapshot.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.image_response import ImageResponse
 from ...models.snapshot_payload import SnapshotPayload
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: SnapshotPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/snapshot".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/snapshot".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> ImageResponse | None:
     if response.status_code == 201:
         response_201 = ImageResponse.from_dict(response.json())
+
+
 
         return response_201
 
@@ -62,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: SnapshotPayload,
     x_tenant_id: int,
+
 ) -> Response[ImageResponse]:
-    """Create snapshot
+    """ Create snapshot
 
      Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
 
@@ -80,12 +93,14 @@ def sync_detailed(
 
     Returns:
         Response[ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -94,15 +109,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: SnapshotPayload,
     x_tenant_id: int,
+
 ) -> ImageResponse | None:
-    """Create snapshot
+    """ Create snapshot
 
      Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
 
@@ -119,15 +134,16 @@ def sync(
 
     Returns:
         ImageResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +151,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: SnapshotPayload,
     x_tenant_id: int,
+
 ) -> Response[ImageResponse]:
-    """Create snapshot
+    """ Create snapshot
 
      Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
 
@@ -153,18 +170,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[ImageResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -172,8 +192,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: SnapshotPayload,
     x_tenant_id: int,
+
 ) -> ImageResponse | None:
-    """Create snapshot
+    """ Create snapshot
 
      Creates a reusable Machine image from the current VM disk. The new image belongs to the same tenant.
 
@@ -190,13 +211,13 @@ async def asyncio(
 
     Returns:
         ImageResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/pause_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/pause_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/pause".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/pause".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Pause VM
+    """ Pause VM
 
      Pauses the VM without stopping it. Poll the VM route to observe completion.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Pause VM
+    """ Pause VM
 
      Pauses the VM without stopping it. Poll the VM route to observe completion.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Pause VM
+    """ Pause VM
 
      Pauses the VM without stopping it. Poll the VM route to observe completion.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Pause VM
+    """ Pause VM
 
      Pauses the VM without stopping it. Poll the VM route to observe completion.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/restart_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/restart_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/restart".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/restart".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Restart VM
+    """ Restart VM
 
      Requests an in-place restart. Poll the VM route to observe completion.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Restart VM
+    """ Restart VM
 
      Requests an in-place restart. Poll the VM route to observe completion.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Restart VM
+    """ Restart VM
 
      Requests an in-place restart. Poll the VM route to observe completion.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Restart VM
+    """ Restart VM
 
      Requests an in-place restart. Poll the VM route to observe completion.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/resume_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/resume_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/resume".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/resume".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resume VM
+    """ Resume VM
 
      Returns a paused VM to the running state. Poll the VM route to observe completion.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resume VM
+    """ Resume VM
 
      Returns a paused VM to the running state. Poll the VM route to observe completion.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resume VM
+    """ Resume VM
 
      Returns a paused VM to the running state. Poll the VM route to observe completion.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resume VM
+    """ Resume VM
 
      Returns a paused VM to the running state. Poll the VM route to observe completion.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/start_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/start_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/start".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/start".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Start VM
+    """ Start VM
 
      Requests the running state. Poll the VM route to observe completion.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Start VM
+    """ Start VM
 
      Requests the running state. Poll the VM route to observe completion.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Start VM
+    """ Start VM
 
      Requests the running state. Poll the VM route to observe completion.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Start VM
+    """ Start VM
 
      Requests the running state. Poll the VM route to observe completion.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_actions/stop_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_actions/stop_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/stop".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/actions/stop".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Stop VM
+    """ Stop VM
 
      Requests the stopped state. Poll the VM route to observe completion.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Stop VM
+    """ Stop VM
 
      Requests the stopped state. Poll the VM route to observe completion.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Stop VM
+    """ Stop VM
 
      Requests the stopped state. Poll the VM route to observe completion.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Stop VM
+    """ Stop VM
 
      Requests the stopped state. Poll the VM route to observe completion.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/__init__.py
+++ b/clients/atlas/atlas/api/vm_configuration/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas/atlas/api/vm_configuration/attach_virtual_machine_ip_address.py
+++ b/clients/atlas/atlas/api/vm_configuration/attach_virtual_machine_ip_address.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.ip_address_assignment_payload import IPAddressAssignmentPayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: IPAddressAssignmentPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "put",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: IPAddressAssignmentPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Attach IP address
+    """ Attach IP address
 
      Attaches one available IP address that the tenant reserved. Detach the current address before you
     attach a different one.
@@ -81,12 +92,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +108,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: IPAddressAssignmentPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Attach IP address
+    """ Attach IP address
 
      Attaches one available IP address that the tenant reserved. Detach the current address before you
     attach a different one.
@@ -119,15 +132,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +149,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: IPAddressAssignmentPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Attach IP address
+    """ Attach IP address
 
      Attaches one available IP address that the tenant reserved. Detach the current address before you
     attach a different one.
@@ -152,18 +167,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -171,8 +189,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: IPAddressAssignmentPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Attach IP address
+    """ Attach IP address
 
      Attaches one available IP address that the tenant reserved. Detach the current address before you
     attach a different one.
@@ -188,13 +207,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/detach_virtual_machine_ip_address.py
+++ b/clients/atlas/atlas/api/vm_configuration/detach_virtual_machine_ip_address.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ip-address".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Detach IP address
+    """ Detach IP address
 
      Detaches the public IP address from the VM and keeps its tenant reservation.
 
@@ -72,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -85,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Detach IP address
+    """ Detach IP address
 
      Detaches the public IP address from the VM and keeps its tenant reservation.
 
@@ -106,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Detach IP address
+    """ Detach IP address
 
      Detaches the public IP address from the VM and keeps its tenant reservation.
 
@@ -135,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Detach IP address
+    """ Detach IP address
 
      Detaches the public IP address from the VM and keeps its tenant reservation.
 
@@ -167,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_metadata.py
+++ b/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_metadata.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.metadata_replacement_payload import MetadataReplacementPayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: MetadataReplacementPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "put",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/metadata".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/metadata".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: MetadataReplacementPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Replace metadata
+    """ Replace metadata
 
      Replaces the complete custom metadata map. Entries that are not in the request are removed.
 
@@ -80,12 +91,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -94,15 +107,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: MetadataReplacementPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Replace metadata
+    """ Replace metadata
 
      Replaces the complete custom metadata map. Entries that are not in the request are removed.
 
@@ -117,15 +130,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -133,8 +147,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: MetadataReplacementPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Replace metadata
+    """ Replace metadata
 
      Replaces the complete custom metadata map. Entries that are not in the request are removed.
 
@@ -149,18 +164,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -168,8 +186,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: MetadataReplacementPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Replace metadata
+    """ Replace metadata
 
      Replaces the complete custom metadata map. Entries that are not in the request are removed.
 
@@ -184,13 +203,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_ssh_keys.py
+++ b/clients/atlas/atlas/api/vm_configuration/replace_virtual_machine_ssh_keys.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.ssh_keys_replacement_payload import SSHKeysReplacementPayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: SSHKeysReplacementPayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "put",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ssh-keys".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/ssh-keys".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: SSHKeysReplacementPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Replace SSH keys
+    """ Replace SSH keys
 
      Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
 
@@ -80,12 +91,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -94,15 +107,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: SSHKeysReplacementPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Replace SSH keys
+    """ Replace SSH keys
 
      Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
 
@@ -117,15 +130,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -133,8 +147,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: SSHKeysReplacementPayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Replace SSH keys
+    """ Replace SSH keys
 
      Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
 
@@ -149,18 +164,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -168,8 +186,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: SSHKeysReplacementPayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Replace SSH keys
+    """ Replace SSH keys
 
      Replaces the complete authorized SSH key list. Keys that are not in the request are removed.
 
@@ -184,13 +203,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.compute_update_payload import ComputeUpdatePayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: ComputeUpdatePayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/compute".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/compute".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: ComputeUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resize compute
+    """ Resize compute
 
      Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
     change.
@@ -81,12 +92,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +108,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: ComputeUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resize compute
+    """ Resize compute
 
      Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
     change.
@@ -119,15 +132,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +149,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: ComputeUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resize compute
+    """ Resize compute
 
      Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
     change.
@@ -152,18 +167,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -171,8 +189,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: ComputeUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resize compute
+    """ Resize compute
 
      Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
     change.
@@ -188,13 +207,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_disk.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_disk.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.disk_update_payload import DiskUpdatePayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: DiskUpdatePayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/disk".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/disk".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: DiskUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resize disk
+    """ Resize disk
 
      Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
     and a limit of 0 removes that limit.
@@ -81,12 +92,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +108,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: DiskUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resize disk
+    """ Resize disk
 
      Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
     and a limit of 0 removes that limit.
@@ -119,15 +132,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +149,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: DiskUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Resize disk
+    """ Resize disk
 
      Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
     and a limit of 0 removes that limit.
@@ -152,18 +167,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -171,8 +189,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: DiskUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Resize disk
+    """ Resize disk
 
      Increases the disk size or changes its throughput and IOPS limits. The disk size cannot decrease,
     and a limit of 0 removes that limit.
@@ -188,13 +207,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_network.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_network.py
@@ -1,14 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.network_update_payload import NetworkUpdatePayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -16,15 +19,21 @@ def _get_kwargs(
     *,
     body: NetworkUpdatePayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/network".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}/network".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
 
     _kwargs["json"] = body.to_dict()
@@ -35,9 +44,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -47,9 +59,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,8 +74,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: NetworkUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Update network
+    """ Update network
 
      Changes egress and network throughput limits. Egress controls internet reachability and does not
     change mesh reachability.
@@ -81,12 +92,14 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -95,15 +108,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     body: NetworkUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Update network
+    """ Update network
 
      Changes egress and network throughput limits. Egress controls internet reachability and does not
     change mesh reachability.
@@ -119,15 +132,16 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
@@ -135,8 +149,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     body: NetworkUpdatePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Update network
+    """ Update network
 
      Changes egress and network throughput limits. Egress controls internet reachability and does not
     change mesh reachability.
@@ -152,18 +167,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        body=body,
-        x_tenant_id=x_tenant_id,
+body=body,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
@@ -171,8 +189,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     body: NetworkUpdatePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Update network
+    """ Update network
 
      Changes egress and network throughput limits. Egress controls internet reachability and does not
     change mesh reachability.
@@ -188,13 +207,13 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/__init__.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/__init__.py
@@ -1,1 +1,1 @@
-"""Contains endpoint functions for accessing the API"""
+""" Contains endpoint functions for accessing the API """

--- a/clients/atlas/atlas/api/vm_lifecycle/create_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/create_virtual_machine.py
@@ -1,22 +1,34 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.create_virtual_machine_payload import CreateVirtualMachinePayload
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     *,
     body: CreateVirtualMachinePayload,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
+
+    
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -31,9 +43,12 @@ def _get_kwargs(
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 201:
         response_201 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_201
 
@@ -43,9 +58,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,8 +72,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     body: CreateVirtualMachinePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Create VM
+    """ Create VM
 
      Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
     configuration.
@@ -75,11 +89,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -88,14 +104,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient | Client,
     body: CreateVirtualMachinePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Create VM
+    """ Create VM
 
      Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
     configuration.
@@ -110,22 +126,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        body=body,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+body=body,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: CreateVirtualMachinePayload,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Create VM
+    """ Create VM
 
      Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
     configuration.
@@ -140,25 +158,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         body=body,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: CreateVirtualMachinePayload,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Create VM
+    """ Create VM
 
      Creates a tenant VM from an image and requests the specified compute, disk, network, and guest
     configuration.
@@ -173,12 +195,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            body=body,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/delete_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/delete_virtual_machine.py
@@ -1,37 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_response import VirtualMachineResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
+
 def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineResponse | None:
     if response.status_code == 202:
         response_202 = VirtualMachineResponse.from_dict(response.json())
+
+
 
         return response_202
 
@@ -41,9 +54,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Delete VM
+    """ Delete VM
 
      Starts VM termination and detaches its public IP address without releasing the tenant reservation.
     Poll the VM until cleanup removes the record and this route returns 404.
@@ -73,11 +85,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -86,14 +100,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Delete VM
+    """ Delete VM
 
      Starts VM termination and detaches its public IP address without releasing the tenant reservation.
     Poll the VM until cleanup removes the record and this route returns 404.
@@ -108,22 +122,24 @@ def sync(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineResponse]:
-    """Delete VM
+    """ Delete VM
 
      Starts VM termination and detaches its public IP address without releasing the tenant reservation.
     Poll the VM until cleanup removes the record and this route returns 404.
@@ -138,25 +154,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineResponse | None:
-    """Delete VM
+    """ Delete VM
 
      Starts VM termination and detaches its public IP address without releasing the tenant reservation.
     Poll the VM until cleanup removes the record and this route returns 404.
@@ -171,12 +191,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/get_virtual_machine.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/get_virtual_machine.py
@@ -1,39 +1,50 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.virtual_machine_detail_response import VirtualMachineDetailResponse
-from ...types import Response
+from typing import cast
+
 
 
 def _get_kwargs(
     virtual_machine_id: str,
     *,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
 
+
+
+
+    
+
+    
+
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(
-            virtual_machine_id=quote(str(virtual_machine_id), safe=""),
-        ),
+        "url": "/api/atlas/virtual-machines/{virtual_machine_id}".format(virtual_machine_id=quote(str(virtual_machine_id), safe=""),),
     }
+
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> VirtualMachineDetailResponse | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> VirtualMachineDetailResponse | None:
     if response.status_code == 200:
         response_200 = VirtualMachineDetailResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -43,9 +54,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[VirtualMachineDetailResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[VirtualMachineDetailResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,8 +68,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineDetailResponse]:
-    """Get VM
+    """ Get VM
 
      Returns the stored VM record together with its desired state and current state.
 
@@ -74,11 +84,13 @@ def sync_detailed(
 
     Returns:
         Response[VirtualMachineDetailResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -87,14 +99,14 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineDetailResponse | None:
-    """Get VM
+    """ Get VM
 
      Returns the stored VM record together with its desired state and current state.
 
@@ -108,22 +120,24 @@ def sync(
 
     Returns:
         VirtualMachineDetailResponse
-    """
+     """
+
 
     return sync_detailed(
         virtual_machine_id=virtual_machine_id,
-        client=client,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+client=client,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> Response[VirtualMachineDetailResponse]:
-    """Get VM
+    """ Get VM
 
      Returns the stored VM record together with its desired state and current state.
 
@@ -137,25 +151,29 @@ async def asyncio_detailed(
 
     Returns:
         Response[VirtualMachineDetailResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         virtual_machine_id=virtual_machine_id,
-        x_tenant_id=x_tenant_id,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     virtual_machine_id: str,
     *,
     client: AuthenticatedClient | Client,
     x_tenant_id: int,
+
 ) -> VirtualMachineDetailResponse | None:
-    """Get VM
+    """ Get VM
 
      Returns the stored VM record together with its desired state and current state.
 
@@ -169,12 +187,12 @@ async def asyncio(
 
     Returns:
         VirtualMachineDetailResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            virtual_machine_id=virtual_machine_id,
-            client=client,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        virtual_machine_id=virtual_machine_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.page_virtual_machine_response import PageVirtualMachineResponse
+from ...models.page_virtual_machine_list_response import PageVirtualMachineListResponse
 from ...types import UNSET, Response, Unset
 
 
@@ -38,9 +38,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> PageVirtualMachineResponse | None:
+) -> PageVirtualMachineListResponse | None:
     if response.status_code == 200:
-        response_200 = PageVirtualMachineResponse.from_dict(response.json())
+        response_200 = PageVirtualMachineListResponse.from_dict(response.json())
 
         return response_200
 
@@ -52,7 +52,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[PageVirtualMachineResponse]:
+) -> Response[PageVirtualMachineListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,10 +67,11 @@ def sync_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
-) -> Response[PageVirtualMachineResponse]:
+) -> Response[PageVirtualMachineListResponse]:
     """List VMs
 
-     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+     Returns one page of tenant VM records in newest-first order, with the state each host last reported.
+    This request does not contact the host.
 
     Args:
         offset (int | Unset):  Default: 0.
@@ -82,7 +83,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PageVirtualMachineResponse]
+        Response[PageVirtualMachineListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -104,10 +105,11 @@ def sync(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
-) -> PageVirtualMachineResponse | None:
+) -> PageVirtualMachineListResponse | None:
     """List VMs
 
-     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+     Returns one page of tenant VM records in newest-first order, with the state each host last reported.
+    This request does not contact the host.
 
     Args:
         offset (int | Unset):  Default: 0.
@@ -119,7 +121,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PageVirtualMachineResponse
+        PageVirtualMachineListResponse
     """
 
     return sync_detailed(
@@ -136,10 +138,11 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
-) -> Response[PageVirtualMachineResponse]:
+) -> Response[PageVirtualMachineListResponse]:
     """List VMs
 
-     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+     Returns one page of tenant VM records in newest-first order, with the state each host last reported.
+    This request does not contact the host.
 
     Args:
         offset (int | Unset):  Default: 0.
@@ -151,7 +154,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PageVirtualMachineResponse]
+        Response[PageVirtualMachineListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -171,10 +174,11 @@ async def asyncio(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
-) -> PageVirtualMachineResponse | None:
+) -> PageVirtualMachineListResponse | None:
     """List VMs
 
-     Returns one page of tenant VM records in newest-first order. This request does not contact the host.
+     Returns one page of tenant VM records in newest-first order, with the state each host last reported.
+    This request does not contact the host.
 
     Args:
         offset (int | Unset):  Default: 0.
@@ -186,7 +190,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PageVirtualMachineResponse
+        PageVirtualMachineListResponse
     """
 
     return (

--- a/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
+++ b/clients/atlas/atlas/api/vm_lifecycle/list_virtual_machines.py
@@ -1,12 +1,17 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
 from ...models.page_virtual_machine_list_response import PageVirtualMachineListResponse
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Unset
+from typing import cast
+
 
 
 def _get_kwargs(
@@ -14,9 +19,15 @@ def _get_kwargs(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     headers["X-Tenant-ID"] = str(x_tenant_id)
+
+
+
+
+    
 
     params: dict[str, Any] = {}
 
@@ -24,7 +35,9 @@ def _get_kwargs(
 
     params["limit"] = limit
 
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -32,15 +45,17 @@ def _get_kwargs(
         "params": params,
     }
 
+
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> PageVirtualMachineListResponse | None:
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> PageVirtualMachineListResponse | None:
     if response.status_code == 200:
         response_200 = PageVirtualMachineListResponse.from_dict(response.json())
+
+
 
         return response_200
 
@@ -50,9 +65,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[PageVirtualMachineListResponse]:
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[PageVirtualMachineListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,8 +80,9 @@ def sync_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageVirtualMachineListResponse]:
-    """List VMs
+    """ List VMs
 
      Returns one page of tenant VM records in newest-first order, with the state each host last reported.
     This request does not contact the host.
@@ -84,12 +98,14 @@ def sync_detailed(
 
     Returns:
         Response[PageVirtualMachineListResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -98,15 +114,15 @@ def sync_detailed(
 
     return _build_response(client=client, response=response)
 
-
 def sync(
     *,
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageVirtualMachineListResponse | None:
-    """List VMs
+    """ List VMs
 
      Returns one page of tenant VM records in newest-first order, with the state each host last reported.
     This request does not contact the host.
@@ -122,15 +138,16 @@ def sync(
 
     Returns:
         PageVirtualMachineListResponse
-    """
+     """
+
 
     return sync_detailed(
         client=client,
-        offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
-    ).parsed
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
 
+    ).parsed
 
 async def asyncio_detailed(
     *,
@@ -138,8 +155,9 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> Response[PageVirtualMachineListResponse]:
-    """List VMs
+    """ List VMs
 
      Returns one page of tenant VM records in newest-first order, with the state each host last reported.
     This request does not contact the host.
@@ -155,18 +173,21 @@ async def asyncio_detailed(
 
     Returns:
         Response[PageVirtualMachineListResponse]
-    """
+     """
+
 
     kwargs = _get_kwargs(
         offset=offset,
-        limit=limit,
-        x_tenant_id=x_tenant_id,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
 
     return _build_response(client=client, response=response)
-
 
 async def asyncio(
     *,
@@ -174,8 +195,9 @@ async def asyncio(
     offset: int | Unset = 0,
     limit: int | Unset = 20,
     x_tenant_id: int,
+
 ) -> PageVirtualMachineListResponse | None:
-    """List VMs
+    """ List VMs
 
      Returns one page of tenant VM records in newest-first order, with the state each host last reported.
     This request does not contact the host.
@@ -191,13 +213,13 @@ async def asyncio(
 
     Returns:
         PageVirtualMachineListResponse
-    """
+     """
 
-    return (
-        await asyncio_detailed(
-            client=client,
-            offset=offset,
-            limit=limit,
-            x_tenant_id=x_tenant_id,
-        )
-    ).parsed
+
+    return (await asyncio_detailed(
+        client=client,
+offset=offset,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/clients/atlas/atlas/client.py
+++ b/clients/atlas/atlas/client.py
@@ -1,8 +1,11 @@
 import ssl
 from typing import Any, Self
 
+from attrs import define, field, evolve
 import httpx
-from attrs import define, evolve, field
+
+
+
 
 
 @define
@@ -33,7 +36,6 @@ class Client:
             status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
             argument to the constructor.
     """
-
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
@@ -266,3 +268,4 @@ class AuthenticatedClient:
     async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+

--- a/clients/atlas/atlas/errors.py
+++ b/clients/atlas/atlas/errors.py
@@ -1,5 +1,4 @@
-"""Contains shared errors types that can be raised from API functions"""
-
+""" Contains shared errors types that can be raised from API functions """
 
 class UnexpectedStatus(Exception):
     """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
@@ -11,6 +10,5 @@ class UnexpectedStatus(Exception):
         super().__init__(
             f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
         )
-
 
 __all__ = ["UnexpectedStatus"]

--- a/clients/atlas/atlas/models/__init__.py
+++ b/clients/atlas/atlas/models/__init__.py
@@ -1,4 +1,4 @@
-"""Contains all the data models used in inputs/outputs"""
+""" Contains all the data models used in inputs/outputs """
 
 from .compute_update_payload import ComputeUpdatePayload
 from .console_token_payload import ConsoleTokenPayload

--- a/clients/atlas/atlas/models/__init__.py
+++ b/clients/atlas/atlas/models/__init__.py
@@ -21,12 +21,13 @@ from .network_update_payload import NetworkUpdatePayload
 from .network_update_payload_egress_type_0 import NetworkUpdatePayloadEgressType0
 from .page_image_response import PageImageResponse
 from .page_ip_address_response import PageIPAddressResponse
-from .page_virtual_machine_response import PageVirtualMachineResponse
+from .page_virtual_machine_list_response import PageVirtualMachineListResponse
 from .reserve_ip_address_payload import ReserveIPAddressPayload
 from .reserve_ip_address_payload_source import ReserveIPAddressPayloadSource
 from .snapshot_payload import SnapshotPayload
 from .ssh_keys_replacement_payload import SSHKeysReplacementPayload
 from .virtual_machine_detail_response import VirtualMachineDetailResponse
+from .virtual_machine_list_response import VirtualMachineListResponse
 from .virtual_machine_response import VirtualMachineResponse
 
 __all__ = (
@@ -51,11 +52,12 @@ __all__ = (
     "NetworkUpdatePayloadEgressType0",
     "PageImageResponse",
     "PageIPAddressResponse",
-    "PageVirtualMachineResponse",
+    "PageVirtualMachineListResponse",
     "ReserveIPAddressPayload",
     "ReserveIPAddressPayloadSource",
     "SnapshotPayload",
     "SSHKeysReplacementPayload",
     "VirtualMachineDetailResponse",
+    "VirtualMachineListResponse",
     "VirtualMachineResponse",
 )

--- a/clients/atlas/atlas/models/compute_update_payload.py
+++ b/clients/atlas/atlas/models/compute_update_payload.py
@@ -1,26 +1,40 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+
+
+
+
+
 
 T = TypeVar("T", bound="ComputeUpdatePayload")
 
 
+
 @_attrs_define
 class ComputeUpdatePayload:
-    """New CPU and memory values for a stopped virtual machine.
+    """ New CPU and memory values for a stopped virtual machine.
 
-    Attributes:
-        memory_mib (int | None | Unset):
-        vcpus (int | None | Unset):
-    """
+        Attributes:
+            memory_mib (int | None | Unset):
+            vcpus (int | None | Unset):
+     """
 
     memory_mib: int | None | Unset = UNSET
     vcpus: int | None | Unset = UNSET
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         memory_mib: int | None | Unset
@@ -35,9 +49,11 @@ class ComputeUpdatePayload:
         else:
             vcpus = self.vcpus
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update({})
+        field_dict.update({
+        })
         if memory_mib is not UNSET:
             field_dict["memory_mib"] = memory_mib
         if vcpus is not UNSET:
@@ -45,10 +61,11 @@ class ComputeUpdatePayload:
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
         def _parse_memory_mib(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -57,6 +74,7 @@ class ComputeUpdatePayload:
             return cast(int | None | Unset, data)
 
         memory_mib = _parse_memory_mib(d.pop("memory_mib", UNSET))
+
 
         def _parse_vcpus(data: object) -> int | None | Unset:
             if data is None:
@@ -67,9 +85,11 @@ class ComputeUpdatePayload:
 
         vcpus = _parse_vcpus(d.pop("vcpus", UNSET))
 
+
         compute_update_payload = cls(
             memory_mib=memory_mib,
             vcpus=vcpus,
         )
 
         return compute_update_payload
+

--- a/clients/atlas/atlas/models/console_token_payload.py
+++ b/clients/atlas/atlas/models/console_token_payload.py
@@ -1,51 +1,73 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 from ..models.console_token_payload_mode import ConsoleTokenPayloadMode
 from ..types import UNSET, Unset
 
+
+
+
+
+
 T = TypeVar("T", bound="ConsoleTokenPayload")
+
 
 
 @_attrs_define
 class ConsoleTokenPayload:
-    """The console mode that the token opens.
+    """ The console mode that the token opens.
 
-    Attributes:
-        mode (ConsoleTokenPayloadMode | Unset):  Default: ConsoleTokenPayloadMode.TTY.
-    """
+        Attributes:
+            mode (ConsoleTokenPayloadMode | Unset):  Default: ConsoleTokenPayloadMode.TTY.
+     """
 
     mode: ConsoleTokenPayloadMode | Unset = ConsoleTokenPayloadMode.TTY
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         mode: str | Unset = UNSET
         if not isinstance(self.mode, Unset):
             mode = self.mode.value
 
+
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update({})
+        field_dict.update({
+        })
         if mode is not UNSET:
             field_dict["mode"] = mode
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _mode = d.pop("mode", UNSET)
         mode: ConsoleTokenPayloadMode | Unset
-        if isinstance(_mode, Unset):
+        if isinstance(_mode,  Unset):
             mode = UNSET
         else:
             mode = ConsoleTokenPayloadMode(_mode)
+
+
+
 
         console_token_payload = cls(
             mode=mode,
         )
 
         return console_token_payload
+

--- a/clients/atlas/atlas/models/console_token_payload_mode.py
+++ b/clients/atlas/atlas/models/console_token_payload_mode.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class ConsoleTokenPayloadMode(StrEnum):
     SSH = "ssh"
     TTY = "tty"

--- a/clients/atlas/atlas/models/console_token_response.py
+++ b/clients/atlas/atlas/models/console_token_response.py
@@ -1,30 +1,42 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 from ..models.console_token_response_mode import ConsoleTokenResponseMode
+
+
+
+
+
 
 T = TypeVar("T", bound="ConsoleTokenResponse")
 
 
+
 @_attrs_define
 class ConsoleTokenResponse:
-    """A single-use console token.
+    """ A single-use console token.
 
-    Attributes:
-        expires_in (int):
-        mode (ConsoleTokenResponseMode):
-        token (str):
-    """
+        Attributes:
+            expires_in (int):
+            mode (ConsoleTokenResponseMode):
+            token (str):
+     """
 
     expires_in: int
     mode: ConsoleTokenResponseMode
     token: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         expires_in = self.expires_in
@@ -33,17 +45,18 @@ class ConsoleTokenResponse:
 
         token = self.token
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "expires_in": expires_in,
-                "mode": mode,
-                "token": token,
-            }
-        )
+        field_dict.update({
+            "expires_in": expires_in,
+            "mode": mode,
+            "token": token,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -52,6 +65,9 @@ class ConsoleTokenResponse:
 
         mode = ConsoleTokenResponseMode(d.pop("mode"))
 
+
+
+
         token = d.pop("token")
 
         console_token_response = cls(
@@ -59,6 +75,7 @@ class ConsoleTokenResponse:
             mode=mode,
             token=token,
         )
+
 
         console_token_response.additional_properties = d
         return console_token_response

--- a/clients/atlas/atlas/models/console_token_response_mode.py
+++ b/clients/atlas/atlas/models/console_token_response_mode.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class ConsoleTokenResponseMode(StrEnum):
     SSH = "ssh"
     TTY = "tty"

--- a/clients/atlas/atlas/models/create_virtual_machine_payload.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload.py
@@ -1,40 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 from ..models.create_virtual_machine_payload_egress import CreateVirtualMachinePayloadEgress
 from ..types import UNSET, Unset
+from typing import cast
 
 if TYPE_CHECKING:
-    from ..models.create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata
+  from ..models.create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata
+
+
+
 
 
 T = TypeVar("T", bound="CreateVirtualMachinePayload")
 
 
+
 @_attrs_define
 class CreateVirtualMachinePayload:
-    """Values that create one virtual machine.
+    """ Values that create one virtual machine.
 
-    Attributes:
-        disk_mib (int):
-        image_id (str):
-        memory_mib (int):
-        vcpus (int):
-        disk_iops (int | Unset):  Default: 0.
-        disk_throughput_mibps (int | Unset):  Default: 0.
-        egress (CreateVirtualMachinePayloadEgress | Unset):  Default: CreateVirtualMachinePayloadEgress.UPLINK.
-        hostname (str | Unset):  Default: ''.
-        ip_address_id (None | str | Unset):
-        metadata (CreateVirtualMachinePayloadMetadata | Unset):
-        private_network_throughput_mibps (int | Unset):  Default: 0.
-        public_network_throughput_mibps (int | Unset):  Default: 0.
-        ssh_keys (list[str] | Unset):
-        user_data (str | Unset):  Default: ''.
-    """
+        Attributes:
+            disk_mib (int):
+            image_id (str):
+            memory_mib (int):
+            vcpus (int):
+            disk_iops (int | Unset):  Default: 0.
+            disk_throughput_mibps (int | Unset):  Default: 0.
+            egress (CreateVirtualMachinePayloadEgress | Unset):  Default: CreateVirtualMachinePayloadEgress.UPLINK.
+            hostname (str | Unset):  Default: ''.
+            ip_address_id (None | str | Unset):
+            metadata (CreateVirtualMachinePayloadMetadata | Unset):
+            private_network_throughput_mibps (int | Unset):  Default: 0.
+            public_network_throughput_mibps (int | Unset):  Default: 0.
+            ssh_keys (list[str] | Unset):
+            user_data (str | Unset):  Default: ''.
+     """
 
     disk_mib: int
     image_id: str
@@ -43,15 +51,20 @@ class CreateVirtualMachinePayload:
     disk_iops: int | Unset = 0
     disk_throughput_mibps: int | Unset = 0
     egress: CreateVirtualMachinePayloadEgress | Unset = CreateVirtualMachinePayloadEgress.UPLINK
-    hostname: str | Unset = ""
+    hostname: str | Unset = ''
     ip_address_id: None | str | Unset = UNSET
     metadata: CreateVirtualMachinePayloadMetadata | Unset = UNSET
     private_network_throughput_mibps: int | Unset = 0
     public_network_throughput_mibps: int | Unset = 0
     ssh_keys: list[str] | Unset = UNSET
-    user_data: str | Unset = ""
+    user_data: str | Unset = ''
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata # noqa: PLC0415
         disk_mib = self.disk_mib
 
         image_id = self.image_id
@@ -67,6 +80,7 @@ class CreateVirtualMachinePayload:
         egress: str | Unset = UNSET
         if not isinstance(self.egress, Unset):
             egress = self.egress.value
+
 
         hostname = self.hostname
 
@@ -88,18 +102,19 @@ class CreateVirtualMachinePayload:
         if not isinstance(self.ssh_keys, Unset):
             ssh_keys = self.ssh_keys
 
+
+
         user_data = self.user_data
+
 
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "disk_mib": disk_mib,
-                "image_id": image_id,
-                "memory_mib": memory_mib,
-                "vcpus": vcpus,
-            }
-        )
+        field_dict.update({
+            "disk_mib": disk_mib,
+            "image_id": image_id,
+            "memory_mib": memory_mib,
+            "vcpus": vcpus,
+        })
         if disk_iops is not UNSET:
             field_dict["disk_iops"] = disk_iops
         if disk_throughput_mibps is not UNSET:
@@ -123,12 +138,11 @@ class CreateVirtualMachinePayload:
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.create_virtual_machine_payload_metadata import (
-            CreateVirtualMachinePayloadMetadata,  # noqa: PLC0415
-        )
-
+        from ..models.create_virtual_machine_payload_metadata import CreateVirtualMachinePayloadMetadata # noqa: PLC0415
         d = dict(src_dict)
         disk_mib = d.pop("disk_mib")
 
@@ -144,10 +158,13 @@ class CreateVirtualMachinePayload:
 
         _egress = d.pop("egress", UNSET)
         egress: CreateVirtualMachinePayloadEgress | Unset
-        if isinstance(_egress, Unset):
+        if isinstance(_egress,  Unset):
             egress = UNSET
         else:
             egress = CreateVirtualMachinePayloadEgress(_egress)
+
+
+
 
         hostname = d.pop("hostname", UNSET)
 
@@ -160,18 +177,23 @@ class CreateVirtualMachinePayload:
 
         ip_address_id = _parse_ip_address_id(d.pop("ip_address_id", UNSET))
 
+
         _metadata = d.pop("metadata", UNSET)
         metadata: CreateVirtualMachinePayloadMetadata | Unset
-        if isinstance(_metadata, Unset):
+        if isinstance(_metadata,  Unset):
             metadata = UNSET
         else:
             metadata = CreateVirtualMachinePayloadMetadata.from_dict(_metadata)
+
+
+
 
         private_network_throughput_mibps = d.pop("private_network_throughput_mibps", UNSET)
 
         public_network_throughput_mibps = d.pop("public_network_throughput_mibps", UNSET)
 
         ssh_keys = cast(list[str], d.pop("ssh_keys", UNSET))
+
 
         user_data = d.pop("user_data", UNSET)
 
@@ -193,3 +215,4 @@ class CreateVirtualMachinePayload:
         )
 
         return create_virtual_machine_payload
+

--- a/clients/atlas/atlas/models/create_virtual_machine_payload_egress.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload_egress.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class CreateVirtualMachinePayloadEgress(StrEnum):
     MESH = "mesh"
     NONE = "none"

--- a/clients/atlas/atlas/models/create_virtual_machine_payload_metadata.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload_metadata.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="CreateVirtualMachinePayloadMetadata")
+
 
 
 @_attrs_define
 class CreateVirtualMachinePayloadMetadata:
+    
+
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        create_virtual_machine_payload_metadata = cls()
+        create_virtual_machine_payload_metadata = cls(
+        )
+
 
         create_virtual_machine_payload_metadata.additional_properties = d
         return create_virtual_machine_payload_metadata

--- a/clients/atlas/atlas/models/disk_update_payload.py
+++ b/clients/atlas/atlas/models/disk_update_payload.py
@@ -1,28 +1,42 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+
+
+
+
+
 
 T = TypeVar("T", bound="DiskUpdatePayload")
 
 
+
 @_attrs_define
 class DiskUpdatePayload:
-    """New disk size and disk rate limits.
+    """ New disk size and disk rate limits.
 
-    Attributes:
-        disk_iops (int | None | Unset):
-        disk_mib (int | None | Unset):
-        disk_throughput_mibps (int | None | Unset):
-    """
+        Attributes:
+            disk_iops (int | None | Unset):
+            disk_mib (int | None | Unset):
+            disk_throughput_mibps (int | None | Unset):
+     """
 
     disk_iops: int | None | Unset = UNSET
     disk_mib: int | None | Unset = UNSET
     disk_throughput_mibps: int | None | Unset = UNSET
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         disk_iops: int | None | Unset
@@ -43,9 +57,11 @@ class DiskUpdatePayload:
         else:
             disk_throughput_mibps = self.disk_throughput_mibps
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update({})
+        field_dict.update({
+        })
         if disk_iops is not UNSET:
             field_dict["disk_iops"] = disk_iops
         if disk_mib is not UNSET:
@@ -55,10 +71,11 @@ class DiskUpdatePayload:
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
         def _parse_disk_iops(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -67,6 +84,7 @@ class DiskUpdatePayload:
             return cast(int | None | Unset, data)
 
         disk_iops = _parse_disk_iops(d.pop("disk_iops", UNSET))
+
 
         def _parse_disk_mib(data: object) -> int | None | Unset:
             if data is None:
@@ -77,6 +95,7 @@ class DiskUpdatePayload:
 
         disk_mib = _parse_disk_mib(d.pop("disk_mib", UNSET))
 
+
         def _parse_disk_throughput_mibps(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -86,6 +105,7 @@ class DiskUpdatePayload:
 
         disk_throughput_mibps = _parse_disk_throughput_mibps(d.pop("disk_throughput_mibps", UNSET))
 
+
         disk_update_payload = cls(
             disk_iops=disk_iops,
             disk_mib=disk_mib,
@@ -93,3 +113,4 @@ class DiskUpdatePayload:
         )
 
         return disk_update_payload
+

--- a/clients/atlas/atlas/models/download_image_artifact.py
+++ b/clients/atlas/atlas/models/download_image_artifact.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class DownloadImageArtifact(StrEnum):
     KERNEL = "kernel"
     ROOTFS = "rootfs"

--- a/clients/atlas/atlas/models/image_download_response.py
+++ b/clients/atlas/atlas/models/image_download_response.py
@@ -1,28 +1,36 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 from ..models.image_download_response_artifact import ImageDownloadResponseArtifact
+
+
+
+
+
 
 T = TypeVar("T", bound="ImageDownloadResponse")
 
 
+
 @_attrs_define
 class ImageDownloadResponse:
-    """Signed downloads for one image.
+    """ Signed downloads for one image.
 
-    Attributes:
-        artifact (ImageDownloadResponseArtifact):
-        expires_at (int):
-        expires_in (int):
-        sha256 (str):
-        size_mib (int):
-        url (str):
-    """
+        Attributes:
+            artifact (ImageDownloadResponseArtifact):
+            expires_at (int):
+            expires_in (int):
+            sha256 (str):
+            size_mib (int):
+            url (str):
+     """
 
     artifact: ImageDownloadResponseArtifact
     expires_at: int
@@ -31,6 +39,10 @@ class ImageDownloadResponse:
     size_mib: int
     url: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         artifact = self.artifact.value
@@ -45,25 +57,29 @@ class ImageDownloadResponse:
 
         url = self.url
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "artifact": artifact,
-                "expires_at": expires_at,
-                "expires_in": expires_in,
-                "sha256": sha256,
-                "size_mib": size_mib,
-                "url": url,
-            }
-        )
+        field_dict.update({
+            "artifact": artifact,
+            "expires_at": expires_at,
+            "expires_in": expires_in,
+            "sha256": sha256,
+            "size_mib": size_mib,
+            "url": url,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         artifact = ImageDownloadResponseArtifact(d.pop("artifact"))
+
+
+
 
         expires_at = d.pop("expires_at")
 
@@ -83,6 +99,7 @@ class ImageDownloadResponse:
             size_mib=size_mib,
             url=url,
         )
+
 
         image_download_response.additional_properties = d
         return image_download_response

--- a/clients/atlas/atlas/models/image_download_response_artifact.py
+++ b/clients/atlas/atlas/models/image_download_response_artifact.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class ImageDownloadResponseArtifact(StrEnum):
     KERNEL = "kernel"
     ROOTFS = "rootfs"

--- a/clients/atlas/atlas/models/image_response.py
+++ b/clients/atlas/atlas/models/image_response.py
@@ -1,37 +1,47 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
+
+
+
+
+
 T = TypeVar("T", bound="ImageResponse")
+
 
 
 @_attrs_define
 class ImageResponse:
-    """A tenant virtual machine image.
+    """ A tenant virtual machine image.
 
-    Attributes:
-        cache_image (bool):
-        created_at (int):
-        enabled (bool):
-        id (str):
-        image_type (str):
-        kernel_size_mib (int):
-        memory_snapshot (bool):
-        operating_system (str):
-        operating_system_version (str):
-        platform (str):
-        rootfs_size_mib (int):
-        status (str):
-        supports_cloud_init (bool):
-        tenant_id (int):
-        title (str):
-        transfer_error (None | str):
-        transfer_progress (int):
-    """
+        Attributes:
+            cache_image (bool):
+            created_at (int):
+            enabled (bool):
+            id (str):
+            image_type (str):
+            kernel_size_mib (int):
+            memory_snapshot (bool):
+            operating_system (str):
+            operating_system_version (str):
+            platform (str):
+            rootfs_size_mib (int):
+            status (str):
+            supports_cloud_init (bool):
+            tenant_id (int):
+            title (str):
+            transfer_error (None | str):
+            transfer_progress (int):
+     """
 
     cache_image: bool
     created_at: int
@@ -51,6 +61,10 @@ class ImageResponse:
     transfer_error: None | str
     transfer_progress: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         cache_image = self.cache_image
@@ -88,31 +102,32 @@ class ImageResponse:
 
         transfer_progress = self.transfer_progress
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cache_image": cache_image,
-                "created_at": created_at,
-                "enabled": enabled,
-                "id": id,
-                "image_type": image_type,
-                "kernel_size_mib": kernel_size_mib,
-                "memory_snapshot": memory_snapshot,
-                "operating_system": operating_system,
-                "operating_system_version": operating_system_version,
-                "platform": platform,
-                "rootfs_size_mib": rootfs_size_mib,
-                "status": status,
-                "supports_cloud_init": supports_cloud_init,
-                "tenant_id": tenant_id,
-                "title": title,
-                "transfer_error": transfer_error,
-                "transfer_progress": transfer_progress,
-            }
-        )
+        field_dict.update({
+            "cache_image": cache_image,
+            "created_at": created_at,
+            "enabled": enabled,
+            "id": id,
+            "image_type": image_type,
+            "kernel_size_mib": kernel_size_mib,
+            "memory_snapshot": memory_snapshot,
+            "operating_system": operating_system,
+            "operating_system_version": operating_system_version,
+            "platform": platform,
+            "rootfs_size_mib": rootfs_size_mib,
+            "status": status,
+            "supports_cloud_init": supports_cloud_init,
+            "tenant_id": tenant_id,
+            "title": title,
+            "transfer_error": transfer_error,
+            "transfer_progress": transfer_progress,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -154,6 +169,7 @@ class ImageResponse:
 
         transfer_error = _parse_transfer_error(d.pop("transfer_error"))
 
+
         transfer_progress = d.pop("transfer_progress")
 
         image_response = cls(
@@ -175,6 +191,7 @@ class ImageResponse:
             transfer_error=transfer_error,
             transfer_progress=transfer_progress,
         )
+
 
         image_response.additional_properties = d
         return image_response

--- a/clients/atlas/atlas/models/ip_address_assignment_payload.py
+++ b/clients/atlas/atlas/models/ip_address_assignment_payload.py
@@ -1,35 +1,50 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
 
 T = TypeVar("T", bound="IPAddressAssignmentPayload")
 
 
+
 @_attrs_define
 class IPAddressAssignmentPayload:
-    """The public IPv4 address to attach.
+    """ The public IPv4 address to attach.
 
-    Attributes:
-        ip_address_id (str):
-    """
+        Attributes:
+            ip_address_id (str):
+     """
 
     ip_address_id: str
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         ip_address_id = self.ip_address_id
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "ip_address_id": ip_address_id,
-            }
-        )
+        field_dict.update({
+            "ip_address_id": ip_address_id,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -41,3 +56,4 @@ class IPAddressAssignmentPayload:
         )
 
         return ip_address_assignment_payload
+

--- a/clients/atlas/atlas/models/ip_address_response.py
+++ b/clients/atlas/atlas/models/ip_address_response.py
@@ -1,26 +1,36 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
+
+
+
+
+
 T = TypeVar("T", bound="IPAddressResponse")
+
 
 
 @_attrs_define
 class IPAddressResponse:
-    """A tenant public IPv4 address.
+    """ A tenant public IPv4 address.
 
-    Attributes:
-        address (str):
-        created_at (int):
-        id (str):
-        state (str):
-        tenant_id (int):
-        virtual_machine_id (None | str):
-    """
+        Attributes:
+            address (str):
+            created_at (int):
+            id (str):
+            state (str):
+            tenant_id (int):
+            virtual_machine_id (None | str):
+     """
 
     address: str
     created_at: int
@@ -29,6 +39,10 @@ class IPAddressResponse:
     tenant_id: int
     virtual_machine_id: None | str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         address = self.address
@@ -44,20 +58,21 @@ class IPAddressResponse:
         virtual_machine_id: None | str
         virtual_machine_id = self.virtual_machine_id
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "address": address,
-                "created_at": created_at,
-                "id": id,
-                "state": state,
-                "tenant_id": tenant_id,
-                "virtual_machine_id": virtual_machine_id,
-            }
-        )
+        field_dict.update({
+            "address": address,
+            "created_at": created_at,
+            "id": id,
+            "state": state,
+            "tenant_id": tenant_id,
+            "virtual_machine_id": virtual_machine_id,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -79,6 +94,7 @@ class IPAddressResponse:
 
         virtual_machine_id = _parse_virtual_machine_id(d.pop("virtual_machine_id"))
 
+
         ip_address_response = cls(
             address=address,
             created_at=created_at,
@@ -87,6 +103,7 @@ class IPAddressResponse:
             tenant_id=tenant_id,
             virtual_machine_id=virtual_machine_id,
         )
+
 
         ip_address_response.additional_properties = d
         return ip_address_response

--- a/clients/atlas/atlas/models/metadata_replacement_payload.py
+++ b/clients/atlas/atlas/models/metadata_replacement_payload.py
@@ -1,49 +1,67 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
 
 if TYPE_CHECKING:
-    from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata
+  from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata
+
+
+
 
 
 T = TypeVar("T", bound="MetadataReplacementPayload")
 
 
+
 @_attrs_define
 class MetadataReplacementPayload:
-    """The complete custom metadata map.
+    """ The complete custom metadata map.
 
-    Attributes:
-        metadata (MetadataReplacementPayloadMetadata):
-    """
+        Attributes:
+            metadata (MetadataReplacementPayloadMetadata):
+     """
 
     metadata: MetadataReplacementPayloadMetadata
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata # noqa: PLC0415
         metadata = self.metadata.to_dict()
+
 
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "metadata": metadata,
-            }
-        )
+        field_dict.update({
+            "metadata": metadata,
+        })
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata  # noqa: PLC0415
-
+        from ..models.metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata # noqa: PLC0415
         d = dict(src_dict)
         metadata = MetadataReplacementPayloadMetadata.from_dict(d.pop("metadata"))
+
+
+
 
         metadata_replacement_payload = cls(
             metadata=metadata,
         )
 
         return metadata_replacement_payload
+

--- a/clients/atlas/atlas/models/metadata_replacement_payload_metadata.py
+++ b/clients/atlas/atlas/models/metadata_replacement_payload_metadata.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="MetadataReplacementPayloadMetadata")
+
 
 
 @_attrs_define
 class MetadataReplacementPayloadMetadata:
+    
+
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
 
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        metadata_replacement_payload_metadata = cls()
+        metadata_replacement_payload_metadata = cls(
+        )
+
 
         metadata_replacement_payload_metadata.additional_properties = d
         return metadata_replacement_payload_metadata

--- a/clients/atlas/atlas/models/network_update_payload.py
+++ b/clients/atlas/atlas/models/network_update_payload.py
@@ -1,29 +1,43 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 from ..models.network_update_payload_egress_type_0 import NetworkUpdatePayloadEgressType0
 from ..types import UNSET, Unset
+from typing import cast
+
+
+
+
+
 
 T = TypeVar("T", bound="NetworkUpdatePayload")
 
 
+
 @_attrs_define
 class NetworkUpdatePayload:
-    """New egress mode and network rate limits.
+    """ New egress mode and network rate limits.
 
-    Attributes:
-        egress (NetworkUpdatePayloadEgressType0 | None | Unset):
-        private_network_throughput_mibps (int | None | Unset):
-        public_network_throughput_mibps (int | None | Unset):
-    """
+        Attributes:
+            egress (NetworkUpdatePayloadEgressType0 | None | Unset):
+            private_network_throughput_mibps (int | None | Unset):
+            public_network_throughput_mibps (int | None | Unset):
+     """
 
     egress: NetworkUpdatePayloadEgressType0 | None | Unset = UNSET
     private_network_throughput_mibps: int | None | Unset = UNSET
     public_network_throughput_mibps: int | None | Unset = UNSET
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         egress: None | str | Unset
@@ -46,9 +60,11 @@ class NetworkUpdatePayload:
         else:
             public_network_throughput_mibps = self.public_network_throughput_mibps
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update({})
+        field_dict.update({
+        })
         if egress is not UNSET:
             field_dict["egress"] = egress
         if private_network_throughput_mibps is not UNSET:
@@ -58,10 +74,11 @@ class NetworkUpdatePayload:
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
         def _parse_egress(data: object) -> NetworkUpdatePayloadEgressType0 | None | Unset:
             if data is None:
                 return data
@@ -72,12 +89,15 @@ class NetworkUpdatePayload:
                     raise TypeError()
                 egress_type_0 = NetworkUpdatePayloadEgressType0(data)
 
+
+
                 return egress_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(NetworkUpdatePayloadEgressType0 | None | Unset, data)
 
         egress = _parse_egress(d.pop("egress", UNSET))
+
 
         def _parse_private_network_throughput_mibps(data: object) -> int | None | Unset:
             if data is None:
@@ -86,9 +106,8 @@ class NetworkUpdatePayload:
                 return data
             return cast(int | None | Unset, data)
 
-        private_network_throughput_mibps = _parse_private_network_throughput_mibps(
-            d.pop("private_network_throughput_mibps", UNSET)
-        )
+        private_network_throughput_mibps = _parse_private_network_throughput_mibps(d.pop("private_network_throughput_mibps", UNSET))
+
 
         def _parse_public_network_throughput_mibps(data: object) -> int | None | Unset:
             if data is None:
@@ -97,9 +116,8 @@ class NetworkUpdatePayload:
                 return data
             return cast(int | None | Unset, data)
 
-        public_network_throughput_mibps = _parse_public_network_throughput_mibps(
-            d.pop("public_network_throughput_mibps", UNSET)
-        )
+        public_network_throughput_mibps = _parse_public_network_throughput_mibps(d.pop("public_network_throughput_mibps", UNSET))
+
 
         network_update_payload = cls(
             egress=egress,
@@ -108,3 +126,4 @@ class NetworkUpdatePayload:
         )
 
         return network_update_payload
+

--- a/clients/atlas/atlas/models/network_update_payload_egress_type_0.py
+++ b/clients/atlas/atlas/models/network_update_payload_egress_type_0.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class NetworkUpdatePayloadEgressType0(StrEnum):
     MESH = "mesh"
     NONE = "none"

--- a/clients/atlas/atlas/models/page_image_response.py
+++ b/clients/atlas/atlas/models/page_image_response.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 if TYPE_CHECKING:
-    from ..models.image_response import ImageResponse
+  from ..models.image_response import ImageResponse
+
+
+
 
 
 T = TypeVar("T", bound="PageImageResponse")
 
 
+
 @_attrs_define
 class PageImageResponse:
-    """
-    Attributes:
-        has_more (bool):
-        items (list[ImageResponse]):
-        limit (int):
-        offset (int):
-    """
+    """ 
+        Attributes:
+            has_more (bool):
+            items (list[ImageResponse]):
+            limit (int):
+            offset (int):
+     """
 
     has_more: bool
     items: list[ImageResponse]
@@ -29,7 +37,12 @@ class PageImageResponse:
     offset: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.image_response import ImageResponse # noqa: PLC0415
         has_more = self.has_more
 
         items = []
@@ -37,36 +50,41 @@ class PageImageResponse:
             items_item = items_item_data.to_dict()
             items.append(items_item)
 
+
+
         limit = self.limit
 
         offset = self.offset
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "has_more": has_more,
-                "items": items,
-                "limit": limit,
-                "offset": offset,
-            }
-        )
+        field_dict.update({
+            "has_more": has_more,
+            "items": items,
+            "limit": limit,
+            "offset": offset,
+        })
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.image_response import ImageResponse  # noqa: PLC0415
-
+        from ..models.image_response import ImageResponse # noqa: PLC0415
         d = dict(src_dict)
         has_more = d.pop("has_more")
 
         items = []
         _items = d.pop("items")
-        for items_item_data in _items:
+        for items_item_data in (_items):
             items_item = ImageResponse.from_dict(items_item_data)
 
+
+
             items.append(items_item)
+
 
         limit = d.pop("limit")
 
@@ -78,6 +96,7 @@ class PageImageResponse:
             limit=limit,
             offset=offset,
         )
+
 
         page_image_response.additional_properties = d
         return page_image_response

--- a/clients/atlas/atlas/models/page_ip_address_response.py
+++ b/clients/atlas/atlas/models/page_ip_address_response.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 if TYPE_CHECKING:
-    from ..models.ip_address_response import IPAddressResponse
+  from ..models.ip_address_response import IPAddressResponse
+
+
+
 
 
 T = TypeVar("T", bound="PageIPAddressResponse")
 
 
+
 @_attrs_define
 class PageIPAddressResponse:
-    """
-    Attributes:
-        has_more (bool):
-        items (list[IPAddressResponse]):
-        limit (int):
-        offset (int):
-    """
+    """ 
+        Attributes:
+            has_more (bool):
+            items (list[IPAddressResponse]):
+            limit (int):
+            offset (int):
+     """
 
     has_more: bool
     items: list[IPAddressResponse]
@@ -29,7 +37,12 @@ class PageIPAddressResponse:
     offset: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.ip_address_response import IPAddressResponse # noqa: PLC0415
         has_more = self.has_more
 
         items = []
@@ -37,36 +50,41 @@ class PageIPAddressResponse:
             items_item = items_item_data.to_dict()
             items.append(items_item)
 
+
+
         limit = self.limit
 
         offset = self.offset
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "has_more": has_more,
-                "items": items,
-                "limit": limit,
-                "offset": offset,
-            }
-        )
+        field_dict.update({
+            "has_more": has_more,
+            "items": items,
+            "limit": limit,
+            "offset": offset,
+        })
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.ip_address_response import IPAddressResponse  # noqa: PLC0415
-
+        from ..models.ip_address_response import IPAddressResponse # noqa: PLC0415
         d = dict(src_dict)
         has_more = d.pop("has_more")
 
         items = []
         _items = d.pop("items")
-        for items_item_data in _items:
+        for items_item_data in (_items):
             items_item = IPAddressResponse.from_dict(items_item_data)
 
+
+
             items.append(items_item)
+
 
         limit = d.pop("limit")
 
@@ -78,6 +96,7 @@ class PageIPAddressResponse:
             limit=limit,
             offset=offset,
         )
+
 
         page_ip_address_response.additional_properties = d
         return page_ip_address_response

--- a/clients/atlas/atlas/models/page_virtual_machine_list_response.py
+++ b/clients/atlas/atlas/models/page_virtual_machine_list_response.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 if TYPE_CHECKING:
-    from ..models.virtual_machine_list_response import VirtualMachineListResponse
+  from ..models.virtual_machine_list_response import VirtualMachineListResponse
+
+
+
 
 
 T = TypeVar("T", bound="PageVirtualMachineListResponse")
 
 
+
 @_attrs_define
 class PageVirtualMachineListResponse:
-    """
-    Attributes:
-        has_more (bool):
-        items (list[VirtualMachineListResponse]):
-        limit (int):
-        offset (int):
-    """
+    """ 
+        Attributes:
+            has_more (bool):
+            items (list[VirtualMachineListResponse]):
+            limit (int):
+            offset (int):
+     """
 
     has_more: bool
     items: list[VirtualMachineListResponse]
@@ -29,7 +37,12 @@ class PageVirtualMachineListResponse:
     offset: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
+
+
+
+
     def to_dict(self) -> dict[str, Any]:
+        from ..models.virtual_machine_list_response import VirtualMachineListResponse # noqa: PLC0415
         has_more = self.has_more
 
         items = []
@@ -37,36 +50,41 @@ class PageVirtualMachineListResponse:
             items_item = items_item_data.to_dict()
             items.append(items_item)
 
+
+
         limit = self.limit
 
         offset = self.offset
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "has_more": has_more,
-                "items": items,
-                "limit": limit,
-                "offset": offset,
-            }
-        )
+        field_dict.update({
+            "has_more": has_more,
+            "items": items,
+            "limit": limit,
+            "offset": offset,
+        })
 
         return field_dict
 
+
+
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.virtual_machine_list_response import VirtualMachineListResponse  # noqa: PLC0415
-
+        from ..models.virtual_machine_list_response import VirtualMachineListResponse # noqa: PLC0415
         d = dict(src_dict)
         has_more = d.pop("has_more")
 
         items = []
         _items = d.pop("items")
-        for items_item_data in _items:
+        for items_item_data in (_items):
             items_item = VirtualMachineListResponse.from_dict(items_item_data)
 
+
+
             items.append(items_item)
+
 
         limit = d.pop("limit")
 
@@ -78,6 +96,7 @@ class PageVirtualMachineListResponse:
             limit=limit,
             offset=offset,
         )
+
 
         page_virtual_machine_list_response.additional_properties = d
         return page_virtual_machine_list_response

--- a/clients/atlas/atlas/models/page_virtual_machine_list_response.py
+++ b/clients/atlas/atlas/models/page_virtual_machine_list_response.py
@@ -7,24 +7,24 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.virtual_machine_response import VirtualMachineResponse
+    from ..models.virtual_machine_list_response import VirtualMachineListResponse
 
 
-T = TypeVar("T", bound="PageVirtualMachineResponse")
+T = TypeVar("T", bound="PageVirtualMachineListResponse")
 
 
 @_attrs_define
-class PageVirtualMachineResponse:
+class PageVirtualMachineListResponse:
     """
     Attributes:
         has_more (bool):
-        items (list[VirtualMachineResponse]):
+        items (list[VirtualMachineListResponse]):
         limit (int):
         offset (int):
     """
 
     has_more: bool
-    items: list[VirtualMachineResponse]
+    items: list[VirtualMachineListResponse]
     limit: int
     offset: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -56,7 +56,7 @@ class PageVirtualMachineResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.virtual_machine_response import VirtualMachineResponse  # noqa: PLC0415
+        from ..models.virtual_machine_list_response import VirtualMachineListResponse  # noqa: PLC0415
 
         d = dict(src_dict)
         has_more = d.pop("has_more")
@@ -64,7 +64,7 @@ class PageVirtualMachineResponse:
         items = []
         _items = d.pop("items")
         for items_item_data in _items:
-            items_item = VirtualMachineResponse.from_dict(items_item_data)
+            items_item = VirtualMachineListResponse.from_dict(items_item_data)
 
             items.append(items_item)
 
@@ -72,15 +72,15 @@ class PageVirtualMachineResponse:
 
         offset = d.pop("offset")
 
-        page_virtual_machine_response = cls(
+        page_virtual_machine_list_response = cls(
             has_more=has_more,
             items=items,
             limit=limit,
             offset=offset,
         )
 
-        page_virtual_machine_response.additional_properties = d
-        return page_virtual_machine_response
+        page_virtual_machine_list_response.additional_properties = d
+        return page_virtual_machine_list_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/clients/atlas/atlas/models/reserve_ip_address_payload.py
+++ b/clients/atlas/atlas/models/reserve_ip_address_payload.py
@@ -1,51 +1,73 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 from ..models.reserve_ip_address_payload_source import ReserveIPAddressPayloadSource
 from ..types import UNSET, Unset
 
+
+
+
+
+
 T = TypeVar("T", bound="ReserveIPAddressPayload")
+
 
 
 @_attrs_define
 class ReserveIPAddressPayload:
-    """Select the source of an IP address reservation.
+    """ Select the source of an IP address reservation.
 
-    Attributes:
-        source (ReserveIPAddressPayloadSource | Unset):  Default: ReserveIPAddressPayloadSource.POOL.
-    """
+        Attributes:
+            source (ReserveIPAddressPayloadSource | Unset):  Default: ReserveIPAddressPayloadSource.POOL.
+     """
 
     source: ReserveIPAddressPayloadSource | Unset = ReserveIPAddressPayloadSource.POOL
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         source: str | Unset = UNSET
         if not isinstance(self.source, Unset):
             source = self.source.value
 
+
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update({})
+        field_dict.update({
+        })
         if source is not UNSET:
             field_dict["source"] = source
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _source = d.pop("source", UNSET)
         source: ReserveIPAddressPayloadSource | Unset
-        if isinstance(_source, Unset):
+        if isinstance(_source,  Unset):
             source = UNSET
         else:
             source = ReserveIPAddressPayloadSource(_source)
+
+
+
 
         reserve_ip_address_payload = cls(
             source=source,
         )
 
         return reserve_ip_address_payload
+

--- a/clients/atlas/atlas/models/reserve_ip_address_payload_source.py
+++ b/clients/atlas/atlas/models/reserve_ip_address_payload_source.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-
 class ReserveIPAddressPayloadSource(StrEnum):
     POOL = "pool"
     PROVIDER = "provider"

--- a/clients/atlas/atlas/models/snapshot_payload.py
+++ b/clients/atlas/atlas/models/snapshot_payload.py
@@ -1,28 +1,41 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+
+
+
+
+
 
 T = TypeVar("T", bound="SnapshotPayload")
 
 
+
 @_attrs_define
 class SnapshotPayload:
-    """Values that create one Machine image from a virtual machine.
+    """ Values that create one Machine image from a virtual machine.
 
-    Attributes:
-        title (str):
-        cache_image (bool | Unset):  Default: False.
-        memory_snapshot (bool | Unset):  Default: False.
-    """
+        Attributes:
+            title (str):
+            cache_image (bool | Unset):  Default: False.
+            memory_snapshot (bool | Unset):  Default: False.
+     """
 
     title: str
     cache_image: bool | Unset = False
     memory_snapshot: bool | Unset = False
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         title = self.title
@@ -31,19 +44,20 @@ class SnapshotPayload:
 
         memory_snapshot = self.memory_snapshot
 
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "title": title,
-            }
-        )
+        field_dict.update({
+            "title": title,
+        })
         if cache_image is not UNSET:
             field_dict["cache_image"] = cache_image
         if memory_snapshot is not UNSET:
             field_dict["memory_snapshot"] = memory_snapshot
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -61,3 +75,4 @@ class SnapshotPayload:
         )
 
         return snapshot_payload
+

--- a/clients/atlas/atlas/models/ssh_keys_replacement_payload.py
+++ b/clients/atlas/atlas/models/ssh_keys_replacement_payload.py
@@ -1,43 +1,63 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+
+
+
+
 
 T = TypeVar("T", bound="SSHKeysReplacementPayload")
 
 
+
 @_attrs_define
 class SSHKeysReplacementPayload:
-    """The complete authorized key list.
+    """ The complete authorized key list.
 
-    Attributes:
-        ssh_keys (list[str]):
-    """
+        Attributes:
+            ssh_keys (list[str]):
+     """
 
     ssh_keys: list[str]
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         ssh_keys = self.ssh_keys
 
+
+
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "ssh_keys": ssh_keys,
-            }
-        )
+        field_dict.update({
+            "ssh_keys": ssh_keys,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         ssh_keys = cast(list[str], d.pop("ssh_keys"))
 
+
         ssh_keys_replacement_payload = cls(
             ssh_keys=ssh_keys,
         )
 
         return ssh_keys_replacement_payload
+

--- a/clients/atlas/atlas/models/virtual_machine_detail_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_detail_response.py
@@ -1,29 +1,39 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
+
+
+
+
+
 T = TypeVar("T", bound="VirtualMachineDetailResponse")
+
 
 
 @_attrs_define
 class VirtualMachineDetailResponse:
-    """A stored virtual machine with its live host state.
+    """ A stored virtual machine with its live host state.
 
-    Attributes:
-        created_at (int):
-        current_state (str):
-        desired_state (None | str):
-        disk_mib (int):
-        id (str):
-        image_id (str):
-        memory_mib (int):
-        tenant_id (int):
-        vcpus (int):
-    """
+        Attributes:
+            created_at (int):
+            current_state (str):
+            desired_state (None | str):
+            disk_mib (int):
+            id (str):
+            image_id (str):
+            memory_mib (int):
+            tenant_id (int):
+            vcpus (int):
+     """
 
     created_at: int
     current_state: str
@@ -35,6 +45,10 @@ class VirtualMachineDetailResponse:
     tenant_id: int
     vcpus: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         created_at = self.created_at
@@ -56,23 +70,24 @@ class VirtualMachineDetailResponse:
 
         vcpus = self.vcpus
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "created_at": created_at,
-                "current_state": current_state,
-                "desired_state": desired_state,
-                "disk_mib": disk_mib,
-                "id": id,
-                "image_id": image_id,
-                "memory_mib": memory_mib,
-                "tenant_id": tenant_id,
-                "vcpus": vcpus,
-            }
-        )
+        field_dict.update({
+            "created_at": created_at,
+            "current_state": current_state,
+            "desired_state": desired_state,
+            "disk_mib": disk_mib,
+            "id": id,
+            "image_id": image_id,
+            "memory_mib": memory_mib,
+            "tenant_id": tenant_id,
+            "vcpus": vcpus,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -87,6 +102,7 @@ class VirtualMachineDetailResponse:
             return cast(None | str, data)
 
         desired_state = _parse_desired_state(d.pop("desired_state"))
+
 
         disk_mib = d.pop("disk_mib")
 
@@ -111,6 +127,7 @@ class VirtualMachineDetailResponse:
             tenant_id=tenant_id,
             vcpus=vcpus,
         )
+
 
         virtual_machine_detail_response.additional_properties = d
         return virtual_machine_detail_response

--- a/clients/atlas/atlas/models/virtual_machine_list_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_list_response.py
@@ -1,29 +1,39 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
+
+
+
+
+
 T = TypeVar("T", bound="VirtualMachineListResponse")
+
 
 
 @_attrs_define
 class VirtualMachineListResponse:
-    """A stored virtual machine with its last known host state.
+    """ A stored virtual machine with its last known host state.
 
-    Attributes:
-        created_at (int):
-        disk_mib (int):
-        id (str):
-        image_id (str):
-        last_known_state (str):
-        memory_mib (int):
-        state_synced_at (int | None):
-        tenant_id (int):
-        vcpus (int):
-    """
+        Attributes:
+            created_at (int):
+            disk_mib (int):
+            id (str):
+            image_id (str):
+            last_known_state (str):
+            memory_mib (int):
+            state_synced_at (int | None):
+            tenant_id (int):
+            vcpus (int):
+     """
 
     created_at: int
     disk_mib: int
@@ -35,6 +45,10 @@ class VirtualMachineListResponse:
     tenant_id: int
     vcpus: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         created_at = self.created_at
@@ -56,23 +70,24 @@ class VirtualMachineListResponse:
 
         vcpus = self.vcpus
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "created_at": created_at,
-                "disk_mib": disk_mib,
-                "id": id,
-                "image_id": image_id,
-                "last_known_state": last_known_state,
-                "memory_mib": memory_mib,
-                "state_synced_at": state_synced_at,
-                "tenant_id": tenant_id,
-                "vcpus": vcpus,
-            }
-        )
+        field_dict.update({
+            "created_at": created_at,
+            "disk_mib": disk_mib,
+            "id": id,
+            "image_id": image_id,
+            "last_known_state": last_known_state,
+            "memory_mib": memory_mib,
+            "state_synced_at": state_synced_at,
+            "tenant_id": tenant_id,
+            "vcpus": vcpus,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -96,6 +111,7 @@ class VirtualMachineListResponse:
 
         state_synced_at = _parse_state_synced_at(d.pop("state_synced_at"))
 
+
         tenant_id = d.pop("tenant_id")
 
         vcpus = d.pop("vcpus")
@@ -111,6 +127,7 @@ class VirtualMachineListResponse:
             tenant_id=tenant_id,
             vcpus=vcpus,
         )
+
 
         virtual_machine_list_response.additional_properties = d
         return virtual_machine_list_response

--- a/clients/atlas/atlas/models/virtual_machine_list_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_list_response.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VirtualMachineListResponse")
+
+
+@_attrs_define
+class VirtualMachineListResponse:
+    """A stored virtual machine with its last known host state.
+
+    Attributes:
+        created_at (int):
+        disk_mib (int):
+        id (str):
+        image_id (str):
+        last_known_state (str):
+        memory_mib (int):
+        state_synced_at (int | None):
+        tenant_id (int):
+        vcpus (int):
+    """
+
+    created_at: int
+    disk_mib: int
+    id: str
+    image_id: str
+    last_known_state: str
+    memory_mib: int
+    state_synced_at: int | None
+    tenant_id: int
+    vcpus: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        created_at = self.created_at
+
+        disk_mib = self.disk_mib
+
+        id = self.id
+
+        image_id = self.image_id
+
+        last_known_state = self.last_known_state
+
+        memory_mib = self.memory_mib
+
+        state_synced_at: int | None
+        state_synced_at = self.state_synced_at
+
+        tenant_id = self.tenant_id
+
+        vcpus = self.vcpus
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "created_at": created_at,
+                "disk_mib": disk_mib,
+                "id": id,
+                "image_id": image_id,
+                "last_known_state": last_known_state,
+                "memory_mib": memory_mib,
+                "state_synced_at": state_synced_at,
+                "tenant_id": tenant_id,
+                "vcpus": vcpus,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        created_at = d.pop("created_at")
+
+        disk_mib = d.pop("disk_mib")
+
+        id = d.pop("id")
+
+        image_id = d.pop("image_id")
+
+        last_known_state = d.pop("last_known_state")
+
+        memory_mib = d.pop("memory_mib")
+
+        def _parse_state_synced_at(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        state_synced_at = _parse_state_synced_at(d.pop("state_synced_at"))
+
+        tenant_id = d.pop("tenant_id")
+
+        vcpus = d.pop("vcpus")
+
+        virtual_machine_list_response = cls(
+            created_at=created_at,
+            disk_mib=disk_mib,
+            id=id,
+            image_id=image_id,
+            last_known_state=last_known_state,
+            memory_mib=memory_mib,
+            state_synced_at=state_synced_at,
+            tenant_id=tenant_id,
+            vcpus=vcpus,
+        )
+
+        virtual_machine_list_response.additional_properties = d
+        return virtual_machine_list_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/atlas/atlas/models/virtual_machine_response.py
+++ b/clients/atlas/atlas/models/virtual_machine_response.py
@@ -1,27 +1,36 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
 T = TypeVar("T", bound="VirtualMachineResponse")
+
 
 
 @_attrs_define
 class VirtualMachineResponse:
-    """A stored tenant virtual machine.
+    """ A stored tenant virtual machine.
 
-    Attributes:
-        created_at (int):
-        disk_mib (int):
-        id (str):
-        image_id (str):
-        memory_mib (int):
-        tenant_id (int):
-        vcpus (int):
-    """
+        Attributes:
+            created_at (int):
+            disk_mib (int):
+            id (str):
+            image_id (str):
+            memory_mib (int):
+            tenant_id (int):
+            vcpus (int):
+     """
 
     created_at: int
     disk_mib: int
@@ -31,6 +40,10 @@ class VirtualMachineResponse:
     tenant_id: int
     vcpus: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
 
     def to_dict(self) -> dict[str, Any]:
         created_at = self.created_at
@@ -47,21 +60,22 @@ class VirtualMachineResponse:
 
         vcpus = self.vcpus
 
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "created_at": created_at,
-                "disk_mib": disk_mib,
-                "id": id,
-                "image_id": image_id,
-                "memory_mib": memory_mib,
-                "tenant_id": tenant_id,
-                "vcpus": vcpus,
-            }
-        )
+        field_dict.update({
+            "created_at": created_at,
+            "disk_mib": disk_mib,
+            "id": id,
+            "image_id": image_id,
+            "memory_mib": memory_mib,
+            "tenant_id": tenant_id,
+            "vcpus": vcpus,
+        })
 
         return field_dict
+
+
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
@@ -89,6 +103,7 @@ class VirtualMachineResponse:
             tenant_id=tenant_id,
             vcpus=vcpus,
         )
+
 
         virtual_machine_response.additional_properties = d
         return virtual_machine_response

--- a/clients/atlas/atlas/types.py
+++ b/clients/atlas/atlas/types.py
@@ -1,8 +1,8 @@
-"""Contains some shared types for properties"""
+""" Contains some shared types for properties """
 
 from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import IO, BinaryIO, Generic, Literal, TypeVar
+from typing import BinaryIO, Generic, TypeVar, Literal, IO
 
 from attrs import define
 
@@ -24,17 +24,16 @@ FileTypes = (
 )
 RequestFiles = list[tuple[str, FileTypes]]
 
-
 @define
 class File:
-    """Contains information for file uploads"""
+    """ Contains information for file uploads """
 
     payload: BinaryIO
     file_name: str | None = None
     mime_type: str | None = None
 
     def to_tuple(self) -> FileTypes:
-        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        """ Return a tuple representation that httpx will accept for multipart/form-data """
         return self.file_name, self.payload, self.mime_type
 
 
@@ -43,7 +42,7 @@ T = TypeVar("T")
 
 @define
 class Response(Generic[T]):
-    """A response from an endpoint"""
+    """ A response from an endpoint """
 
     status_code: HTTPStatus
     content: bytes

--- a/clients/openapi/atlas.json
+++ b/clients/openapi/atlas.json
@@ -632,7 +632,7 @@
         "title": "Page[ImageResponse]",
         "type": "object"
       },
-      "Page[VirtualMachineResponse]": {
+      "Page[VirtualMachineListResponse]": {
         "examples": [
           {
             "has_more": false,
@@ -648,7 +648,7 @@
           },
           "items": {
             "items": {
-              "$ref": "#/components/schemas/VirtualMachineResponse"
+              "$ref": "#/components/schemas/VirtualMachineListResponse"
             },
             "title": "Items",
             "type": "array"
@@ -668,7 +668,7 @@
           "limit",
           "has_more"
         ],
-        "title": "Page[VirtualMachineResponse]",
+        "title": "Page[VirtualMachineListResponse]",
         "type": "object"
       },
       "ReserveIPAddressPayload": {
@@ -804,6 +804,80 @@
           "current_state"
         ],
         "title": "VirtualMachineDetailResponse",
+        "type": "object"
+      },
+      "VirtualMachineListResponse": {
+        "description": "A stored virtual machine with its last known host state.",
+        "examples": [
+          {
+            "created_at": 1788834165,
+            "disk_mib": 20480,
+            "id": "vm-00001",
+            "image_id": "8f1c2d3e4b5a6978",
+            "last_known_state": "running",
+            "memory_mib": 2048,
+            "state_synced_at": 1788834165,
+            "tenant_id": 7,
+            "vcpus": 2
+          }
+        ],
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "disk_mib": {
+            "title": "Disk Mib",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "image_id": {
+            "title": "Image Id",
+            "type": "string"
+          },
+          "last_known_state": {
+            "title": "Last Known State",
+            "type": "string"
+          },
+          "memory_mib": {
+            "title": "Memory Mib",
+            "type": "integer"
+          },
+          "state_synced_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Synced At"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "integer"
+          },
+          "vcpus": {
+            "title": "Vcpus",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "tenant_id",
+          "image_id",
+          "vcpus",
+          "memory_mib",
+          "disk_mib",
+          "created_at",
+          "last_known_state",
+          "state_synced_at"
+        ],
+        "title": "VirtualMachineListResponse",
         "type": "object"
       },
       "VirtualMachineResponse": {
@@ -1279,7 +1353,7 @@
     },
     "/api/atlas/virtual-machines": {
       "get": {
-        "description": "Returns one page of tenant VM records in newest-first order. This request does not contact the host.",
+        "description": "Returns one page of tenant VM records in newest-first order, with the state each host last reported. This request does not contact the host.",
         "operationId": "list_virtual_machines",
         "parameters": [
           {
@@ -1322,7 +1396,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Page[VirtualMachineResponse]"
+                  "$ref": "#/components/schemas/Page[VirtualMachineListResponse]"
                 }
               }
             },

--- a/docs/api-clients.md
+++ b/docs/api-clients.md
@@ -14,7 +14,7 @@ The `atlas` client package has the same name as the Frappe app package. Do not i
 `scripts/generate-api-client.py` writes the OpenAPI document and then the client. It imports the application and reads the specification in memory. A site, a database, and a running server are not necessary.
 
 ```bash
-pip install openapi-python-client==0.29.1 ruff==0.16.6
+pip install openapi-python-client==0.29.1
 ./scripts/generate-api-clients.sh
 ```
 
@@ -27,7 +27,7 @@ python scripts/generate-api-client.py atlas-http-proxy
 
 Commit the result. The `atlas` command needs `frappe` and the `atlas` app on the Python path, so run it from a bench environment. The `atlas-http-proxy` command needs the `atlas-proxy-control` package. It writes a temporary configuration file, because `proxy_control.main` loads its configuration at import time.
 
-The generator formats its output with the `ruff` that it finds on the path. Install the pinned version with the generator, or the result is different from the committed client.
+The generator uses no post hooks. It does not lint or format its output, so the committed client is the same for every environment.
 
 The client method names come from the OpenAPI operation IDs. Atlas uses the route function name. The HTTP proxy control daemon uses `generate_unique_id_function` to do the same.
 

--- a/docs/metal-v1-contract.md
+++ b/docs/metal-v1-contract.md
@@ -223,6 +223,8 @@ The snapshot status reports `pending`, `uploading`, `completing`, `completed`, o
 
 The response contains current host capacity. CPU, memory, storage, and virtual machine counts use complete field names and binary units.
 
+The response also contains `virtual_machines`. It maps each VM identifier on the host to an object with its last observed `status`. Metal reads the stored observed record of each VM, so the status is as fresh as the last reconcile pass.
+
 ## Errors
 
 Every HTTP error uses one safe object:

--- a/metal/internal/api/controller_sync.go
+++ b/metal/internal/api/controller_sync.go
@@ -26,9 +26,17 @@ type wireGuardPeerRequest struct {
 	Address   string `json:"address"`
 }
 
-// syncResponse returns host capacity in the same exchange as the sync.
+// syncResponse returns host capacity and virtual machine state in the same
+// exchange as the sync.
 type syncResponse struct {
 	Capacity capacityResponse `json:"capacity"`
+	// VirtualMachines maps a VM identifier to its last observed state.
+	VirtualMachines map[string]virtualMachineStateResponse `json:"virtual_machines"`
+}
+
+// virtualMachineStateResponse is the state of one virtual machine on this host.
+type virtualMachineStateResponse struct {
+	Status string `json:"status"`
 }
 
 // capacityResponse is what the controller needs to place the next VM.
@@ -78,7 +86,7 @@ func (s *Server) exchangeControllerState(c echo.Context) error {
 		}
 	}
 
-	capacity, err := s.hostService.Synchronize(c.Request().Context(), host.DesiredState{
+	result, err := s.hostService.Synchronize(c.Request().Context(), host.DesiredState{
 		WireGuardPeers: request.wireGuardPeers(), Images: request.imagePolicies(),
 		PrivilegedVirtualMachineAddresses: request.PrivilegedVMAddresses,
 	})
@@ -86,7 +94,10 @@ func (s *Server) exchangeControllerState(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, syncResponse{Capacity: capacityResponseFromHost(capacity)})
+	return c.JSON(http.StatusOK, syncResponse{
+		Capacity:        capacityResponseFromHost(result.Capacity),
+		VirtualMachines: virtualMachineStateResponses(result.VirtualMachineStates),
+	})
 }
 
 // imagePolicies converts the requested images into image policies.
@@ -123,4 +134,13 @@ func capacityResponseFromHost(capacity host.Capacity) capacityResponse {
 		TotalStorageMiB:     capacity.TotalStorageMiB,
 		AvailableStorageMiB: capacity.AvailableStorageMiB,
 	}
+}
+
+// virtualMachineStateResponses converts host states into the response form.
+func virtualMachineStateResponses(states map[string]vm.State) map[string]virtualMachineStateResponse {
+	responses := make(map[string]virtualMachineStateResponse, len(states))
+	for identifier, state := range states {
+		responses[identifier] = virtualMachineStateResponse{Status: string(state)}
+	}
+	return responses
 }

--- a/metal/internal/api/server.go
+++ b/metal/internal/api/server.go
@@ -35,7 +35,7 @@ type SnapshotStore interface {
 
 // HostService synchronizes controller-owned host state and reports capacity.
 type HostService interface {
-	Synchronize(context.Context, host.DesiredState) (host.Capacity, error)
+	Synchronize(context.Context, host.DesiredState) (host.SyncResult, error)
 	Capacity(context.Context) (host.Capacity, error)
 }
 

--- a/metal/internal/host/SPEC.md
+++ b/metal/internal/host/SPEC.md
@@ -12,8 +12,9 @@ Each set arrives complete and replaces the previous one. The controller sends no
 
 | Type | Responsibility |
 |---|---|
-| `Service` | Applies desired host state, then reports capacity. |
+| `Service` | Applies desired host state, then reports the sync result. |
 | `DesiredState` | The 3 controller-owned sets, each complete. |
+| `SyncResult` | What one sync returns: capacity and VM states. |
 | `Capacity` | What the controller needs to place the next VM. |
 | `PrivilegedMesh`, `WireGuardManager`, `ImagePolicyStore`, `VirtualMachineSource`, `StorageCapacitySource` | The services a sync calls out to. |
 
@@ -28,7 +29,8 @@ POST /v1/sync
    +-> Apply                      WireGuard peers
    +-> SetImagePolicies           image policies
    +-> Wake                       start a reconcile pass now
-   +-> Capacity                   returned in the same response
+   +-> List                       one read, used for capacity and states
+   +-> SyncResult                 returned in the same response
 ```
 
 The steps run in order and stop at the first error, so a failed step leaves the later sets untouched and the controller retries the whole sync. `Wake` follows the writes, so the reconciler acts on the new policies at once instead of at its next tick.
@@ -38,6 +40,10 @@ The steps run in order and stop at the first error, so a failed step leaves the 
 CPU is reported against reservations, not against host load: available CPU is the host count minus the virtual CPUs that existing VMs reserve, and it never goes below zero. The host may therefore be busy while CPU still reads as available.
 
 Memory and storage are read from the host instead. Available memory comes from `MemAvailable` in `/proc/meminfo`, which counts cache the kernel can reclaim. Free memory alone would understate what a new guest can use.
+
+## Virtual machine states
+
+`SyncResult.VirtualMachineStates` maps each VM identifier to its last observed state. The states come from the same `List` call that capacity uses, so the sync makes one read. `List` reads the stored observed record of each VM, which the reconciler writes. It does not inspect the runtime, so the state is as fresh as the last reconcile pass.
 
 ## Related
 

--- a/metal/internal/host/service.go
+++ b/metal/internal/host/service.go
@@ -18,6 +18,12 @@ type DesiredState struct {
 	PrivilegedVirtualMachineAddresses []string
 }
 
+// SyncResult contains what the controller reads back from one sync exchange.
+type SyncResult struct {
+	Capacity             Capacity
+	VirtualMachineStates map[string]vm.State
+}
+
 // Capacity contains current host compute and storage capacity.
 type Capacity struct {
 	TotalCPUCount       int
@@ -93,23 +99,38 @@ func NewService(dependencies Dependencies) (*Service, error) {
 	}, nil
 }
 
-// Synchronize applies controller-owned state and returns current capacity. Each
+// Synchronize applies controller-owned state and returns the sync result. Each
 // set is replaced in full, so the controller never sends incremental changes.
-func (service *Service) Synchronize(ctx context.Context, desired DesiredState) (Capacity, error) {
+func (service *Service) Synchronize(ctx context.Context, desired DesiredState) (SyncResult, error) {
 	addresses := desired.PrivilegedVirtualMachineAddresses
 	if err := service.mesh.ApplyPrivilegedAddresses(ctx, addresses); err != nil {
-		return Capacity{}, fmt.Errorf("apply privileged virtual machine addresses: %w", err)
+		return SyncResult{}, fmt.Errorf("apply privileged virtual machine addresses: %w", err)
 	}
 	if err := service.wireGuard.Apply(ctx, desired.WireGuardPeers); err != nil {
-		return Capacity{}, fmt.Errorf("apply WireGuard peers: %w", err)
+		return SyncResult{}, fmt.Errorf("apply WireGuard peers: %w", err)
 	}
 	if err := service.images.SetImagePolicies(ctx, desired.Images); err != nil {
-		return Capacity{}, fmt.Errorf("apply image policies: %w", err)
+		return SyncResult{}, fmt.Errorf("apply image policies: %w", err)
 	}
 
 	service.wake()
 
-	return service.Capacity(ctx)
+	virtualMachines, err := service.virtualMachines.List(ctx)
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("list virtual machine reservations: %w", err)
+	}
+
+	capacity, err := service.capacityOf(ctx, virtualMachines)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	states := make(map[string]vm.State, len(virtualMachines))
+	for _, information := range virtualMachines {
+		states[information.ID] = information.State
+	}
+
+	return SyncResult{Capacity: capacity, VirtualMachineStates: states}, nil
 }
 
 // Capacity returns current host capacity and valid VM reservations. CPU is
@@ -120,6 +141,11 @@ func (service *Service) Capacity(ctx context.Context) (Capacity, error) {
 		return Capacity{}, fmt.Errorf("list virtual machine reservations: %w", err)
 	}
 
+	return service.capacityOf(ctx, virtualMachines)
+}
+
+// capacityOf reports capacity against reservations the caller already listed.
+func (service *Service) capacityOf(ctx context.Context, virtualMachines []vm.Information) (Capacity, error) {
 	reservedCPUCount := 0
 	for _, information := range virtualMachines {
 		reservedCPUCount += information.VirtualCPUCount

--- a/metal/internal/host/service_test.go
+++ b/metal/internal/host/service_test.go
@@ -43,7 +43,7 @@ func (dependencies *testHostDependencies) Capacity(context.Context) (storage.Cap
 
 func TestSynchronizeAppliesControllerStateAndReportsCapacity(t *testing.T) {
 	dependencies := &testHostDependencies{
-		virtualMachines: []vm.Information{{VirtualCPUCount: 2}},
+		virtualMachines: []vm.Information{{ID: "vm-00001", State: vm.StateRunning, VirtualCPUCount: 2}},
 	}
 	service, err := NewService(Dependencies{
 		Mesh: dependencies, WireGuard: dependencies, Images: dependencies,
@@ -59,7 +59,7 @@ func TestSynchronizeAppliesControllerStateAndReportsCapacity(t *testing.T) {
 		WireGuardPeers:                    []network.WireGuardPeer{{Node: "node-2"}},
 		Images:                            []vm.Image{{Name: "ubuntu"}},
 	}
-	capacity, err := service.Synchronize(t.Context(), desired)
+	result, err := service.Synchronize(t.Context(), desired)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,11 @@ func TestSynchronizeAppliesControllerStateAndReportsCapacity(t *testing.T) {
 	if dependencies.wakeCount != 1 {
 		t.Fatalf("wake count = %d, want 1", dependencies.wakeCount)
 	}
+	capacity := result.Capacity
 	if capacity.AvailableCPUCount != max(runtime.NumCPU()-2, 0) || capacity.TotalStorageMiB != 4096 || capacity.AvailableStorageMiB != 3072 {
 		t.Fatalf("capacity = %+v", capacity)
+	}
+	if result.VirtualMachineStates["vm-00001"] != vm.StateRunning {
+		t.Fatalf("virtual machine states = %+v", result.VirtualMachineStates)
 	}
 }

--- a/scripts/generate-api-client.py
+++ b/scripts/generate-api-client.py
@@ -77,7 +77,10 @@ class Client:
 		with tempfile.TemporaryDirectory() as directory:
 			configuration = Path(directory) / "config.yml"
 			configuration.write_text(
-				f"package_name_override: {self.package}\nproject_name_override: {self.name}\n"
+				f"package_name_override: {self.package}\n"
+				f"project_name_override: {self.name}\n"
+				# No post hooks. The generated client is not linted or formatted.
+				"post_hooks: []\n"
 			)
 			subprocess.run(
 				[

--- a/scripts/generate-api-clients.sh
+++ b/scripts/generate-api-clients.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GENERATE="$ROOT/scripts/generate-api-client.py"
 GENERATOR_VERSION="0.29.1"
-RUFF_VERSION="0.16.6"
 ATLAS_PYTHON="${ATLAS_PYTHON:-$ROOT/../../env/bin/python}"
 
 if [ ! -x "$ATLAS_PYTHON" ]; then
@@ -13,12 +12,7 @@ if [ ! -x "$ATLAS_PYTHON" ]; then
 fi
 
 if ! command -v openapi-python-client >/dev/null; then
-	echo "Install openapi-python-client==$GENERATOR_VERSION and ruff==$RUFF_VERSION." >&2
-	exit 1
-fi
-
-if ! command -v ruff >/dev/null; then
-	echo "Install ruff==$RUFF_VERSION. The generator formats its output with it." >&2
+	echo "Install openapi-python-client==$GENERATOR_VERSION." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
- For this, added a doctype `Virtual Machine State` doctype, where the state will be updated. It was to avoid lock issue with syncing and action on vm doc. Only the `/api/atlas` apis will merge the state.
- Another reason is that we can use framework's webhook feature to send event to central easily.

Additional changes -
- Don't run ruff on generated client. For the changes, need to re-generate the client.