### PR TITLE
feat(install): Complete the desk setup wizard

### DIFF
--- a/atlas/atlas/core/install.py
+++ b/atlas/atlas/core/install.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import frappe
+
+
+def complete_setup_wizard() -> None:
+	from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+
+	setup_complete({})
+
+	if not frappe.get_system_settings("time_zone"):
+		frappe.db.set_single_value("System Settings", "time_zone", "UTC")

--- a/atlas/atlas/core/test_install.py
+++ b/atlas/atlas/core/test_install.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from frappe.tests import UnitTestCase
+
+from atlas.atlas.core.install import complete_setup_wizard
+
+
+class TestSetupWizard(UnitTestCase):
+	def test_the_wizard_is_walked_with_no_answers(self) -> None:
+		with (
+			patch("frappe.desk.page.setup_wizard.setup_wizard.setup_complete") as setup_complete,
+			patch("atlas.atlas.core.install.frappe.get_system_settings", return_value="UTC"),
+			patch("atlas.atlas.core.install.frappe.db.set_single_value") as set_single_value,
+		):
+			complete_setup_wizard()
+
+		setup_complete.assert_called_once_with({})
+		set_single_value.assert_not_called()
+
+	def test_a_site_without_a_time_zone_gets_utc(self) -> None:
+		with (
+			patch("frappe.desk.page.setup_wizard.setup_wizard.setup_complete"),
+			patch("atlas.atlas.core.install.frappe.get_system_settings", return_value=None),
+			patch("atlas.atlas.core.install.frappe.db.set_single_value") as set_single_value,
+		):
+			complete_setup_wizard()
+
+		set_single_value.assert_called_once_with("System Settings", "time_zone", "UTC")
+
+	def test_a_chosen_time_zone_is_kept(self) -> None:
+		with (
+			patch("frappe.desk.page.setup_wizard.setup_wizard.setup_complete"),
+			patch("atlas.atlas.core.install.frappe.get_system_settings", return_value="Europe/Berlin"),
+			patch("atlas.atlas.core.install.frappe.db.set_single_value") as set_single_value,
+		):
+			complete_setup_wizard()
+
+		set_single_value.assert_not_called()

--- a/atlas/hooks.py
+++ b/atlas/hooks.py
@@ -100,6 +100,7 @@ code_only_modules = {
 
 # before_install = "atlas.install.before_install"
 after_install = [
+	"atlas.atlas.core.install.complete_setup_wizard",
 	"atlas.atlas.core.host_binaries.publish_host_binaries",
 	"atlas.service.core.http_proxy_package.publish_http_proxy_package",
 ]


### PR DESCRIPTION
## Summary
A new site holds the desk at the setup wizard, and an Atlas machine has nobody to answer it. Install now walks the wizard and pins the time zone.

## What changed
- `after_install` calls `complete_setup_wizard`.
- The wizard is walked with no answers.
- A site with no time zone is pinned to UTC. A chosen zone stays.

## Why
`frappe.is_setup_complete()` reports true while the wizard still holds the desk, so `setup_complete` decides with its own lock and check.

The wizard writes no System Settings without a country, and an unset time zone reads as `Asia/Kolkata`. A control plane belongs on UTC.

## Validation
On a host that installed itself, the desk served the wizard and the site reported `Asia/Kolkata`. After the hook, the desk opens and the site reports `UTC`. The app suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1h6nqPHPNgSSJu2EXEa99