### PR TITLE
fix(auth): Let a host read a published public file

### DIFF
--- a/atlas/auth/request.py
+++ b/atlas/auth/request.py
@@ -24,7 +24,7 @@ REALTIME_PATHS = frozenset(
 )
 GUEST_PATHS = frozenset({"/login", "/api/method/login", "/api/method/logout"})
 PUBLIC_ATLAS_PATHS = frozenset({"/api/atlas/jwks.json"})
-GUEST_PATH_PREFIXES = ("/assets/",)
+GUEST_PATH_PREFIXES = ("/assets/", "/files/")
 
 
 def validate_auth() -> None:
@@ -62,7 +62,7 @@ def validate_auth() -> None:
 
 
 def validate_guest_path(path: str) -> None:
-	"""Allow a guest to sign in and to read the API reference, and nothing else."""
+	"""Allow a guest to sign in, read the API reference, and read a public file."""
 	if path in GUEST_PATHS or path.startswith(GUEST_PATH_PREFIXES):
 		return
 

--- a/atlas/auth/test_identity.py
+++ b/atlas/auth/test_identity.py
@@ -186,6 +186,7 @@ class TestGuestPaths(UnitTestCase):
 			"/api/method/login",
 			"/api/method/logout",
 			"/assets/atlas/app.js",
+			"/files/metald-linux-amd64-0123456789ab",
 			"/api/atlas/docs",
 			"/api/atlas/docs/openapi.json",
 			"/api/atlas/jwks.json",

--- a/atlas/docs/security.md
+++ b/atlas/docs/security.md
@@ -12,7 +12,7 @@ The Atlas API at `/api/atlas` is the only tenant-facing surface. Metal Servers, 
 
 A service caller needs a valid Central or regional Atlas token. Send the token in the `Authorization: Bearer <token>` header. A System Manager can also use the Atlas API.
 
-The authentication validator closes the standard Frappe guest surface. A guest can sign in and read the API reference or public key set. The realtime console stays open because its handshake and permission calls need the web process. A session without a verified token cannot use an Atlas API route.
+The authentication validator closes the standard Frappe guest surface. A guest can sign in, read the API reference or public key set, and read a public file under `/files/`, which is how a Metal host downloads the published binaries and boot artifacts. The realtime console stays open because its handshake and permission calls need the web process. A session without a verified token cannot use an Atlas API route.
 
 Atlas requires the `iss`, `sub`, `aud`, `scope`, `tenant`, `iat`, and `exp` claims. It checks `nbf` when the claim is present. The audience is `atlas-admin:<region ID>`. The API surface is unrestricted, so the token needs `scope=*`, a subject, a tenant, and no resource constraint. The subject is an identity label and does not change the authority. The `tenant` claim carries the tenant boundary. Central uses `tenant=*`.
 


### PR DESCRIPTION
## Issue
A guest request for a public File was refused, so a host that downloads metald, Atlas WG Mesh, or a boot artifact from the Atlas site could not read it.

## Summary
`/files/` joins the guest path prefixes, so a host reads a published public File with no credentials.

## What changed
- `/files/` added to `GUEST_PATH_PREFIXES`.
- One guest path test covers a published file.
- The security document states the guest surface.

## Why
Atlas publishes the host binaries, the HTTP proxy package, and a bootstrap boot artifact as public Files, and a host downloads them before it has any credential. Private files keep their own permission check, so only the public directory becomes readable.

Seen on a production host: `GET /files/atlas-wg-mesh-linux-amd64-<digest>` answered 403 Not Permitted from the guest check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1h6nqPHPNgSSJu2EXEa99