### PR TITLE
chore(atlas): Exclude non-app paths from bench validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,11 @@ docstring-code-format = true
 frappe = ">=16.0.0,<18.0.0"
 
 [tool.bench]
-validation-ignore = ["atlas/vm/scripts/*"]
+validation-ignore = [
+    "atlas/vm/scripts/*",
+    "scripts/*",
+    "clients/*",
+    "services/*",
+    "metal/*",
+]
 


### PR DESCRIPTION
Bench app validation checks Python files that only run on production hosts or that belong to independent components of the monorepo. These paths are not part of the Frappe app.

- Ignore `scripts/`, `clients/`, `services/`, and `metal/`.
- Keep `atlas/vm/scripts/` ignored for the cloud-init data source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mjCpMr8E2WzWMUrApeTo4