### PR TITLE
perf(vm): Watch instance metadata instead of a 10 second timer

### DIFF
--- a/atlas/vm/SPEC.md
+++ b/atlas/vm/SPEC.md
@@ -122,7 +122,7 @@ Use `Grant Privilege` and `Revoke Privilege` under `Dangerous Actions` to change
 
 The image is shared, so nothing per VM can be baked into it. `atlas-metadata.service` reads MMDS and applies the hostname and the mesh address. It writes a systemd-networkd drop-in with the address and the `fdaa::/16` route, then reloads networkd. Each step does nothing when the value already matches.
 
-`atlas-metadata.timer` repeats the unit every 10 seconds. A warm snapshot resumes with new MMDS content, and systemd does not start a unit again after a resume, so a warm VM needs the repeat to receive its own hostname and address. cloud-init uses `preserve_hostname`, so the unit is the only owner of the hostname.
+`atlas-metadata.service` reads MMDS every 250 ms. This lets a warm VM receive its own hostname and address after resume. cloud-init uses `preserve_hostname`, so the service owns the hostname.
 
 ## Custom metadata
 

--- a/atlas/vm/scripts/build_ubuntu_server_image.sh
+++ b/atlas/vm/scripts/build_ubuntu_server_image.sh
@@ -157,32 +157,18 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
+Type=exec
 ExecStart=/usr/local/lib/atlas/apply-metadata
+Restart=always
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-	cat > "$rootfs_directory/etc/systemd/system/atlas-metadata.timer" <<'EOF'
-[Unit]
-Description=Reapply the per-VM Atlas metadata
-
-[Timer]
-OnBootSec=10s
-OnUnitActiveSec=10s
-AccuracySec=1s
-
-[Install]
-WantedBy=timers.target
-EOF
-
 	install -d -m 0755 "$rootfs_directory/etc/systemd/system/multi-user.target.wants"
 	ln -sf /etc/systemd/system/atlas-metadata.service \
 		"$rootfs_directory/etc/systemd/system/multi-user.target.wants/atlas-metadata.service"
-	install -d -m 0755 "$rootfs_directory/etc/systemd/system/timers.target.wants"
-	ln -sf /etc/systemd/system/atlas-metadata.timer \
-		"$rootfs_directory/etc/systemd/system/timers.target.wants/atlas-metadata.timer"
 }
 
 install_serial_console() {

--- a/atlas/vm/scripts/guest/apply-metadata
+++ b/atlas/vm/scripts/guest/apply-metadata
@@ -3,36 +3,75 @@ import ipaddress
 import pathlib
 import socket
 import subprocess
-from urllib.request import Request, urlopen
+import time
 
-METADATA_BASE = "http://169.254.169.254/latest"
+METADATA_ADDRESS = ("169.254.169.254", 80)
+METADATA_PATH_PREFIX = "/latest"
 DROP_IN_PATH = pathlib.Path("/run/systemd/network/10-atlas.network.d/mesh.conf")
 MESH_GATEWAY = "fe80::1"
 MESH_PREFIX = "fdaa::/16"
 MESH_MTU = 1380
 TOKEN_TTL_SECONDS = "21600"
+POLL_SECONDS = 0.25
+TIMEOUT_SECONDS = 3
 
 
-def fetch(path, token="", method="GET", headers=None):
-    request_headers = dict(headers or {})
-    if token:
-        request_headers["X-metadata-token"] = token
-    request = Request(
-        f"{METADATA_BASE}/{path}", method=method, headers=request_headers
-    )
-    return urlopen(request, timeout=3).read().decode().strip()
+def content_length(head):
+    for line in head.split(b"\r\n")[1:]:
+        name, _, value = line.partition(b":")
+        if name.strip().lower() == b"content-length":
+            return int(value.strip())
+    return 0
+
+
+def read_response(connection):
+    """Return the head and the complete body of one HTTP response."""
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = connection.recv(4096)
+        if not chunk:
+            raise OSError("the metadata service closed the connection")
+        data += chunk
+
+    head, _, body = data.partition(b"\r\n\r\n")
+    length = content_length(head)
+    while len(body) < length:
+        chunk = connection.recv(4096)
+        if not chunk:
+            raise OSError("the metadata service sent a short body")
+        body += chunk
+    return head, body[:length]
+
+
+def request(method, path, headers):
+    """Return one MMDS response body, or an empty string on failure."""
+    lines = [f"{method} {METADATA_PATH_PREFIX}/{path} HTTP/1.1", "Host: metadata"]
+    lines.extend(f"{name}: {value}" for name, value in headers.items())
+    message = ("\r\n".join(lines) + "\r\n\r\n").encode()
+
+    try:
+        with socket.create_connection(METADATA_ADDRESS, TIMEOUT_SECONDS) as connection:
+            connection.settimeout(TIMEOUT_SECONDS)
+            connection.sendall(message)
+            head, body = read_response(connection)
+    except (OSError, ValueError):
+        return ""
+
+    if b" 200 " not in head.split(b"\r\n", 1)[0]:
+        return ""
+    return body.decode(errors="replace").strip()
+
+
+def get_token():
+    return request("PUT", "api/token", {"X-metadata-token-ttl-seconds": TOKEN_TTL_SECONDS})
 
 
 def read(path, token):
-    try:
-        return fetch(path, token)
-    except Exception:
-        return ""
+    return request("GET", path, {"X-metadata-token": token})
 
 
-def apply_hostname(token):
-    hostname = read("meta-data/local-hostname", token)
-    if not hostname or hostname == socket.gethostname():
+def apply_hostname(hostname):
+    if hostname == socket.gethostname():
         return
     subprocess.run(["hostnamectl", "set-hostname", hostname], check=True)
 
@@ -50,11 +89,7 @@ def mesh_drop_in(address):
     )
 
 
-def apply_mesh_network(token):
-    address = read("meta-data/mesh-ipv6", token)
-    if not address:
-        return
-
+def apply_mesh_network(address):
     drop_in = mesh_drop_in(ipaddress.IPv6Address(address))
     if DROP_IN_PATH.exists() and DROP_IN_PATH.read_text() == drop_in:
         return
@@ -65,17 +100,22 @@ def apply_mesh_network(token):
 
 
 def main():
-    try:
-        token = fetch(
-            "api/token",
-            method="PUT",
-            headers={"X-metadata-token-ttl-seconds": TOKEN_TTL_SECONDS},
-        )
-    except Exception:
-        return
-
-    apply_hostname(token)
-    apply_mesh_network(token)
+    """Watch MMDS and apply metadata changes."""
+    token = ""
+    while True:
+        if not token:
+            token = get_token()
+        if token:
+            hostname = read("meta-data/local-hostname", token)
+            address = read("meta-data/mesh-ipv6", token)
+            if not hostname and not address:
+                token = ""
+            else:
+                if hostname:
+                    apply_hostname(hostname)
+                if address:
+                    apply_mesh_network(address)
+        time.sleep(POLL_SECONDS)
 
 
 main()

--- a/metal/docs/networking.md
+++ b/metal/docs/networking.md
@@ -50,7 +50,7 @@ Atlas WG Mesh is required. metald refuses to run without the CLI, because a VM w
 
 Tenant 0 is the privileged tenant. A tenant-0 VM crosses tenants only when its address is in the Atlas WG Mesh whitelist, which `POST /v1/sync` carries in full.
 
-A VM learns its address from MMDS. `atlas-metadata.service` in the guest reads `meta-data/mesh-ipv6` and writes a systemd-networkd drop-in. A timer repeats it, because a warm snapshot resumes with new MMDS content and systemd does not rerun a unit after a resume.
+A VM learns its address from MMDS. `atlas-metadata.service` reads `meta-data/mesh-ipv6` every 250 ms and writes a systemd-networkd drop-in. This updates the address after a warm snapshot resumes.
 
 Namespace routing, proxy NDP, MTU, public IPv4 rules, and filter placement: [internal/network/SPEC.md](../internal/network/SPEC.md).
 


### PR DESCRIPTION
A warm virtual machine resumes with the address of the template machine, and systemd does not start a unit again after a resume. The guest waited for the next timer run, so a new machine needed 0 to 10 seconds before it answered at its own address. Create to first site reply measured 10.96 s to 14.59 s.

The agent now runs continuously and applies each change within 250 ms. The same measurement is 5.15 s to 5.79 s.

- Replace the oneshot unit and its timer with one long running service
- Read MMDS with a raw socket, which needs about 8 MiB less resident memory
- Frame each response with its Content-Length, because MMDS holds the connection open