### PR TITLE
fix(host-binaries): Resolve the Go toolchain path

### DIFF
--- a/atlas/atlas/core/host_binaries.py
+++ b/atlas/atlas/core/host_binaries.py
@@ -165,8 +165,11 @@ def repository_path() -> Path:
 
 
 def toolchain_path() -> Path:
-	"""Return the directory that holds the downloaded Go toolchain."""
-	return Path(frappe.get_site_path("private", "files", "toolchain"))
+	"""Return the directory that holds the downloaded Go toolchain.
+
+	A site path is relative, and the build runs in the module directory.
+	"""
+	return Path(frappe.get_site_path("private", "files", "toolchain")).resolve()
 
 
 def ensure_go_toolchain() -> str:

--- a/atlas/atlas/core/test_host_binaries.py
+++ b/atlas/atlas/core/test_host_binaries.py
@@ -24,6 +24,12 @@ class TestHostBinaries(UnitTestCase):
 	def test_file_name_comes_from_the_artifact(self) -> None:
 		self.assertEqual(HOST_BINARIES[0].file_name, "metald-linux-amd64")
 
+	def test_the_toolchain_path_is_absolute(self) -> None:
+		with patch.object(
+			host_binaries.frappe, "get_site_path", return_value="site.local/private/files/toolchain"
+		):
+			self.assertTrue(host_binaries.toolchain_path().is_absolute())
+
 	def test_find_host_binary_reads_the_command_line_key(self) -> None:
 		self.assertEqual(host_binaries.find_host_binary("metald").label, "metald")
 		self.assertEqual(host_binaries.find_host_binary("wg-mesh").label, "Atlas WG Mesh")


### PR DESCRIPTION
## Issue
`install-app` fails on a host that has no Go: `make: go: No such file or directory`.

## Summary
The downloaded Go toolchain now reaches `PATH` as an absolute path, so a host without a system Go can build `metald` and Atlas WG Mesh.

## What changed
- `toolchain_path()` resolves the site path before it is used.
- One test keeps the path absolute.

## Why
A site path is relative to the sites directory. The download worked, because it runs with that directory as its working directory, but the binary reached `PATH` as `<site>/private/files/toolchain/go/bin`. The build runs `make` in the module directory, where that entry resolves to nothing.

A host with a system Go never used this path, so the fault appeared only on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1h6nqPHPNgSSJu2EXEa99