### PR TITLE
feat(vm): Add the virtual machine sleep policy

### DIFF
--- a/atlas/api/models.py
+++ b/atlas/api/models.py
@@ -204,6 +204,8 @@ class CreateVirtualMachinePayload(StrictModel):
 	metadata: dict[str, str] = Field(default_factory=dict)
 	ip_address_id: str | None = None
 	egress: EgressMode = "uplink"
+	is_sleepy: bool = False
+	idle_timeout_seconds: int = Field(default=0, ge=0)
 	disk_throughput_mibps: int = Field(default=0, ge=0)
 	disk_iops: int = Field(default=0, ge=0)
 	private_network_throughput_mibps: int = Field(default=0, ge=0)
@@ -224,6 +226,8 @@ class CreateVirtualMachinePayload(StrictModel):
 			user_data=self.user_data,
 			metadata=self.metadata,
 			egress=self.egress,
+			is_sleepy=self.is_sleepy,
+			idle_timeout_seconds=self.idle_timeout_seconds,
 			disk_throughput_mibps=self.disk_throughput_mibps,
 			disk_iops=self.disk_iops,
 			private_network_throughput_mibps=self.private_network_throughput_mibps,
@@ -233,10 +237,12 @@ class CreateVirtualMachinePayload(StrictModel):
 
 
 class ComputeUpdatePayload(PatchPayload):
-	"""New CPU and memory values for a stopped virtual machine."""
+	"""New CPU shape, memory shape, and sleep policy."""
 
 	vcpus: int | None = Field(default=None, gt=0)
 	memory_mib: int | None = Field(default=None, gt=0)
+	is_sleepy: bool | None = None
+	idle_timeout_seconds: int | None = Field(default=None, ge=0)
 
 	def to_domain_changes(self) -> dict[str, Any]:
 		"""Return the field names that the VM service accepts."""

--- a/atlas/api/models.py
+++ b/atlas/api/models.py
@@ -238,6 +238,13 @@ class ComputeUpdatePayload(PatchPayload):
 	vcpus: int | None = Field(default=None, gt=0)
 	memory_mib: int | None = Field(default=None, gt=0)
 
+	def to_domain_changes(self) -> dict[str, Any]:
+		"""Return the field names that the VM service accepts."""
+		changes = self.model_dump(exclude_none=True)
+		if "vcpus" in changes:
+			changes["virtual_cpu_count"] = changes.pop("vcpus")
+		return changes
+
 
 class DiskUpdatePayload(PatchPayload):
 	"""New disk size and disk rate limits."""

--- a/atlas/api/routes/virtual_machines.py
+++ b/atlas/api/routes/virtual_machines.py
@@ -281,15 +281,17 @@ def create_virtual_machine_console_token(
 
 @virtual_machine_configuration.patch("<virtual_machine_id>/compute")
 @api_docs(
-	request_example={"vcpus": 4},
+	request_example={"vcpus": 4, "is_sleepy": True, "idle_timeout_seconds": 1800},
 	responses=ACCEPTED_RESPONSE,
 )
 def update_virtual_machine_compute(
 	virtual_machine_id: str, payload: ComputeUpdatePayload
 ) -> ApiResult[VirtualMachineResponse]:
-	"""Resize compute.
+	"""Update compute.
 
-	Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the change.
+	Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas changes the vCPU count or the memory size. A sleep policy change applies in any state.
+
+	With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. An idle timeout of 0 disables sleep.
 	"""
 	virtual_machine = get_owned_virtual_machine(virtual_machine_id)
 	virtual_machine.update_compute(payload.to_domain_changes())

--- a/atlas/api/routes/virtual_machines.py
+++ b/atlas/api/routes/virtual_machines.py
@@ -292,7 +292,7 @@ def update_virtual_machine_compute(
 	Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the change.
 	"""
 	virtual_machine = get_owned_virtual_machine(virtual_machine_id)
-	virtual_machine.update_compute(payload.vcpus, payload.memory_mib)
+	virtual_machine.update_compute(payload.to_domain_changes())
 	return ApiResult(VirtualMachineResponse.from_document(virtual_machine), status=202)
 
 

--- a/atlas/api/routes/virtual_machines.py
+++ b/atlas/api/routes/virtual_machines.py
@@ -289,9 +289,9 @@ def update_virtual_machine_compute(
 ) -> ApiResult[VirtualMachineResponse]:
 	"""Update compute.
 
-	Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas changes the vCPU count or the memory size. A sleep policy change applies in any state.
+	Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or memory change. A sleep policy change applies in any state.
 
-	With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. An idle timeout of 0 disables sleep.
+	With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. 0 disables sleep.
 	"""
 	virtual_machine = get_owned_virtual_machine(virtual_machine_id)
 	virtual_machine.update_compute(payload.to_domain_changes())

--- a/atlas/api/routes/virtual_machines.py
+++ b/atlas/api/routes/virtual_machines.py
@@ -289,9 +289,9 @@ def update_virtual_machine_compute(
 ) -> ApiResult[VirtualMachineResponse]:
 	"""Update compute.
 
-	Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or memory change. A sleep policy change applies in any state.
+	Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a stopped VM.
 
-	With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. 0 disables sleep.
+	With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and wakes it on the next packet. 0 disables sleep.
 	"""
 	virtual_machine = get_owned_virtual_machine(virtual_machine_id)
 	virtual_machine.update_compute(payload.to_domain_changes())

--- a/atlas/api/tests/test_virtual_machines.py
+++ b/atlas/api/tests/test_virtual_machines.py
@@ -250,6 +250,23 @@ class TestVirtualMachineConfiguration(UnitTestCase):
 		self.assertEqual(status, 202)
 		virtual_machine.update_compute.assert_called_once_with({"virtual_cpu_count": 4})
 
+	def test_a_sleep_policy_change_reaches_the_virtual_machine_method(self) -> None:
+		with (
+			api_request(
+				"PATCH",
+				"/api/atlas/virtual-machines/vm-00001/compute",
+				tenant_id=TENANT_ID,
+				json={"is_sleepy": True, "idle_timeout_seconds": 1800},
+			),
+			owned_document(virtual_machine := build_virtual_machine()),
+		):
+			status, _ = call_route(update_virtual_machine_compute, virtual_machine_id="vm-00001")
+
+		self.assertEqual(status, 202)
+		virtual_machine.update_compute.assert_called_once_with(
+			{"is_sleepy": True, "idle_timeout_seconds": 1800}
+		)
+
 	def test_a_patch_without_a_supported_field_is_rejected(self) -> None:
 		with (
 			api_request(

--- a/atlas/api/tests/test_virtual_machines.py
+++ b/atlas/api/tests/test_virtual_machines.py
@@ -233,7 +233,7 @@ class TestVirtualMachineConfiguration(UnitTestCase):
 
 		self.assertEqual(status, 202)
 		self.assertEqual(body["id"], "vm-00001")
-		virtual_machine.update_compute.assert_called_once_with(4, None)
+		virtual_machine.update_compute.assert_called_once_with({"virtual_cpu_count": 4})
 
 	def test_compute_change_keeps_the_value_that_is_absent(self) -> None:
 		with (
@@ -248,7 +248,7 @@ class TestVirtualMachineConfiguration(UnitTestCase):
 			status, _ = call_route(update_virtual_machine_compute, virtual_machine_id="vm-00001")
 
 		self.assertEqual(status, 202)
-		virtual_machine.update_compute.assert_called_once_with(4, None)
+		virtual_machine.update_compute.assert_called_once_with({"virtual_cpu_count": 4})
 
 	def test_a_patch_without_a_supported_field_is_rejected(self) -> None:
 		with (

--- a/atlas/vm/SPEC.md
+++ b/atlas/vm/SPEC.md
@@ -158,11 +158,9 @@ Active connections can stop when the public IPv4 address or the egress mode chan
 
 ## Sleep policy
 
-Metal can put an idle VM to sleep and wake it on the next network packet. The policy is per VM: `is_sleepy` allows automatic sleep, and `idle_timeout_seconds` is the idle time before sleep. An idle timeout of `0` disables sleep.
+`is_sleepy` allows the host to sleep an idle VM. `idle_timeout_seconds` is the idle time before sleep, and `0` disables it. Set both during creation or with the Edit Sleep Policy action.
 
-The policy is intent, not machine shape, so Metal accepts a change in any state. Atlas reads both values through to Metal and sets them with the Edit Sleep Policy action or during creation.
-
-`PUT /v1/vms/{name}/compute` replaces the complete compute object, so Atlas reads the desired compute object, applies the requested change, and sends every value. A vCPU or memory change still needs a stopped VM.
+`PUT /v1/vms/{name}/compute` replaces the complete compute object, so Atlas reads the desired compute object, applies the change, and sends every value. Only a vCPU or memory change needs a stopped VM.
 
 ## Disk limits
 

--- a/atlas/vm/SPEC.md
+++ b/atlas/vm/SPEC.md
@@ -156,6 +156,14 @@ A public IPv4 address needs `uplink`. Atlas refuses `mesh` and `none` while an a
 
 Active connections can stop when the public IPv4 address or the egress mode changes.
 
+## Sleep policy
+
+Metal can put an idle VM to sleep and wake it on the next network packet. The policy is per VM: `is_sleepy` allows automatic sleep, and `idle_timeout_seconds` is the idle time before sleep. An idle timeout of `0` disables sleep.
+
+The policy is intent, not machine shape, so Metal accepts a change in any state. Atlas reads both values through to Metal and sets them with the Edit Sleep Policy action or during creation.
+
+`PUT /v1/vms/{name}/compute` replaces the complete compute object, so Atlas reads the desired compute object, applies the requested change, and sends every value. A vCPU or memory change still needs a stopped VM.
+
 ## Disk limits
 
 The VM configuration can set `disk_throughput_mibps` and `disk_iops`. Each limit covers reads and writes together. A value of `0` does not apply a limit.

--- a/atlas/vm/SPEC.md
+++ b/atlas/vm/SPEC.md
@@ -158,9 +158,9 @@ Active connections can stop when the public IPv4 address or the egress mode chan
 
 ## Sleep policy
 
-`is_sleepy` allows the host to sleep an idle VM. `idle_timeout_seconds` is the idle time before sleep, and `0` disables it. Set both during creation or with the Edit Sleep Policy action.
+`is_sleepy` lets the host sleep an idle VM after `idle_timeout_seconds`. `0` disables sleep. Set both during creation or with the Edit Sleep Policy action.
 
-`PUT /v1/vms/{name}/compute` replaces the complete compute object, so Atlas reads the desired compute object, applies the change, and sends every value. Only a vCPU or memory change needs a stopped VM.
+`PUT /v1/vms/{name}/compute` replaces the complete compute object, so Atlas merges each change into the desired compute object. Only a vCPU or memory change needs a stopped VM.
 
 ## Disk limits
 

--- a/atlas/vm/core/metal_client.py
+++ b/atlas/vm/core/metal_client.py
@@ -170,13 +170,13 @@ class MetalClient:
 		return self._virtual_machine(response)
 
 	def set_virtual_machine_compute(
-		self, virtual_machine_id: str, virtual_cpu_count: int, memory_mib: int
+		self, virtual_machine_id: str, compute: dict[str, Any]
 	) -> MetalVirtualMachine:
-		"""Replace the desired CPU and memory for one stopped VM."""
+		"""Replace the complete desired compute object for one VM."""
 		response = self._request(
 			"PUT",
 			f"/v1/vms/{quote(virtual_machine_id, safe='')}/compute",
-			json={"virtual_cpu_count": virtual_cpu_count, "memory_mib": memory_mib},
+			json=compute,
 			expected_status=202,
 			uncertain_on_failure=True,
 		)

--- a/atlas/vm/core/metal_models.py
+++ b/atlas/vm/core/metal_models.py
@@ -6,10 +6,12 @@ from typing import Any
 
 @dataclass(frozen=True, slots=True)
 class MetalCompute:
-	"""Store the desired CPU and memory values."""
+	"""Store the desired CPU, memory, and sleep policy values."""
 
 	virtual_cpu_count: int
 	memory_mib: int
+	is_sleepy: bool
+	idle_timeout_seconds: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,6 +154,8 @@ def parse_desired_state(value: dict[str, Any]) -> MetalDesiredState:
 		compute=MetalCompute(
 			virtual_cpu_count=integer_field(compute, "virtual_cpu_count"),
 			memory_mib=integer_field(compute, "memory_mib"),
+			is_sleepy=boolean_field(compute, "is_sleepy"),
+			idle_timeout_seconds=integer_field(compute, "idle_timeout_seconds"),
 		),
 		disk=MetalDisk(
 			size_mib=integer_field(disk, "size_mib"),

--- a/atlas/vm/core/models.py
+++ b/atlas/vm/core/models.py
@@ -96,7 +96,7 @@ class VirtualMachineCreateRequest:
 
 	@staticmethod
 	def non_negative_integer(payload: dict[str, Any], field_name: str) -> int:
-		"""Return one optional whole number. An absent value is 0."""
+		"""Return one optional non-negative integer."""
 		value = payload.get(field_name) or 0
 		if not isinstance(value, int) or isinstance(value, bool) or value < 0:
 			raise ValueError(f"{field_name} must be a non-negative integer.")

--- a/atlas/vm/core/models.py
+++ b/atlas/vm/core/models.py
@@ -24,6 +24,8 @@ class VirtualMachineCreateRequest:
 	ssh_keys: tuple[str, ...] = ()
 	user_data: str = ""
 	egress: str = "uplink"
+	is_sleepy: bool = False
+	idle_timeout_seconds: int = 0
 	disk_throughput_mibps: int = 0
 	disk_iops: int = 0
 	private_network_throughput_mibps: int = 0
@@ -53,7 +55,7 @@ class VirtualMachineCreateRequest:
 		if egress not in EGRESS_MODES:
 			raise ValueError("Egress must be uplink, mesh, or none.")
 
-		public_network_throughput_mibps = cls.throughput(payload, "public_network_throughput_mibps")
+		public_network_throughput_mibps = cls.non_negative_integer(payload, "public_network_throughput_mibps")
 		server_ip_address = payload.get("server_ip_address") or None
 		if egress != "uplink" and server_ip_address:
 			raise ValueError("A public IPv4 address requires uplink egress.")
@@ -69,9 +71,13 @@ class VirtualMachineCreateRequest:
 			ssh_keys=cls.ssh_keys_tuple(payload),
 			user_data=str(payload.get("user_data") or ""),
 			egress=egress,
-			disk_throughput_mibps=cls.throughput(payload, "disk_throughput_mibps"),
-			disk_iops=cls.throughput(payload, "disk_iops"),
-			private_network_throughput_mibps=cls.throughput(payload, "private_network_throughput_mibps"),
+			is_sleepy=strict_bool(payload.get("is_sleepy"), "is_sleepy"),
+			idle_timeout_seconds=cls.non_negative_integer(payload, "idle_timeout_seconds"),
+			disk_throughput_mibps=cls.non_negative_integer(payload, "disk_throughput_mibps"),
+			disk_iops=cls.non_negative_integer(payload, "disk_iops"),
+			private_network_throughput_mibps=cls.non_negative_integer(
+				payload, "private_network_throughput_mibps"
+			),
 			public_network_throughput_mibps=public_network_throughput_mibps,
 			server_ip_address=server_ip_address,
 			metadata=cls.metadata_map(payload),
@@ -89,8 +95,8 @@ class VirtualMachineCreateRequest:
 		return tuple(key.strip() for key in value if key.strip())
 
 	@staticmethod
-	def throughput(payload: dict[str, Any], field_name: str) -> int:
-		"""Return one throughput limit in MiB/s. A value of 0 applies no limit."""
+	def non_negative_integer(payload: dict[str, Any], field_name: str) -> int:
+		"""Return one optional whole number. An absent value is 0."""
 		value = payload.get(field_name) or 0
 		if not isinstance(value, int) or isinstance(value, bool) or value < 0:
 			raise ValueError(f"{field_name} must be a non-negative integer.")

--- a/atlas/vm/core/test_metal_models.py
+++ b/atlas/vm/core/test_metal_models.py
@@ -17,7 +17,12 @@ def complete_response() -> dict:
 			"generation": 3,
 			"restart_generation": 1,
 			"state": "running",
-			"compute": {"virtual_cpu_count": 2, "memory_mib": 2048},
+			"compute": {
+				"virtual_cpu_count": 2,
+				"memory_mib": 2048,
+				"is_sleepy": True,
+				"idle_timeout_seconds": 1800,
+			},
 			"disk": {"size_mib": 8192, "throughput_mibps": 100, "iops": 500},
 			"image": {
 				"ref": "ubuntu",
@@ -65,7 +70,12 @@ def new_virtual_machine_response() -> dict:
 			"generation": 1,
 			"restart_generation": 0,
 			"state": "running",
-			"compute": {"virtual_cpu_count": 0, "memory_mib": 0},
+			"compute": {
+				"virtual_cpu_count": 0,
+				"memory_mib": 0,
+				"is_sleepy": False,
+				"idle_timeout_seconds": 0,
+			},
 			"disk": {"size_mib": 0, "throughput_mibps": 0, "iops": 0},
 			"image": {
 				"ref": "ubuntu",
@@ -100,6 +110,8 @@ class TestMetalVirtualMachineParsing(UnitTestCase):
 
 		self.assertEqual(machine.id, "VM-00001")
 		self.assertEqual(machine.desired.compute.virtual_cpu_count, 2)
+		self.assertTrue(machine.desired.compute.is_sleepy)
+		self.assertEqual(machine.desired.compute.idle_timeout_seconds, 1800)
 		self.assertEqual(machine.desired.image.rootfs.sha256, "a" * 64)
 		self.assertEqual(machine.desired.guest.ssh_keys, ("ssh-ed25519 AAAA",))
 		self.assertEqual(machine.desired.guest.metadata, {"role": "web"})
@@ -172,6 +184,11 @@ class TestMetalContract(UnitTestCase):
 			definitions,
 			"api.desiredVirtualMachineResponse",
 			{"generation", "restart_generation", "state", "compute", "disk", "image", "network", "guest"},
+		)
+		self.assert_has_fields(
+			definitions,
+			"api.computeResponse",
+			{"virtual_cpu_count", "memory_mib", "is_sleepy", "idle_timeout_seconds"},
 		)
 		self.assert_has_fields(
 			definitions,

--- a/atlas/vm/core/test_vm_service.py
+++ b/atlas/vm/core/test_vm_service.py
@@ -225,6 +225,77 @@ class TestVirtualMachineDisk(UnitTestCase):
 		set_disk.assert_not_called()
 
 
+class TestVirtualMachineCompute(UnitTestCase):
+	def build_service(self, observed_state: str = "running") -> tuple[VirtualMachineService, SimpleNamespace]:
+		"""Return a service whose host reports one desired compute object."""
+		virtual_machine = SimpleNamespace(name="VM-00001", db_set=Mock())
+		information = SimpleNamespace(
+			desired=SimpleNamespace(
+				compute=SimpleNamespace(
+					virtual_cpu_count=2,
+					memory_mib=2048,
+					is_sleepy=False,
+					idle_timeout_seconds=0,
+				)
+			),
+			observed=SimpleNamespace(state=observed_state),
+		)
+		return VirtualMachineService(virtual_machine), information
+
+	def test_a_sleep_policy_change_does_not_need_a_stopped_virtual_machine(self) -> None:
+		service, information = self.build_service("running")
+
+		with (
+			patch.object(service, "require_information", return_value=information),
+			patch.object(service, "set_compute", return_value={}) as set_compute,
+		):
+			service.update_compute({"is_sleepy": True, "idle_timeout_seconds": 1800})
+
+		set_compute.assert_called_once_with(
+			{
+				"virtual_cpu_count": 2,
+				"memory_mib": 2048,
+				"is_sleepy": True,
+				"idle_timeout_seconds": 1800,
+			}
+		)
+		service.virtual_machine.db_set.assert_not_called()
+
+	def test_a_shape_change_keeps_the_stored_sleep_policy(self) -> None:
+		"""Metal replaces the complete compute object, so a resize must resend the policy."""
+		service, information = self.build_service("stopped")
+		information.desired.compute.is_sleepy = True
+		information.desired.compute.idle_timeout_seconds = 1800
+
+		with (
+			patch.object(service, "require_information", return_value=information),
+			patch.object(service, "set_compute", return_value={}) as set_compute,
+		):
+			service.update_compute({"virtual_cpu_count": 4})
+
+		set_compute.assert_called_once_with(
+			{
+				"virtual_cpu_count": 4,
+				"memory_mib": 2048,
+				"is_sleepy": True,
+				"idle_timeout_seconds": 1800,
+			}
+		)
+		service.virtual_machine.db_set.assert_called_once_with({"vcpus": 4, "memory_mib": 2048})
+
+	def test_a_shape_change_needs_a_stopped_virtual_machine(self) -> None:
+		service, information = self.build_service("running")
+
+		with (
+			patch.object(service, "require_information", return_value=information),
+			patch.object(service, "set_compute") as set_compute,
+			self.assertRaises(frappe.ValidationError),
+		):
+			service.update_compute({"memory_mib": 4096})
+
+		set_compute.assert_not_called()
+
+
 class TestVirtualMachineNetworkChanges(UnitTestCase):
 	def build_service(self, attached: str | None) -> VirtualMachineService:
 		"""Return a service for a managed virtual machine."""

--- a/atlas/vm/core/vm_service.py
+++ b/atlas/vm/core/vm_service.py
@@ -130,6 +130,8 @@ class VirtualMachineService:
 			"compute": {
 				"virtual_cpu_count": request.virtual_cpu_count,
 				"memory_mib": request.memory_mib,
+				"is_sleepy": request.is_sleepy,
+				"idle_timeout_seconds": request.idle_timeout_seconds,
 			},
 			"disk": {
 				"size_mib": request.disk_mib,
@@ -228,14 +230,46 @@ class VirtualMachineService:
 			)
 		)
 
-	def set_compute(self, virtual_cpu_count: int, memory_mib: int) -> None:
-		"""Set compute values in Metal, then update Atlas request metadata."""
-		self.perform_metal_operation(
+	def set_compute(self, compute: dict[str, Any]) -> dict[str, Any]:
+		"""Set the complete compute values in Metal."""
+		information = self.perform_metal_operation(
 			lambda metal_client: metal_client.set_virtual_machine_compute(
-				cast(str, self.virtual_machine.name), virtual_cpu_count, memory_mib
+				cast(str, self.virtual_machine.name), compute
 			)
 		)
-		self.virtual_machine.db_set({"vcpus": virtual_cpu_count, "memory_mib": memory_mib})
+		return information.as_dict()
+
+	def update_compute(self, changes: dict[str, Any]) -> dict[str, Any]:
+		"""Apply selected compute changes and keep the stored shape in step.
+
+		Only a CPU or memory change needs a stopped VM. The sleep policy is
+		intent, not machine shape, so Metal accepts it in any state.
+		"""
+		information = self.require_information()
+		current_compute = information.desired.compute
+		request = {
+			"virtual_cpu_count": current_compute.virtual_cpu_count,
+			"memory_mib": current_compute.memory_mib,
+			"is_sleepy": current_compute.is_sleepy,
+			"idle_timeout_seconds": current_compute.idle_timeout_seconds,
+			**changes,
+		}
+		is_shape_changed = (
+			request["virtual_cpu_count"] != current_compute.virtual_cpu_count
+			or request["memory_mib"] != current_compute.memory_mib
+		)
+		if is_shape_changed and information.observed.state != "stopped":
+			frappe.throw(
+				_("Stop the Virtual Machine before you change its compute values."), exc=AtlasUserError
+			)
+
+		result = self.set_compute(request)
+		if is_shape_changed:
+			self.virtual_machine.db_set(
+				{"vcpus": request["virtual_cpu_count"], "memory_mib": request["memory_mib"]}
+			)
+
+		return result
 
 	def set_disk(self, size_mib: int, throughput_mibps: int, iops: int) -> dict[str, Any]:
 		"""Set the complete disk values in Metal."""

--- a/atlas/vm/core/vm_service.py
+++ b/atlas/vm/core/vm_service.py
@@ -240,11 +240,7 @@ class VirtualMachineService:
 		return information.as_dict()
 
 	def update_compute(self, changes: dict[str, Any]) -> dict[str, Any]:
-		"""Apply selected compute changes and keep the stored shape in step.
-
-		Only a CPU or memory change needs a stopped VM. The sleep policy is
-		intent, not machine shape, so Metal accepts it in any state.
-		"""
+		"""Apply selected compute changes. Only a shape change needs a stopped VM."""
 		information = self.require_information()
 		current_compute = information.desired.compute
 		request = {

--- a/atlas/vm/core/vm_service.py
+++ b/atlas/vm/core/vm_service.py
@@ -240,7 +240,7 @@ class VirtualMachineService:
 		return information.as_dict()
 
 	def update_compute(self, changes: dict[str, Any]) -> dict[str, Any]:
-		"""Apply selected compute changes. Only a shape change needs a stopped VM."""
+		"""Apply selected compute changes."""
 		information = self.require_information()
 		current_compute = information.desired.compute
 		request = {

--- a/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
@@ -224,6 +224,18 @@ class TestVirtualMachineRequest(UnitTestCase):
 			)
 
 
+class TestVirtualMachineDocument(UnitTestCase):
+	# Frappe reads every virtual field to build the new document template. A new
+	# record has no Server, so the Metal lookup must not run.
+	def test_new_document_reads_virtual_fields_without_a_server(self) -> None:
+		virtual_machine = frappe.new_doc("Virtual Machine")
+
+		self.assertIsNone(virtual_machine.get_metal_vm_info())
+		self.assertEqual(virtual_machine.current_state, "unknown")
+		self.assertIsNone(virtual_machine.desired_state)
+		self.assertFalse(virtual_machine.is_sleepy)
+
+
 class TestVirtualMachineService(UnitTestCase):
 	def test_machine_image_uses_its_own_artifacts(self) -> None:
 		request = VirtualMachineCreateRequest("machine-image", 2, 2048, 10240, 7)

--- a/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/test_virtual_machine.py
@@ -20,7 +20,12 @@ METAL_VIRTUAL_MACHINE_RESPONSE = {
 		"generation": 2,
 		"restart_generation": 1,
 		"state": "running",
-		"compute": {"virtual_cpu_count": 2, "memory_mib": 2048},
+		"compute": {
+			"virtual_cpu_count": 2,
+			"memory_mib": 2048,
+			"is_sleepy": True,
+			"idle_timeout_seconds": 1800,
+		},
 		"disk": {"size_mib": 2048, "throughput_mibps": 50, "iops": 2000},
 		"image": {
 			"ref": "ubuntu",
@@ -56,6 +61,14 @@ METAL_VIRTUAL_MACHINE_RESPONSE = {
 		"network": {"mac": "06:00:00:00:00:01"},
 		"error": None,
 	},
+}
+
+
+COMPUTE_REQUEST = {
+	"virtual_cpu_count": 2,
+	"memory_mib": 2048,
+	"is_sleepy": True,
+	"idle_timeout_seconds": 1800,
 }
 
 
@@ -251,7 +264,12 @@ class TestVirtualMachineService(UnitTestCase):
 
 		self.assertEqual(
 			metal_request["compute"],
-			{"virtual_cpu_count": 2, "memory_mib": 2048},
+			{
+				"virtual_cpu_count": 2,
+				"memory_mib": 2048,
+				"is_sleepy": False,
+				"idle_timeout_seconds": 0,
+			},
 		)
 		self.assertEqual(metal_request["disk"]["size_mib"], 10240)
 		self.assertEqual(metal_request["guest"]["ssh_keys"], [])
@@ -303,7 +321,7 @@ class TestMetalClient(UnitTestCase):
 			client.set_virtual_machine_power_state("VM-00001", "running")
 			client.request_virtual_machine_restart("VM-00001")
 			client.set_virtual_machine_disk("VM-00001", {"size_mib": 2048, "throughput_mibps": 0, "iops": 0})
-			client.set_virtual_machine_compute("VM-00001", 2, 2048)
+			client.set_virtual_machine_compute("VM-00001", COMPUTE_REQUEST)
 			client.delete_virtual_machine("VM-00001")
 
 		paths = [call.args[1] for call in request.call_args_list]
@@ -321,10 +339,7 @@ class TestMetalClient(UnitTestCase):
 			request.call_args_list[2].kwargs["json"],
 			{"size_mib": 2048, "throughput_mibps": 0, "iops": 0},
 		)
-		self.assertEqual(
-			request.call_args_list[3].kwargs["json"],
-			{"virtual_cpu_count": 2, "memory_mib": 2048},
-		)
+		self.assertEqual(request.call_args_list[3].kwargs["json"], COMPUTE_REQUEST)
 
 	def test_console_connection_builds_websocket_url(self) -> None:
 		client = MetalClient.__new__(MetalClient)
@@ -486,7 +501,7 @@ class TestMetalClient(UnitTestCase):
 			"metadata": lambda: client.replace_virtual_machine_metadata("VM-00001", {}),
 			"network": lambda: client.set_virtual_machine_network("VM-00001", {}),
 			"disk": lambda: client.set_virtual_machine_disk("VM-00001", {}),
-			"compute": lambda: client.set_virtual_machine_compute("VM-00001", 2, 2048),
+			"compute": lambda: client.set_virtual_machine_compute("VM-00001", COMPUTE_REQUEST),
 			"sync": lambda: client.sync([], [], []),
 		}
 
@@ -550,6 +565,8 @@ class TestMetalVirtualMachineModel(UnitTestCase):
 		self.assertEqual(virtual_machine.egress, "uplink")
 		self.assertEqual(virtual_machine.wireguard_mesh_ipv6, "fdaa:1::1")
 		self.assertEqual(virtual_machine.public_ipv4, "203.0.113.10")
+		self.assertTrue(virtual_machine.is_sleepy)
+		self.assertEqual(virtual_machine.idle_timeout_seconds, 1800)
 		self.assertEqual(virtual_machine.disk_throughput_mibps, 50)
 		self.assertEqual(virtual_machine.disk_iops, 2000)
 		self.assertEqual(virtual_machine.private_network_throughput_mibps, 100)

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -354,7 +354,6 @@ function showEditSleepPolicyDialog(frm) {
 				fieldtype: "Check",
 				label: __("Is Sleepy"),
 				default: frm.doc.is_sleepy,
-				description: __("The host sleeps an idle VM and wakes it on a network packet."),
 			},
 			{
 				fieldname: "idle_timeout_seconds",

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -360,6 +360,7 @@ function showEditSleepPolicyDialog(frm) {
 				fieldtype: "Int",
 				label: __("Idle Timeout (Seconds)"),
 				default: frm.doc.idle_timeout_seconds,
+				depends_on: "eval: doc.is_sleepy",
 				description: __("0 disables sleep."),
 			},
 		],

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.js
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.js
@@ -67,6 +67,11 @@ frappe.ui.form.on("Virtual Machine", {
 			);
 		}
 		frm.add_custom_button(
+			__("Edit Sleep Policy"),
+			() => showEditSleepPolicyDialog(frm),
+			__("Actions")
+		);
+		frm.add_custom_button(
 			__("Edit SSH Keys"),
 			() => showEditSSHKeysDialog(frm),
 			__("Actions")
@@ -338,6 +343,39 @@ function showResizeComputeDialog(frm) {
 				.then(() => frm.reload_doc()),
 		__("Resize Compute"),
 		__("Resize")
+	);
+}
+
+function showEditSleepPolicyDialog(frm) {
+	frappe.prompt(
+		[
+			{
+				fieldname: "is_sleepy",
+				fieldtype: "Check",
+				label: __("Is Sleepy"),
+				default: frm.doc.is_sleepy,
+				description: __("The host sleeps an idle VM and wakes it on a network packet."),
+			},
+			{
+				fieldname: "idle_timeout_seconds",
+				fieldtype: "Int",
+				label: __("Idle Timeout (Seconds)"),
+				default: frm.doc.idle_timeout_seconds,
+				description: __("0 disables sleep."),
+			},
+		],
+		(values) =>
+			frm
+				.call({
+					method: "update_sleep_policy",
+					doc: frm.doc,
+					args: values,
+					freeze: true,
+					freeze_message: __("Updating sleep policy..."),
+				})
+				.then(() => frm.reload_doc()),
+		__("Edit Sleep Policy"),
+		__("Save")
 	);
 }
 

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -129,6 +129,7 @@
    "show_description_on_click": 1
   },
   {
+   "depends_on": "eval: doc.is_sleepy",
    "description": "Idle time before sleep. 0 disables sleep.",
    "fieldname": "idle_timeout_seconds",
    "fieldtype": "Int",

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -19,6 +19,8 @@
   "section_break_compute_and_storage",
   "vcpus",
   "memory_mib",
+  "is_sleepy",
+  "idle_timeout_seconds",
   "column_break_compute",
   "disk_mib",
   "disk_throughput_mibps",
@@ -118,6 +120,24 @@
    "set_only_once": 1
   },
   {
+   "description": "Metal puts an idle VM to sleep and wakes it on a network packet.",
+   "fieldname": "is_sleepy",
+   "fieldtype": "Check",
+   "is_virtual": 1,
+   "label": "Is Sleepy",
+   "read_only": 1,
+   "show_description_on_click": 1
+  },
+  {
+   "description": "Idle time before sleep. 0 disables sleep.",
+   "fieldname": "idle_timeout_seconds",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Idle Timeout (Seconds)",
+   "read_only": 1,
+   "show_description_on_click": 1
+  },
+  {
    "fieldname": "disk_mib",
    "fieldtype": "Int",
    "label": "Disk (MiB)",
@@ -146,9 +166,9 @@
    "label": "Tenant ID",
    "read_only": 1,
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1,
-   "show_description_on_click": 1,
-   "search_index": 1
+   "show_description_on_click": 1
   },
   {
    "default": "0",
@@ -253,7 +273,7 @@
    "link_fieldname": "target"
   }
  ],
- "modified": "2026-09-07 22:00:01.466665",
+ "modified": "2026-09-09 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "VM",
  "name": "Virtual Machine",

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -120,7 +120,7 @@
    "set_only_once": 1
   },
   {
-   "description": "The host sleeps an idle VM and wakes it on a network packet.",
+   "description": "The host sleeps an idle VM and wakes it on a packet.",
    "fieldname": "is_sleepy",
    "fieldtype": "Check",
    "is_virtual": 1,

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.json
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.json
@@ -120,7 +120,7 @@
    "set_only_once": 1
   },
   {
-   "description": "Metal puts an idle VM to sleep and wakes it on a network packet.",
+   "description": "The host sleeps an idle VM and wakes it on a network packet.",
    "fieldname": "is_sleepy",
    "fieldtype": "Check",
    "is_virtual": 1,

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -136,6 +136,18 @@ class VirtualMachine(Document):
 		return self.public_ipv4
 
 	@property
+	def is_sleepy(self) -> bool:
+		"""Report whether Metal may put this idle VM to sleep."""
+		information = self.get_metal_vm_info()
+		return information.desired.compute.is_sleepy if information else False
+
+	@property
+	def idle_timeout_seconds(self) -> int:
+		"""Return the idle time before sleep. Zero disables sleep."""
+		information = self.get_metal_vm_info()
+		return information.desired.compute.idle_timeout_seconds if information else 0
+
+	@property
 	def disk_throughput_mibps(self) -> int:
 		"""Return the disk throughput limit. Zero applies no limit."""
 		information = self.get_metal_vm_info()
@@ -327,24 +339,33 @@ class VirtualMachine(Document):
 		return self.update_disk({"size_mib": int(disk_mib)})
 
 	@frappe.whitelist(methods=["POST"])
-	def resize_compute(self, vcpus: int, memory_mib: int) -> None:
+	def resize_compute(self, vcpus: int, memory_mib: int) -> dict[str, Any]:
 		"""Ask Metal to change this VM CPU and memory. The VM must be stopped."""
-		self.update_compute(int(vcpus), int(memory_mib))
+		return self.update_compute({"virtual_cpu_count": int(vcpus), "memory_mib": int(memory_mib)})
 
-	def update_compute(self, vcpus: int | None, memory_mib: int | None) -> None:
-		"""Change the VM CPU and memory when the VM is stopped."""
-		self.check_permission("write")
-		service = VirtualMachineService(self)
-		information = service.require_information()
-		if information.observed.state != "stopped":
-			frappe.throw(
-				_("Stop the Virtual Machine before you change its compute values."), exc=AtlasUserError
-			)
+	@frappe.whitelist(methods=["POST"])
+	def update_sleep_policy(self, is_sleepy: bool | int | str, idle_timeout_seconds: int) -> dict[str, Any]:
+		"""Change automatic sleep without a VM restart. An idle timeout of 0 disables sleep."""
+		try:
+			sleepy = strict_bool(is_sleepy, "is_sleepy")
+		except ValueError as error:
+			frappe.throw(_(str(error)), exc=AtlasUserError)
+			raise AssertionError from error
 
-		service.set_compute(
-			vcpus if vcpus is not None else information.desired.compute.virtual_cpu_count,
-			memory_mib if memory_mib is not None else information.desired.compute.memory_mib,
+		return self.update_compute(
+			{
+				"is_sleepy": sleepy,
+				"idle_timeout_seconds": self.parse_limit(idle_timeout_seconds, _("Idle timeout")),
+			}
 		)
+
+	def update_compute(self, changes: dict[str, Any]) -> dict[str, Any]:
+		"""Apply selected CPU, memory, and sleep policy changes."""
+		self.check_permission("write")
+		if self.is_draft:
+			frappe.throw(_("Wait for Virtual Machine creation before a compute change."), exc=AtlasUserError)
+
+		return VirtualMachineService(self).update_compute(changes)
 
 	def update_disk(self, changes: dict[str, int]) -> dict[str, Any]:
 		"""Apply selected disk size and limit changes."""

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -47,7 +47,13 @@ class VirtualMachine(Document):
 
 	@request_cache
 	def get_metal_vm_info(self) -> MetalVirtualMachine | None:
-		"""Return the Metal record for this VM, cached for one request."""
+		"""Return the Metal record for this VM, cached for one request.
+
+		A record with no Server holds no Metal state. Frappe reads every virtual
+		field to build the new document template, so this runs before placement.
+		"""
+		if not self.server:
+			return None
 		return VirtualMachineService(self).get_information()
 
 	def before_insert(self) -> None:

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -137,7 +137,7 @@ class VirtualMachine(Document):
 
 	@property
 	def is_sleepy(self) -> bool:
-		"""Report whether Metal may put this idle VM to sleep."""
+		"""Report whether Metal sleeps this VM when it is idle."""
 		information = self.get_metal_vm_info()
 		return information.desired.compute.is_sleepy if information else False
 
@@ -345,7 +345,7 @@ class VirtualMachine(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def update_sleep_policy(self, is_sleepy: bool | int | str, idle_timeout_seconds: int) -> dict[str, Any]:
-		"""Change automatic sleep without a VM restart. An idle timeout of 0 disables sleep."""
+		"""Change automatic sleep. An idle timeout of 0 disables sleep."""
 		try:
 			sleepy = strict_bool(is_sleepy, "is_sleepy")
 		except ValueError as error:
@@ -360,7 +360,7 @@ class VirtualMachine(Document):
 		)
 
 	def update_compute(self, changes: dict[str, Any]) -> dict[str, Any]:
-		"""Apply selected CPU, memory, and sleep policy changes."""
+		"""Apply selected compute changes."""
 		self.check_permission("write")
 		if self.is_draft:
 			frappe.throw(_("Wait for Virtual Machine creation before a compute change."), exc=AtlasUserError)

--- a/atlas/vm/doctype/virtual_machine/virtual_machine.py
+++ b/atlas/vm/doctype/virtual_machine/virtual_machine.py
@@ -143,7 +143,7 @@ class VirtualMachine(Document):
 
 	@property
 	def is_sleepy(self) -> bool:
-		"""Report whether Metal sleeps this VM when it is idle."""
+		"""Report whether the host sleeps this VM when it is idle."""
 		information = self.get_metal_vm_info()
 		return information.desired.compute.is_sleepy if information else False
 
@@ -351,7 +351,7 @@ class VirtualMachine(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def update_sleep_policy(self, is_sleepy: bool | int | str, idle_timeout_seconds: int) -> dict[str, Any]:
-		"""Change automatic sleep. An idle timeout of 0 disables sleep."""
+		"""Change automatic sleep. An idle timeout of 0 disables it."""
 		try:
 			sleepy = strict_bool(is_sleepy, "is_sleepy")
 		except ValueError as error:

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
@@ -67,11 +67,11 @@ def sync_detailed(
 ) -> Response[VirtualMachineResponse]:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
-    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
+    memory change. A sleep policy change applies in any state.
 
     With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
-    wakes it on the next packet. An idle timeout of 0 disables sleep.
+    wakes it on the next packet. 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
@@ -108,11 +108,11 @@ def sync(
 ) -> VirtualMachineResponse | None:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
-    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
+    memory change. A sleep policy change applies in any state.
 
     With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
-    wakes it on the next packet. An idle timeout of 0 disables sleep.
+    wakes it on the next packet. 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
@@ -144,11 +144,11 @@ async def asyncio_detailed(
 ) -> Response[VirtualMachineResponse]:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
-    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
+    memory change. A sleep policy change applies in any state.
 
     With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
-    wakes it on the next packet. An idle timeout of 0 disables sleep.
+    wakes it on the next packet. 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
@@ -183,11 +183,11 @@ async def asyncio(
 ) -> VirtualMachineResponse | None:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
-    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
+    memory change. A sleep policy change applies in any state.
 
     With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
-    wakes it on the next packet. An idle timeout of 0 disables sleep.
+    wakes it on the next packet. 0 disables sleep.
 
     Args:
         virtual_machine_id (str):

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
@@ -67,10 +67,10 @@ def sync_detailed(
 ) -> Response[VirtualMachineResponse]:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
-    memory change. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a
+    stopped VM.
 
-    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and
     wakes it on the next packet. 0 disables sleep.
 
     Args:
@@ -108,10 +108,10 @@ def sync(
 ) -> VirtualMachineResponse | None:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
-    memory change. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a
+    stopped VM.
 
-    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and
     wakes it on the next packet. 0 disables sleep.
 
     Args:
@@ -144,10 +144,10 @@ async def asyncio_detailed(
 ) -> Response[VirtualMachineResponse]:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
-    memory change. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a
+    stopped VM.
 
-    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and
     wakes it on the next packet. 0 disables sleep.
 
     Args:
@@ -183,10 +183,10 @@ async def asyncio(
 ) -> VirtualMachineResponse | None:
     """Update compute
 
-     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or
-    memory change. A sleep policy change applies in any state.
+     Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a
+    stopped VM.
 
-    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and
     wakes it on the next packet. 0 disables sleep.
 
     Args:

--- a/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
+++ b/clients/atlas/atlas/api/vm_configuration/update_virtual_machine_compute.py
@@ -65,15 +65,18 @@ def sync_detailed(
     body: ComputeUpdatePayload,
     x_tenant_id: int,
 ) -> Response[VirtualMachineResponse]:
-    """Resize compute
+    """Update compute
 
-     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
-    change.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
+    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    wakes it on the next packet. An idle timeout of 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
         x_tenant_id (int):
-        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+        body (ComputeUpdatePayload): New CPU shape, memory shape, and sleep policy.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,15 +106,18 @@ def sync(
     body: ComputeUpdatePayload,
     x_tenant_id: int,
 ) -> VirtualMachineResponse | None:
-    """Resize compute
+    """Update compute
 
-     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
-    change.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
+    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    wakes it on the next packet. An idle timeout of 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
         x_tenant_id (int):
-        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+        body (ComputeUpdatePayload): New CPU shape, memory shape, and sleep policy.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -136,15 +142,18 @@ async def asyncio_detailed(
     body: ComputeUpdatePayload,
     x_tenant_id: int,
 ) -> Response[VirtualMachineResponse]:
-    """Resize compute
+    """Update compute
 
-     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
-    change.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
+    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    wakes it on the next packet. An idle timeout of 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
         x_tenant_id (int):
-        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+        body (ComputeUpdatePayload): New CPU shape, memory shape, and sleep policy.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,15 +181,18 @@ async def asyncio(
     body: ComputeUpdatePayload,
     x_tenant_id: int,
 ) -> VirtualMachineResponse | None:
-    """Resize compute
+    """Update compute
 
-     Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the
-    change.
+     Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas
+    changes the vCPU count or the memory size. A sleep policy change applies in any state.
+
+    With `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and
+    wakes it on the next packet. An idle timeout of 0 disables sleep.
 
     Args:
         virtual_machine_id (str):
         x_tenant_id (int):
-        body (ComputeUpdatePayload): New CPU and memory values for a stopped virtual machine.
+        body (ComputeUpdatePayload): New CPU shape, memory shape, and sleep policy.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/clients/atlas/atlas/models/compute_update_payload.py
+++ b/clients/atlas/atlas/models/compute_update_payload.py
@@ -12,17 +12,33 @@ T = TypeVar("T", bound="ComputeUpdatePayload")
 
 @_attrs_define
 class ComputeUpdatePayload:
-    """New CPU and memory values for a stopped virtual machine.
+    """New CPU shape, memory shape, and sleep policy.
 
     Attributes:
+        idle_timeout_seconds (int | None | Unset):
+        is_sleepy (bool | None | Unset):
         memory_mib (int | None | Unset):
         vcpus (int | None | Unset):
     """
 
+    idle_timeout_seconds: int | None | Unset = UNSET
+    is_sleepy: bool | None | Unset = UNSET
     memory_mib: int | None | Unset = UNSET
     vcpus: int | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        idle_timeout_seconds: int | None | Unset
+        if isinstance(self.idle_timeout_seconds, Unset):
+            idle_timeout_seconds = UNSET
+        else:
+            idle_timeout_seconds = self.idle_timeout_seconds
+
+        is_sleepy: bool | None | Unset
+        if isinstance(self.is_sleepy, Unset):
+            is_sleepy = UNSET
+        else:
+            is_sleepy = self.is_sleepy
+
         memory_mib: int | None | Unset
         if isinstance(self.memory_mib, Unset):
             memory_mib = UNSET
@@ -38,6 +54,10 @@ class ComputeUpdatePayload:
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
+        if idle_timeout_seconds is not UNSET:
+            field_dict["idle_timeout_seconds"] = idle_timeout_seconds
+        if is_sleepy is not UNSET:
+            field_dict["is_sleepy"] = is_sleepy
         if memory_mib is not UNSET:
             field_dict["memory_mib"] = memory_mib
         if vcpus is not UNSET:
@@ -48,6 +68,24 @@ class ComputeUpdatePayload:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+
+        def _parse_idle_timeout_seconds(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        idle_timeout_seconds = _parse_idle_timeout_seconds(d.pop("idle_timeout_seconds", UNSET))
+
+        def _parse_is_sleepy(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_sleepy = _parse_is_sleepy(d.pop("is_sleepy", UNSET))
 
         def _parse_memory_mib(data: object) -> int | None | Unset:
             if data is None:
@@ -68,6 +106,8 @@ class ComputeUpdatePayload:
         vcpus = _parse_vcpus(d.pop("vcpus", UNSET))
 
         compute_update_payload = cls(
+            idle_timeout_seconds=idle_timeout_seconds,
+            is_sleepy=is_sleepy,
             memory_mib=memory_mib,
             vcpus=vcpus,
         )

--- a/clients/atlas/atlas/models/create_virtual_machine_payload.py
+++ b/clients/atlas/atlas/models/create_virtual_machine_payload.py
@@ -28,7 +28,9 @@ class CreateVirtualMachinePayload:
         disk_throughput_mibps (int | Unset):  Default: 0.
         egress (CreateVirtualMachinePayloadEgress | Unset):  Default: CreateVirtualMachinePayloadEgress.UPLINK.
         hostname (str | Unset):  Default: ''.
+        idle_timeout_seconds (int | Unset):  Default: 0.
         ip_address_id (None | str | Unset):
+        is_sleepy (bool | Unset):  Default: False.
         metadata (CreateVirtualMachinePayloadMetadata | Unset):
         private_network_throughput_mibps (int | Unset):  Default: 0.
         public_network_throughput_mibps (int | Unset):  Default: 0.
@@ -44,7 +46,9 @@ class CreateVirtualMachinePayload:
     disk_throughput_mibps: int | Unset = 0
     egress: CreateVirtualMachinePayloadEgress | Unset = CreateVirtualMachinePayloadEgress.UPLINK
     hostname: str | Unset = ""
+    idle_timeout_seconds: int | Unset = 0
     ip_address_id: None | str | Unset = UNSET
+    is_sleepy: bool | Unset = False
     metadata: CreateVirtualMachinePayloadMetadata | Unset = UNSET
     private_network_throughput_mibps: int | Unset = 0
     public_network_throughput_mibps: int | Unset = 0
@@ -70,11 +74,15 @@ class CreateVirtualMachinePayload:
 
         hostname = self.hostname
 
+        idle_timeout_seconds = self.idle_timeout_seconds
+
         ip_address_id: None | str | Unset
         if isinstance(self.ip_address_id, Unset):
             ip_address_id = UNSET
         else:
             ip_address_id = self.ip_address_id
+
+        is_sleepy = self.is_sleepy
 
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
@@ -108,8 +116,12 @@ class CreateVirtualMachinePayload:
             field_dict["egress"] = egress
         if hostname is not UNSET:
             field_dict["hostname"] = hostname
+        if idle_timeout_seconds is not UNSET:
+            field_dict["idle_timeout_seconds"] = idle_timeout_seconds
         if ip_address_id is not UNSET:
             field_dict["ip_address_id"] = ip_address_id
+        if is_sleepy is not UNSET:
+            field_dict["is_sleepy"] = is_sleepy
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
         if private_network_throughput_mibps is not UNSET:
@@ -151,6 +163,8 @@ class CreateVirtualMachinePayload:
 
         hostname = d.pop("hostname", UNSET)
 
+        idle_timeout_seconds = d.pop("idle_timeout_seconds", UNSET)
+
         def _parse_ip_address_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -159,6 +173,8 @@ class CreateVirtualMachinePayload:
             return cast(None | str | Unset, data)
 
         ip_address_id = _parse_ip_address_id(d.pop("ip_address_id", UNSET))
+
+        is_sleepy = d.pop("is_sleepy", UNSET)
 
         _metadata = d.pop("metadata", UNSET)
         metadata: CreateVirtualMachinePayloadMetadata | Unset
@@ -184,7 +200,9 @@ class CreateVirtualMachinePayload:
             disk_throughput_mibps=disk_throughput_mibps,
             egress=egress,
             hostname=hostname,
+            idle_timeout_seconds=idle_timeout_seconds,
             ip_address_id=ip_address_id,
+            is_sleepy=is_sleepy,
             metadata=metadata,
             private_network_throughput_mibps=private_network_throughput_mibps,
             public_network_throughput_mibps=public_network_throughput_mibps,

--- a/clients/openapi/atlas.json
+++ b/clients/openapi/atlas.json
@@ -3,8 +3,33 @@
     "schemas": {
       "ComputeUpdatePayload": {
         "additionalProperties": false,
-        "description": "New CPU and memory values for a stopped virtual machine.",
+        "description": "New CPU shape, memory shape, and sleep policy.",
         "properties": {
+          "idle_timeout_seconds": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Idle Timeout Seconds"
+          },
+          "is_sleepy": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Is Sleepy"
+          },
           "memory_mib": {
             "anyOf": [
               {
@@ -123,6 +148,12 @@
             "title": "Hostname",
             "type": "string"
           },
+          "idle_timeout_seconds": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Idle Timeout Seconds",
+            "type": "integer"
+          },
           "image_id": {
             "minLength": 1,
             "title": "Image Id",
@@ -139,6 +170,11 @@
             ],
             "default": null,
             "title": "Ip Address Id"
+          },
+          "is_sleepy": {
+            "default": false,
+            "title": "Is Sleepy",
+            "type": "boolean"
           },
           "memory_mib": {
             "exclusiveMinimum": 0,
@@ -1803,7 +1839,7 @@
     },
     "/api/atlas/virtual-machines/{virtual_machine_id}/compute": {
       "patch": {
-        "description": "Changes the vCPU count, memory size, or both. The VM must be stopped before Atlas applies the change.",
+        "description": "Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas changes the vCPU count or the memory size. A sleep policy change applies in any state.\n\nWith `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. An idle timeout of 0 disables sleep.",
         "operationId": "update_virtual_machine_compute",
         "parameters": [
           {
@@ -1830,6 +1866,8 @@
           "content": {
             "application/json": {
               "example": {
+                "idle_timeout_seconds": 1800,
+                "is_sleepy": true,
                 "vcpus": 4
               },
               "schema": {
@@ -1851,7 +1889,7 @@
             "description": "The change is accepted. Poll the virtual machine route."
           }
         },
-        "summary": "Resize compute",
+        "summary": "Update compute",
         "tags": [
           "VM Configuration"
         ]

--- a/clients/openapi/atlas.json
+++ b/clients/openapi/atlas.json
@@ -1839,7 +1839,7 @@
     },
     "/api/atlas/virtual-machines/{virtual_machine_id}/compute": {
       "patch": {
-        "description": "Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped before Atlas changes the vCPU count or the memory size. A sleep policy change applies in any state.\n\nWith `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. An idle timeout of 0 disables sleep.",
+        "description": "Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or memory change. A sleep policy change applies in any state.\n\nWith `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. 0 disables sleep.",
         "operationId": "update_virtual_machine_compute",
         "parameters": [
           {

--- a/clients/openapi/atlas.json
+++ b/clients/openapi/atlas.json
@@ -1839,7 +1839,7 @@
     },
     "/api/atlas/virtual-machines/{virtual_machine_id}/compute": {
       "patch": {
-        "description": "Changes the vCPU count, the memory size, and the sleep policy. The VM must be stopped for a vCPU or memory change. A sleep policy change applies in any state.\n\nWith `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` without network activity and wakes it on the next packet. 0 disables sleep.",
+        "description": "Changes the vCPU count, the memory size, and the sleep policy. A vCPU or memory change needs a stopped VM.\n\nWith `is_sleepy`, the host sleeps the VM after `idle_timeout_seconds` of no network activity and wakes it on the next packet. 0 disables sleep.",
         "operationId": "update_virtual_machine_compute",
         "parameters": [
           {

--- a/docs/metal-v1-contract.md
+++ b/docs/metal-v1-contract.md
@@ -171,7 +171,7 @@ Valid states are `running`, `stopped`, and `paused`. Delete records the desired 
 
 Restart has no request body. Each accepted request increases `restart_generation`.
 
-Compute replaces the complete compute object. It carries the CPU shape, the memory shape, and the sleep policy. Metal needs a stopped VM for a shape change and accepts a sleep policy change in any state. An `idle_timeout_seconds` of `0` disables sleep.
+Compute replaces the complete compute object: the CPU shape, the memory shape, and the sleep policy. A shape change needs a stopped VM. A sleep policy change does not. An `idle_timeout_seconds` of `0` disables sleep.
 
 ```json
 {"virtual_cpu_count": 4, "memory_mib": 4096, "is_sleepy": true, "idle_timeout_seconds": 1800}

--- a/docs/metal-v1-contract.md
+++ b/docs/metal-v1-contract.md
@@ -171,7 +171,7 @@ Valid states are `running`, `stopped`, and `paused`. Delete records the desired 
 
 Restart has no request body. Each accepted request increases `restart_generation`.
 
-Compute replaces the complete compute object: the CPU shape, the memory shape, and the sleep policy. A shape change needs a stopped VM. A sleep policy change does not. An `idle_timeout_seconds` of `0` disables sleep.
+Compute replaces the CPU shape, the memory shape, and the sleep policy. A shape change needs a stopped VM. A sleep policy change does not, and `idle_timeout_seconds` `0` disables sleep.
 
 ```json
 {"virtual_cpu_count": 4, "memory_mib": 4096, "is_sleepy": true, "idle_timeout_seconds": 1800}

--- a/docs/metal-v1-contract.md
+++ b/docs/metal-v1-contract.md
@@ -56,7 +56,9 @@ Secure Shell key and metadata updates use an immediate operation with a 2-second
 {
   "compute": {
     "virtual_cpu_count": 2,
-    "memory_mib": 2048
+    "memory_mib": 2048,
+    "is_sleepy": true,
+    "idle_timeout_seconds": 1800
   },
   "disk": {
     "size_mib": 20480,
@@ -108,7 +110,9 @@ Create, read, and mutation routes return the same nested resource shape.
     "state": "running",
     "compute": {
       "virtual_cpu_count": 2,
-      "memory_mib": 2048
+      "memory_mib": 2048,
+      "is_sleepy": true,
+      "idle_timeout_seconds": 1800
     },
     "disk": {
       "size_mib": 20480,
@@ -167,10 +171,10 @@ Valid states are `running`, `stopped`, and `paused`. Delete records the desired 
 
 Restart has no request body. Each accepted request increases `restart_generation`.
 
-Compute replaces the complete compute object:
+Compute replaces the complete compute object. It carries the CPU shape, the memory shape, and the sleep policy. Metal needs a stopped VM for a shape change and accepts a sleep policy change in any state. An `idle_timeout_seconds` of `0` disables sleep.
 
 ```json
-{"virtual_cpu_count": 4, "memory_mib": 4096}
+{"virtual_cpu_count": 4, "memory_mib": 4096, "is_sleepy": true, "idle_timeout_seconds": 1800}
 ```
 
 Disk replaces the complete mutable disk object. Metal rejects disk shrink requests.

--- a/metal/internal/api/SPEC.md
+++ b/metal/internal/api/SPEC.md
@@ -98,6 +98,8 @@ A domain error is mapped to one status and one safe message. An unrecognized err
 
 Every error body carries a `retryable` flag, so a caller does not have to know which statuses are worth another attempt. `501` is excluded: repeating it cannot change the answer.
 
+`POST /v1/sync` addresses no resource, so it maps a not-found from host state to `503` `unavailable`. A `404` would tell the controller to stop when it must try the request again.
+
 Responses never carry host command output, signed URL query values, or local error detail.
 
 ## Response shape

--- a/metal/internal/api/controller_sync.go
+++ b/metal/internal/api/controller_sync.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 
 	"github.com/frappe/atlas/metal/internal/host"
 	"github.com/frappe/atlas/metal/internal/network"
+	"github.com/frappe/atlas/metal/internal/storage"
 	"github.com/frappe/atlas/metal/internal/vm"
 )
 
@@ -56,6 +59,7 @@ type capacityResponse struct {
 // @Failure	409		{object}	errorResponse
 // @Failure	422		{object}	errorResponse
 // @Failure	500		{object}	errorResponse
+// @Failure	503		{object}	errorResponse
 // @Router		/v1/sync [post]
 func (s *Server) exchangeControllerState(c echo.Context) error {
 	var request syncRequest
@@ -83,10 +87,21 @@ func (s *Server) exchangeControllerState(c echo.Context) error {
 		PrivilegedVirtualMachineAddresses: request.PrivilegedVMAddresses,
 	})
 	if err != nil {
-		return err
+		return synchronizationFailure(err)
 	}
 
 	return c.JSON(http.StatusOK, syncResponse{Capacity: capacityResponseFromHost(capacity)})
+}
+
+// synchronizationFailure keeps a host not-found out of the response. This
+// endpoint addresses no resource, so a 404 stops the controller when it must
+// try the request again.
+func synchronizationFailure(err error) error {
+	if errors.Is(err, vm.ErrNotFound) || errors.Is(err, storage.ErrNotFound) {
+		unavailable := newAPIError(http.StatusServiceUnavailable, "unavailable", "host state is incomplete")
+		return fmt.Errorf("%w: %w", unavailable, err)
+	}
+	return err
 }
 
 // imagePolicies converts the requested images into image policies.

--- a/metal/internal/api/server_test.go
+++ b/metal/internal/api/server_test.go
@@ -903,6 +903,27 @@ func TestSyncAppliesControllerStateAndReturnsCapacity(t *testing.T) {
 	}
 }
 
+// A host not-found has no addressed resource. A 404 tells the controller to
+// stop, so the sync must report a retryable host fault instead.
+func TestSyncReportsHostNotFoundAsUnavailable(t *testing.T) {
+	driver := &fakeVirtualMachineManager{virtualMachines: map[string]*fakeVM{}, listError: vm.ErrNotFound}
+	server := newServerWithServices(t, driver, newFakeRuntimeServices(), &fakeWireGuardManager{})
+
+	recorder := do(
+		t, server, http.MethodPost, "/v1/sync",
+		`{"wireguard_peers":[],"images":[],"privileged_vm_addresses":[]}`,
+		http.StatusServiceUnavailable,
+	)
+
+	var response errorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Error.Retryable || response.Error.Code != "unavailable" {
+		t.Fatalf("error = %+v", response.Error)
+	}
+}
+
 // A missing collection would read as an empty set and clear host state.
 func TestSyncRequiresControllerCollections(t *testing.T) {
 	server := newTestServer(t)

--- a/metal/internal/host/SPEC.md
+++ b/metal/internal/host/SPEC.md
@@ -39,6 +39,8 @@ CPU is reported against reservations, not against host load: available CPU is th
 
 Memory and storage are read from the host instead. Available memory comes from `MemAvailable` in `/proc/meminfo`, which counts cache the kernel can reclaim. Free memory alone would understate what a new guest can use.
 
+A VM that is created or destroyed now holds one record for a short time. `VirtualMachineSource` skips it, so capacity reports the VMs that have both records instead of failing the sync.
+
 ## Related
 
 - [docs/architecture.md](../../docs/architecture.md) places the sync in the daemon.

--- a/metal/internal/vm/SPEC.md
+++ b/metal/internal/vm/SPEC.md
@@ -55,6 +55,8 @@ The create fingerprint identifies the reservation a create request asked for. It
 
 The daemon validates every record at startup and refuses to run on one it cannot read. It never repairs or removes a record: losing desired state is worse than failing to start.
 
+A directory under `machines/` is a reserved VM only when it holds `config.json`. A temporary VM keeps no records, and the runtime makes its directory, so a build that stops leaves a directory with no record. That directory is not a VM and the daemon ignores it. A capacity read also skips a VM whose records are removed while the read runs.
+
 The desired record holds the sleep policy of one VM: `is_sleepy` and `idle_timeout_seconds`. The policy is intent, not machine shape, so a change to it does not raise the specification generation and leaves a published memory snapshot valid. The API carries it with the compute settings.
 
 `sleeping` is an observed state only. It means that Firecracker is stopped and a valid VM memory snapshot exists. The `sleep` object stores activity, request, snapshot, and generation values. It stores no paths. Old records without this object remain valid. A partial object or a sleeping record without a published snapshot is invalid.

--- a/metal/internal/vm/manager.go
+++ b/metal/internal/vm/manager.go
@@ -177,7 +177,9 @@ func (manager *Manager) Information(ctx context.Context, identifier string) (Inf
 	return manager.information(identifier)
 }
 
-// List returns all valid virtual machine records.
+// List returns all valid virtual machine records. A directory without both
+// records is skipped, because a VM that is created or destroyed now must not
+// fail the whole list.
 func (manager *Manager) List(ctx context.Context) ([]Information, error) {
 	identifiers, err := manager.store.listIDs()
 	if err != nil {
@@ -186,6 +188,11 @@ func (manager *Manager) List(ctx context.Context) ([]Information, error) {
 	information := make([]Information, 0, len(identifiers))
 	for _, identifier := range identifiers {
 		current, err := manager.Information(ctx, identifier)
+		if errors.Is(err, ErrNotFound) {
+			manager.logger.WarnContext(ctx, "skipped incomplete virtual machine records",
+				"virtual_machine_id", identifier, "error", err)
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/metal/internal/vm/manager_test.go
+++ b/metal/internal/vm/manager_test.go
@@ -570,6 +570,46 @@ func TestNewManagerRejectsUnknownAndTrailingRecordData(t *testing.T) {
 	}
 }
 
+// A create or a destroy leaves a directory with one record for a short time.
+// Capacity reads must not fail for the whole host in that window.
+func TestListSkipsIncompleteRecords(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	for _, identifier := range []string{"machine-1", "machine-2"} {
+		if _, err := manager.Create(context.Background(), identifier, testSpecification(), SleepPolicy{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Remove(manager.store.observedPath("machine-2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(manager.store.directory, "machine-3"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	information, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List = %v", err)
+	}
+	if len(information) != 1 || information[0].ID != "machine-1" {
+		t.Fatalf("information = %+v", information)
+	}
+}
+
+// A record that is present but corrupt is a host fault, not a VM in flux.
+func TestListReportsCorruptRecords(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	if _, err := manager.Create(context.Background(), "machine-1", testSpecification(), SleepPolicy{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manager.store.observedPath("machine-1"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.List(context.Background()); err == nil {
+		t.Fatal("List accepted a corrupt record")
+	}
+}
+
 func TestReconcileUsesRuntimeAndResourceDependencies(t *testing.T) {
 	manager, runtime, network, storage := newTestManager(t)
 	if _, err := manager.Create(context.Background(), "machine-1", testSpecification(), SleepPolicy{}); err != nil {
@@ -717,6 +757,30 @@ func TestRunTemporaryRemovesMachineDirectory(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(manager.store.directory, identifier)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("machine directory stat = %v, want not exist", err)
+	}
+}
+
+// A host that stops during a temporary build keeps the directory. metald must
+// still start, because a directory without a desired record is not a VM.
+func TestNewManagerStartsWithLeftoverTemporaryDirectory(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	if _, err := manager.Create(context.Background(), "machine-1", testSpecification(), SleepPolicy{}); err != nil {
+		t.Fatal(err)
+	}
+	leftover := filepath.Join(manager.store.directory, "warm-529e5118abe6", "firecracker")
+	if err := os.MkdirAll(leftover, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.store.validateAll(); err != nil {
+		t.Fatalf("validateAll = %v", err)
+	}
+	identifiers, err := manager.store.listIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(identifiers) != 1 || identifiers[0] != "machine-1" {
+		t.Fatalf("identifiers = %v", identifiers)
 	}
 }
 

--- a/metal/internal/vm/manager_test.go
+++ b/metal/internal/vm/manager_test.go
@@ -703,6 +703,23 @@ func TestCreateSnapshotRejectsUnknownRuntimeState(t *testing.T) {
 	}
 }
 
+// The runtime makes a machine directory for a temporary VM. A directory that
+// stays behind holds no records, so it stops every later start and list.
+func TestRunTemporaryRemovesMachineDirectory(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	identifier := "warm-529e5118abe6"
+	run := func(RuntimeMachine) error {
+		return os.MkdirAll(filepath.Join(manager.store.directory, identifier, "firecracker"), 0o700)
+	}
+	if err := manager.RunTemporary(context.Background(), identifier, testSpecification(), run); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(manager.store.directory, identifier)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("machine directory stat = %v, want not exist", err)
+	}
+}
+
 func TestRunTemporaryRejectsInvalidIdentifier(t *testing.T) {
 	manager, _, _, _ := newTestManager(t)
 	err := manager.RunTemporary(context.Background(), "../machine-1", testSpecification(), func(RuntimeMachine) error {

--- a/metal/internal/vm/records.go
+++ b/metal/internal/vm/records.go
@@ -147,7 +147,9 @@ func (store *recordStore) validateAll() error {
 	return nil
 }
 
-// listIDs returns every reserved identifier in sorted order.
+// listIDs returns every reserved identifier in sorted order. A directory
+// without a desired record is not a reserved VM: a temporary VM keeps no
+// records, and a stopped build leaves its directory behind.
 func (store *recordStore) listIDs() ([]string, error) {
 	entries, err := os.ReadDir(store.directory)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -158,9 +160,16 @@ func (store *recordStore) listIDs() ([]string, error) {
 	}
 	identifiers := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
-			identifiers = append(identifiers, entry.Name())
+		if !entry.IsDir() {
+			continue
 		}
+		if _, err := os.Stat(store.desiredPath(entry.Name())); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("list virtual machine records: %w", err)
+		}
+		identifiers = append(identifiers, entry.Name())
 	}
 	sort.Strings(identifiers)
 	return identifiers, nil

--- a/metal/internal/vm/warm_image_builder.go
+++ b/metal/internal/vm/warm_image_builder.go
@@ -186,6 +186,9 @@ func (manager *Manager) RunTemporary(
 				WireGuardMeshIPv6: specification.Network.WireGuardMeshIPv6,
 			}),
 			manager.storage.Release(cleanupContext, identifier),
+			// The runtime makes a machine directory. A temporary VM keeps no
+			// records, so the directory must not stay and look like a reserved VM.
+			manager.store.remove(identifier),
 		)
 	}()
 	if err := manager.runtime.Start(ctx, machine, StartNormal); err != nil {


### PR DESCRIPTION
- A virtual machine can now sleep when it is idle and wake on a network packet. The policy is `is_sleepy` and `idle_timeout_seconds`, and the Edit Sleep Policy action changes it.
- Fix a warm image build that left its machine directory behind. The leftover directory looked like a virtual machine with no records, which broke host synchronization and stopped metald from starting.
- Fix `POST /v1/sync` answering `404` for a host fault. It now answers `503`, so the controller tries the request again instead of stopping.
- Fix the new Virtual Machine form failing with `Metal Server None not found`.