### PR TITLE
fix: Misc

### DIFF
--- a/atlas/api/models.py
+++ b/atlas/api/models.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from frappe.utils import get_datetime, get_system_timezone
 from pydantic import BaseModel, ConfigDict, Field
 
-from atlas.api.core.base import PatchPayload, StrictModel
+from atlas.api.core.base import ListQuery, PatchPayload, StrictModel
 from atlas.vm.core.models import VirtualMachineCreateRequest
 
 if TYPE_CHECKING:
@@ -160,6 +160,12 @@ class ImageResponse(BaseModel):
 			transfer_error=image.transfer_error or None,
 			created_at=to_unix_timestamp(image.creation),
 		)
+
+
+class ImageListQuery(ListQuery):
+	"""Page through images, and narrow them to one image type when asked."""
+
+	image_type: Literal["system", "machine"] | None = None
 
 
 class ImageDownloadQuery(StrictModel):

--- a/atlas/api/routes/images.py
+++ b/atlas/api/routes/images.py
@@ -93,13 +93,13 @@ def download_image(image_id: str, query: ImageDownloadQuery) -> ApiResult[ImageD
 @api_docs(
 	responses={
 		202: {"description": "Deletion started. Poll the image route."},
-		409: {"description": "A virtual machine uses this image, or another tenant owns it."},
+		409: {"description": "Another tenant owns this System image."},
 	},
 )
 def delete_image(image_id: str) -> ApiResult[ImageResponse]:
 	"""Delete image.
 
-	Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored artifacts and remaining host snapshot data.
+	Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes Archived and keeps its artifacts.
 	"""
 	image = get_owned_image(image_id)
 	if image.tenant_id != get_current_tenant_id():

--- a/atlas/api/routes/images.py
+++ b/atlas/api/routes/images.py
@@ -38,11 +38,15 @@ def get_owned_image(image_id: str) -> VirtualMachineImage:
 def list_images(query: ImageListQuery) -> Page[ImageResponse]:
 	"""List images.
 
-	Returns one page of System and Machine images owned by the tenant in newest-first order. Pass `image_type` as `system` or `machine` to return only that type. Omit it to return both.
+	Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as `system` or `machine` to return only that type. Omit it to return both.
 	"""
+	filters: dict[str, str | int] = {"enabled": 1}
+	if query.image_type:
+		filters["image_type"] = query.image_type
+
 	rows: list[VirtualMachineImage] = frappe.get_list(
 		"Virtual Machine Image",
-		filters={"image_type": query.image_type} if query.image_type else None,
+		filters=filters,
 		or_filters={"tenant_id": get_current_tenant_id(), "image_type": "system"},
 		fields=[
 			"name",

--- a/atlas/api/routes/images.py
+++ b/atlas/api/routes/images.py
@@ -6,7 +6,6 @@ import frappe
 
 from atlas.api.core.base import (
 	ApiResult,
-	ListQuery,
 	Page,
 	build_page,
 	get_owned_document,
@@ -16,7 +15,12 @@ from atlas.api.core.errors import (
 	ResourceConflict,
 	ResourceNotFound,
 )
-from atlas.api.models import ImageDownloadQuery, ImageDownloadResponse, ImageResponse
+from atlas.api.models import (
+	ImageDownloadQuery,
+	ImageDownloadResponse,
+	ImageListQuery,
+	ImageResponse,
+)
 from atlas.api.router import images
 from atlas.auth.identity import get_current_tenant_id
 
@@ -31,13 +35,14 @@ def get_owned_image(image_id: str) -> VirtualMachineImage:
 
 @images.get("")
 @api_docs()
-def list_images(query: ListQuery) -> Page[ImageResponse]:
+def list_images(query: ImageListQuery) -> Page[ImageResponse]:
 	"""List images.
 
-	Returns one page of System and Machine images owned by the tenant in newest-first order.
+	Returns one page of System and Machine images owned by the tenant in newest-first order. Pass `image_type` as `system` or `machine` to return only that type. Omit it to return both.
 	"""
 	rows: list[VirtualMachineImage] = frappe.get_list(
 		"Virtual Machine Image",
+		filters={"image_type": query.image_type} if query.image_type else None,
 		or_filters={"tenant_id": get_current_tenant_id(), "image_type": "system"},
 		fields=[
 			"name",

--- a/atlas/api/tests/test_images.py
+++ b/atlas/api/tests/test_images.py
@@ -80,9 +80,12 @@ class TestImageAccess(IntegrationTestCase):
 		self.own_image = insert_image(TENANT_ID)
 		self.other_image = insert_image(OTHER_TENANT_ID)
 
-	def list_names(self, tenant_id: int) -> set[str]:
+	def list_names(self, tenant_id: int, image_type: str | None = None) -> set[str]:
 		"""Return the image identifiers that one tenant can list."""
-		with api_request("GET", "/api/atlas/images", tenant_id=tenant_id, query_string={"limit": "100"}):
+		query = {"limit": "100"}
+		if image_type:
+			query["image_type"] = image_type
+		with api_request("GET", "/api/atlas/images", tenant_id=tenant_id, query_string=query):
 			status, body = call_route(list_images)
 
 		self.assertEqual(status, 200)
@@ -95,6 +98,28 @@ class TestImageAccess(IntegrationTestCase):
 		self.assertIn(self.own_image, names)
 		self.assertNotIn(self.other_image, names)
 		self.assertIn(self.zero_tenant_image, names)
+
+	def test_the_system_type_returns_only_system_images(self) -> None:
+		names = self.list_names(TENANT_ID, "system")
+
+		self.assertIn(self.system_image, names)
+		self.assertIn(self.zero_tenant_image, names)
+		self.assertNotIn(self.own_image, names)
+
+	def test_the_machine_type_returns_only_owned_machine_images(self) -> None:
+		names = self.list_names(TENANT_ID, "machine")
+
+		self.assertIn(self.own_image, names)
+		self.assertNotIn(self.system_image, names)
+		self.assertNotIn(self.other_image, names)
+
+	def test_an_unknown_image_type_is_refused(self) -> None:
+		with api_request(
+			"GET", "/api/atlas/images", tenant_id=TENANT_ID, query_string={"image_type": "bogus"}
+		):
+			status, _body = call_route(list_images)
+
+		self.assertEqual(status, 400)
 
 	def test_another_tenant_cannot_read_a_machine_image(self) -> None:
 		with api_request("GET", "/api/atlas/images/x", tenant_id=OTHER_TENANT_ID):

--- a/atlas/api/tests/test_images.py
+++ b/atlas/api/tests/test_images.py
@@ -113,6 +113,16 @@ class TestImageAccess(IntegrationTestCase):
 		self.assertNotIn(self.system_image, names)
 		self.assertNotIn(self.other_image, names)
 
+	def test_a_disabled_image_is_left_out(self) -> None:
+		disabled = insert_image(TENANT_ID, "machine", enabled=0)
+		disabled_system = insert_image(TENANT_ID, "system", enabled=0)
+
+		names = self.list_names(TENANT_ID)
+
+		self.assertNotIn(disabled, names)
+		self.assertNotIn(disabled_system, names)
+		self.assertIn(self.own_image, names)
+
 	def test_an_unknown_image_type_is_refused(self) -> None:
 		with api_request(
 			"GET", "/api/atlas/images", tenant_id=TENANT_ID, query_string={"image_type": "bogus"}

--- a/atlas/docs/images.md
+++ b/atlas/docs/images.md
@@ -45,13 +45,27 @@ Atlas saves both multipart upload IDs before it asks Metal to start. A failed st
 
 Retry Transfer uses these durable values. It does not create a second image record. Atlas does not log signed URLs.
 
-## Deletion
+## Listing
 
-Only an Available Machine image can enter deletion. Deletion marks the image `Deleting` and queues a cleanup job. The job deletes the root file system and kernel objects, removes the Metal staging data, and then deletes the record.
+`GET /api/atlas/images` returns the enabled images that the tenant owns, and every enabled System image. A disabled image cannot boot a virtual machine, so the list leaves it out. Retirement disables an image, so a retired image also leaves the list.
 
-Atlas refuses deletion while a virtual machine uses the image. A System image cannot be deleted through the tenant API.
+Pass `image_type` as `system` or `machine` to return only that type. Omit it to return both. Any other value is a `400`.
+
+`GET /api/atlas/images/<image ID>` returns one image by its identifier, and it also returns a disabled image. Use it to follow a retiring image.
+
+## Retirement and deletion
+
+An Available or Failed image can be retired. Retirement always disables the image, so no new virtual machine can use it.
+
+Atlas reclaims the stored artifacts only when nothing needs them. A Machine image that no virtual machine uses becomes `Deleting` and queues a cleanup job. Every other image becomes `Archived` and keeps its artifacts. A System image is shared, so it always becomes `Archived`.
+
+The cleanup job deletes the root file system and kernel objects, removes the Metal staging data, and then deletes the record.
+
+A scheduled pass reclaims an `Archived` Machine image after its last virtual machine is deleted. The pass moves the image to `Deleting` and queues the same cleanup job. An `Archived` System image stays.
 
 If a Metal or object storage cleanup operation fails, Atlas keeps the image in `Deleting`, records the error, and tries the job again every 30 seconds.
+
+A retiring image keeps its record until the cleanup job removes it, so a caller can read the image by its identifier and follow the status.
 
 ## Cached and warm artifacts
 

--- a/atlas/metal_server/SPEC.md
+++ b/atlas/metal_server/SPEC.md
@@ -54,6 +54,10 @@ An address carries a desired intent and an intent version. Reconciliation applie
 
 An address also carries the tenant that reserved it. An address without a tenant is in the shared pool. `IPAddressService` owns reservation and release. A reservation uses the shared pool or the provider. A pool claim locks one unowned row before it writes the tenant, so two requests never take the same address, and an empty pool is an error instead of a silent provider reservation. A release clears the tenant, keeps the provider reservation, and refuses an attached or detaching address.
 
+A virtual machine can attach an address that its own tenant holds, or an unowned address from the shared pool. Attaching an unowned address claims it for the tenant of the virtual machine. An address that another tenant holds is refused.
+
+Reset Tenant returns one unattached address to the shared pool from the desk. It needs the System Manager role, and it refuses an address that is already unowned. The action adds a comment that records the losing tenant, because the address keeps no trace of its previous owner.
+
 ## Related
 
 - [docs/metal-server-lifecycle.md](../docs/metal-server-lifecycle.md) describes the lifecycle and its reasons.

--- a/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.js
+++ b/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on("Metal Server IP Address", {
+	refresh(frm) {
+		const isDetached = frm.doc.status === "Allocated" && !frm.doc.virtual_machine;
+
+		if (frappe.user.has_role("System Manager") && isDetached) {
+			frm.add_custom_button(__("Reset Tenant"), () => {
+				frappe.confirm(
+					__("Return {0} to the shared pool? Tenant {1} loses it.", [
+						frm.doc.address,
+						frm.doc.tenant_id,
+					]),
+					() => frm.call("reset_tenant").then(() => frm.reload_doc())
+				);
+			});
+		}
+	},
+});

--- a/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
@@ -92,12 +92,21 @@ class MetalServerIPAddress(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def reset_tenant(self) -> None:
-		"""Drop tenant ownership of this unattached address from the desk."""
+		"""Drop tenant ownership of this unattached address from the desk.
+
+		The comment is the audit record. It keeps the losing tenant, the acting
+		user, and the time, which the address itself no longer holds afterwards.
+		"""
 		frappe.only_for("System Manager")
 		if self.tenant_id == UNOWNED_TENANT_ID:
 			frappe.throw(_("IP address {0} is already in the shared pool.").format(self.address))
 
+		previous_tenant_id = self.tenant_id
 		self.release_to_pool()
+		self.add_comment(
+			"Info",
+			_("Reset to the shared pool from tenant {0}.").format(previous_tenant_id),
+		)
 
 	def queue_reconcile(self) -> None:
 		"""Queue the provider reconcile job for this address."""

--- a/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
@@ -90,6 +90,15 @@ class MetalServerIPAddress(Document):
 		self.check_permission("write")
 		IPAddressService().release(self)
 
+	@frappe.whitelist(methods=["POST"])
+	def reset_tenant(self) -> None:
+		"""Drop tenant ownership of this unattached address from the desk."""
+		frappe.only_for("System Manager")
+		if self.tenant_id == UNOWNED_TENANT_ID:
+			frappe.throw(_("IP address {0} is already in the shared pool.").format(self.address))
+
+		self.release_to_pool()
+
 	def queue_reconcile(self) -> None:
 		"""Queue the provider reconcile job for this address."""
 		frappe.enqueue_doc(

--- a/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/metal_server_ip_address.py
@@ -92,11 +92,7 @@ class MetalServerIPAddress(Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def reset_tenant(self) -> None:
-		"""Drop tenant ownership of this unattached address from the desk.
-
-		The comment is the audit record. It keeps the losing tenant, the acting
-		user, and the time, which the address itself no longer holds afterwards.
-		"""
+		"""Drop tenant ownership of this unattached address from the desk."""
 		frappe.only_for("System Manager")
 		if self.tenant_id == UNOWNED_TENANT_ID:
 			frappe.throw(_("IP address {0} is already in the shared pool.").format(self.address))

--- a/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
@@ -2,6 +2,7 @@ from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import frappe
 from frappe.tests import UnitTestCase
 
 from atlas.atlas.core.server_providers.base import ReservedIPAddress
@@ -17,6 +18,32 @@ class TestServerIPAddress(UnitTestCase):
 
 		with self.assertRaises(FrozenInstanceError):
 			reserved.address = "203.0.113.11"
+
+	def test_reset_tenant_returns_the_address_to_the_pool(self) -> None:
+		address = SimpleNamespace(address="203.0.113.10", tenant_id=7, release_to_pool=Mock())
+
+		with patch("frappe.only_for") as only_for:
+			MetalServerIPAddress.reset_tenant(address)
+
+		only_for.assert_called_once_with("System Manager")
+		address.release_to_pool.assert_called_once()
+
+	def test_reset_tenant_needs_a_system_manager(self) -> None:
+		address = SimpleNamespace(address="203.0.113.10", tenant_id=7, release_to_pool=Mock())
+
+		with patch("frappe.only_for", side_effect=frappe.PermissionError):
+			with self.assertRaises(frappe.PermissionError):
+				MetalServerIPAddress.reset_tenant(address)
+
+		address.release_to_pool.assert_not_called()
+
+	def test_an_unowned_address_is_already_in_the_pool(self) -> None:
+		address = SimpleNamespace(address="203.0.113.10", tenant_id=-1, release_to_pool=Mock())
+
+		with patch("frappe.only_for"), self.assertRaises(frappe.ValidationError):
+			MetalServerIPAddress.reset_tenant(address)
+
+		address.release_to_pool.assert_not_called()
 
 	def test_assignment_increments_the_intent_version(self) -> None:
 		address = SimpleNamespace(

--- a/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
@@ -31,7 +31,6 @@ class TestServerIPAddress(UnitTestCase):
 		address.release_to_pool.assert_called_once()
 
 	def test_reset_tenant_records_the_losing_tenant(self) -> None:
-		"""The address keeps no trace of its old owner, so the comment must."""
 		address = SimpleNamespace(
 			address="203.0.113.10", tenant_id=7, release_to_pool=Mock(), add_comment=Mock()
 		)

--- a/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
+++ b/atlas/metal_server/doctype/metal_server_ip_address/test_metal_server_ip_address.py
@@ -20,7 +20,9 @@ class TestServerIPAddress(UnitTestCase):
 			reserved.address = "203.0.113.11"
 
 	def test_reset_tenant_returns_the_address_to_the_pool(self) -> None:
-		address = SimpleNamespace(address="203.0.113.10", tenant_id=7, release_to_pool=Mock())
+		address = SimpleNamespace(
+			address="203.0.113.10", tenant_id=7, release_to_pool=Mock(), add_comment=Mock()
+		)
 
 		with patch("frappe.only_for") as only_for:
 			MetalServerIPAddress.reset_tenant(address)
@@ -28,8 +30,24 @@ class TestServerIPAddress(UnitTestCase):
 		only_for.assert_called_once_with("System Manager")
 		address.release_to_pool.assert_called_once()
 
+	def test_reset_tenant_records_the_losing_tenant(self) -> None:
+		"""The address keeps no trace of its old owner, so the comment must."""
+		address = SimpleNamespace(
+			address="203.0.113.10", tenant_id=7, release_to_pool=Mock(), add_comment=Mock()
+		)
+
+		with patch("frappe.only_for"):
+			MetalServerIPAddress.reset_tenant(address)
+
+		address.add_comment.assert_called_once()
+		kind, message = address.add_comment.call_args.args
+		self.assertEqual(kind, "Info")
+		self.assertIn("7", message)
+
 	def test_reset_tenant_needs_a_system_manager(self) -> None:
-		address = SimpleNamespace(address="203.0.113.10", tenant_id=7, release_to_pool=Mock())
+		address = SimpleNamespace(
+			address="203.0.113.10", tenant_id=7, release_to_pool=Mock(), add_comment=Mock()
+		)
 
 		with patch("frappe.only_for", side_effect=frappe.PermissionError):
 			with self.assertRaises(frappe.PermissionError):
@@ -38,7 +56,9 @@ class TestServerIPAddress(UnitTestCase):
 		address.release_to_pool.assert_not_called()
 
 	def test_an_unowned_address_is_already_in_the_pool(self) -> None:
-		address = SimpleNamespace(address="203.0.113.10", tenant_id=-1, release_to_pool=Mock())
+		address = SimpleNamespace(
+			address="203.0.113.10", tenant_id=-1, release_to_pool=Mock(), add_comment=Mock()
+		)
 
 		with patch("frappe.only_for"), self.assertRaises(frappe.ValidationError):
 			MetalServerIPAddress.reset_tenant(address)

--- a/atlas/vm/core/metal_client.py
+++ b/atlas/vm/core/metal_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import time
+from time import monotonic
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -46,6 +47,7 @@ class MetalClient:
 	create_timeout_seconds = (5, 60)
 	status_timeout_seconds = (5, 30)
 	status_attempts = 3
+	status_budget_seconds = 30
 	retry_delay_seconds = 2
 	snapshot_timeout_seconds = (5, 3600)
 
@@ -95,6 +97,7 @@ class MetalClient:
 			f"/v1/vms/{quote(virtual_machine_id, safe='')}",
 			timeout=self.status_timeout_seconds,
 			attempts=self.status_attempts,
+			budget_seconds=self.status_budget_seconds,
 		)
 		return self._virtual_machine(response)
 
@@ -290,9 +293,18 @@ class MetalClient:
 		expected_status: int | tuple[int, ...] | None = None,
 		uncertain_on_failure: bool = False,
 		attempts: int = 1,
+		budget_seconds: float | None = None,
 		**kwargs: Any,
 	) -> dict[str, Any]:
-		"""Send one request. Repeat a retryable failure only when the caller allows it."""
+		"""Send one request, and repeat a retryable failure within the caller budget.
+
+		Every attempt shares one deadline, so a repeated call never waits longer
+		than a single call would. A caller that reads state while a user waits
+		keeps its own latency.
+		"""
+		timeout = kwargs.pop("timeout", self.timeout_seconds)
+		deadline = monotonic() + budget_seconds if budget_seconds else None
+
 		for attempt in range(1, attempts + 1):
 			try:
 				return self._send(
@@ -300,14 +312,26 @@ class MetalClient:
 					path,
 					expected_status=expected_status,
 					uncertain_on_failure=uncertain_on_failure,
+					timeout=self._attempt_timeout(timeout, deadline),
 					**kwargs,
 				)
 			except MetalClientError as error:
 				if not error.retryable or attempt == attempts:
 					raise
+				if deadline and monotonic() + self.retry_delay_seconds >= deadline:
+					raise
 				time.sleep(self.retry_delay_seconds)
 
 		raise AssertionError("unreachable")
+
+	@staticmethod
+	def _attempt_timeout(timeout: tuple[float, float], deadline: float | None) -> tuple[float, float]:
+		"""Return the timeout for one attempt, narrowed to the remaining budget."""
+		if deadline is None:
+			return timeout
+
+		connect, read = timeout
+		return (connect, max(0.1, min(read, deadline - monotonic())))
 
 	def _send(
 		self,

--- a/atlas/vm/core/metal_client.py
+++ b/atlas/vm/core/metal_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -44,6 +45,8 @@ class MetalClient:
 	timeout_seconds = (5, 60)
 	create_timeout_seconds = (5, 60)
 	status_timeout_seconds = (5, 30)
+	status_attempts = 3
+	retry_delay_seconds = 2
 	snapshot_timeout_seconds = (5, 3600)
 
 	def __init__(self, server: "MetalServer") -> None:
@@ -91,6 +94,7 @@ class MetalClient:
 			"GET",
 			f"/v1/vms/{quote(virtual_machine_id, safe='')}",
 			timeout=self.status_timeout_seconds,
+			attempts=self.status_attempts,
 		)
 		return self._virtual_machine(response)
 
@@ -279,6 +283,33 @@ class MetalClient:
 		)
 
 	def _request(
+		self,
+		method: str,
+		path: str,
+		*,
+		expected_status: int | tuple[int, ...] | None = None,
+		uncertain_on_failure: bool = False,
+		attempts: int = 1,
+		**kwargs: Any,
+	) -> dict[str, Any]:
+		"""Send one request. Repeat a retryable failure only when the caller allows it."""
+		for attempt in range(1, attempts + 1):
+			try:
+				return self._send(
+					method,
+					path,
+					expected_status=expected_status,
+					uncertain_on_failure=uncertain_on_failure,
+					**kwargs,
+				)
+			except MetalClientError as error:
+				if not error.retryable or attempt == attempts:
+					raise
+				time.sleep(self.retry_delay_seconds)
+
+		raise AssertionError("unreachable")
+
+	def _send(
 		self,
 		method: str,
 		path: str,

--- a/atlas/vm/core/test_metal_client.py
+++ b/atlas/vm/core/test_metal_client.py
@@ -14,6 +14,7 @@ def build_client() -> MetalClient:
 	client.base_url = "http://10.0.0.2:9000"
 	client.headers = {"Authorization": "Bearer token"}
 	client.timeout_seconds = 5
+	client.retry_delay_seconds = 0
 	return client
 
 
@@ -23,6 +24,66 @@ def build_response(status: int, body: Any = None, content: bytes | None = None) 
 	response.content = content if content is not None else (b"{}" if body is None else b"body")
 	response.json.return_value = {} if body is None else body
 	return response
+
+
+class TestMetalClientRetries(UnitTestCase):
+	def test_a_retryable_failure_is_repeated_until_it_succeeds(self) -> None:
+		client = build_client()
+		responses = [requests.ReadTimeout("read timed out"), build_response(200, {"state": "running"})]
+
+		with patch("atlas.vm.core.metal_client.requests.request", side_effect=responses) as request:
+			body = client._request("GET", "/v1/vms/VM-00001", attempts=client.status_attempts)
+
+		self.assertEqual(body, {"state": "running"})
+		self.assertEqual(request.call_count, 2)
+
+	def test_migration_polling_is_not_repeated(self) -> None:
+		"""The migration worker runs its own poll loop, so one read must not retry."""
+		client = build_client()
+
+		with patch(
+			"atlas.vm.core.metal_client.requests.request",
+			side_effect=requests.ReadTimeout("read timed out"),
+		) as request:
+			with self.assertRaises(MetalClientError):
+				client.get_migration("migration-1")
+
+		self.assertEqual(request.call_count, 1)
+
+	def test_a_status_read_gives_up_after_the_last_attempt(self) -> None:
+		client = build_client()
+
+		with patch(
+			"atlas.vm.core.metal_client.requests.request",
+			side_effect=requests.ReadTimeout("read timed out"),
+		) as request:
+			with self.assertRaises(MetalClientError):
+				client.get_virtual_machine("VM-00001")
+
+		self.assertEqual(request.call_count, client.status_attempts)
+
+	def test_a_status_read_does_not_repeat_a_final_failure(self) -> None:
+		client = build_client()
+
+		with patch(
+			"atlas.vm.core.metal_client.requests.request", return_value=build_response(404)
+		) as request:
+			with self.assertRaises(MetalClientError):
+				client.get_virtual_machine("VM-00001")
+
+		self.assertEqual(request.call_count, 1)
+
+	def test_a_write_is_never_repeated(self) -> None:
+		client = build_client()
+
+		with patch(
+			"atlas.vm.core.metal_client.requests.request",
+			side_effect=requests.ReadTimeout("read timed out"),
+		) as request:
+			with self.assertRaises(MetalClientError):
+				client.put_virtual_machine("VM-00001", {})
+
+		self.assertEqual(request.call_count, 1)
 
 
 class TestMetalClientErrors(UnitTestCase):

--- a/atlas/vm/core/test_metal_client.py
+++ b/atlas/vm/core/test_metal_client.py
@@ -37,6 +37,38 @@ class TestMetalClientRetries(UnitTestCase):
 		self.assertEqual(body, {"state": "running"})
 		self.assertEqual(request.call_count, 2)
 
+	def test_retries_share_one_deadline(self) -> None:
+		"""Three attempts must not cost three full read timeouts."""
+		client = build_client()
+		clock = iter(range(0, 400))
+		seen: list[tuple[float, float]] = []
+
+		def record(*_args, **kwargs):
+			seen.append(kwargs["timeout"])
+			raise requests.ReadTimeout("read timed out")
+
+		with (
+			patch("atlas.vm.core.metal_client.monotonic", lambda: next(clock) * 10),
+			patch("atlas.vm.core.metal_client.requests.request", side_effect=record),
+		):
+			with self.assertRaises(MetalClientError):
+				client._request("GET", "/v1/vms/VM-00001", timeout=(5, 30), attempts=3, budget_seconds=30)
+
+		# Every attempt is narrowed to what the shared deadline still allows, so
+		# the repeated call never costs more than a single 30 second read.
+		self.assertLessEqual(sum(read for _, read in seen), 30)
+		self.assertLess(seen[-1][1], seen[0][1])
+
+	def test_a_fast_failure_still_retries_inside_the_budget(self) -> None:
+		client = build_client()
+		responses = [requests.ConnectionError("refused"), build_response(200, {"state": "running"})]
+
+		with patch("atlas.vm.core.metal_client.requests.request", side_effect=responses) as request:
+			body = client._request("GET", "/v1/vms/VM-00001", timeout=(5, 30), attempts=3, budget_seconds=30)
+
+		self.assertEqual(body, {"state": "running"})
+		self.assertEqual(request.call_count, 2)
+
 	def test_migration_polling_is_not_repeated(self) -> None:
 		"""The migration worker runs its own poll loop, so one read must not retry."""
 		client = build_client()

--- a/atlas/vm/core/test_vm_image_deletion.py
+++ b/atlas/vm/core/test_vm_image_deletion.py
@@ -26,27 +26,47 @@ def build_image(**overrides) -> SimpleNamespace:
 
 
 class TestMachineImageDeletionRequest(UnitTestCase):
-	def test_a_system_image_cannot_be_deleted(self) -> None:
+	def test_a_system_image_is_archived_and_keeps_its_artifacts(self) -> None:
 		service = VirtualMachineImageDeletionService()
+		image = build_image(image_type="system")
 
-		with self.assertRaises(frappe.ValidationError):
-			service.request(build_image(image_type="system"))
+		with patch.object(service, "enqueue") as enqueue:
+			self.assertEqual(service.request(image), "Archived")
 
-	def test_an_image_in_use_cannot_be_deleted(self) -> None:
+		self.assertEqual(image.status, "Archived")
+		self.assertEqual(image.enabled, 0)
+		self.assertEqual(image.image_object_key, "images/image-1/rootfs.img")
+		enqueue.assert_not_called()
+
+	def test_an_image_in_use_is_archived_instead_of_deleted(self) -> None:
 		service = VirtualMachineImageDeletionService()
+		image = build_image()
 
 		with (
 			patch("atlas.vm.core.vm_image_deletion.frappe.db", Mock(exists=Mock(return_value=True))),
-			self.assertRaises(frappe.ValidationError),
+			patch.object(service, "enqueue") as enqueue,
 		):
-			service.request(build_image())
+			self.assertEqual(service.request(image), "Archived")
+
+		self.assertEqual(image.status, "Archived")
+		enqueue.assert_not_called()
 
 	def test_an_incomplete_image_cannot_be_deleted(self) -> None:
 		service = VirtualMachineImageDeletionService()
 
-		for status in ("Pending", "Uploading", "Failed", "Deleting"):
+		for status in ("Pending", "Uploading", "Deleting", "Archived"):
 			with self.subTest(status=status), self.assertRaises(frappe.ValidationError):
 				service.request(build_image(status=status))
+
+	def test_a_failed_image_can_be_retired(self) -> None:
+		service = VirtualMachineImageDeletionService()
+		image = build_image(status="Failed")
+
+		with (
+			patch("atlas.vm.core.vm_image_deletion.frappe.db", Mock(exists=Mock(return_value=False))),
+			patch.object(service, "enqueue"),
+		):
+			self.assertEqual(service.request(image), "Deleting")
 
 	def test_a_request_marks_the_image_and_queues_the_cleanup(self) -> None:
 		service = VirtualMachineImageDeletionService()
@@ -56,7 +76,7 @@ class TestMachineImageDeletionRequest(UnitTestCase):
 			patch("atlas.vm.core.vm_image_deletion.frappe.db", Mock(exists=Mock(return_value=False))),
 			patch.object(service, "enqueue") as enqueue,
 		):
-			service.request(image)
+			self.assertEqual(service.request(image), "Deleting")
 
 		self.assertEqual(image.status, "Deleting")
 		self.assertEqual(image.enabled, 0)

--- a/atlas/vm/core/test_vm_image_deletion.py
+++ b/atlas/vm/core/test_vm_image_deletion.py
@@ -84,6 +84,39 @@ class TestMachineImageDeletionRequest(UnitTestCase):
 		enqueue.assert_called_once_with("image-1")
 
 
+class TestArchivedImageReclamation(UnitTestCase):
+	def reclaim(self, is_referenced: bool):
+		"""Run one reclamation pass over a single archived image."""
+		service = VirtualMachineImageDeletionService()
+		database = Mock(exists=Mock(return_value=is_referenced), set_value=Mock())
+
+		with (
+			patch("atlas.vm.core.vm_image_deletion.frappe.db", database),
+			patch("atlas.vm.core.vm_image_deletion.frappe.get_all", return_value=["image-1"]) as get_all,
+			patch.object(service, "enqueue") as enqueue,
+		):
+			service.reclaim_archived()
+
+		return database, get_all, enqueue
+
+	def test_an_unused_archived_image_moves_to_deleting_and_queues_cleanup(self) -> None:
+		database, _get_all, enqueue = self.reclaim(is_referenced=False)
+
+		database.set_value.assert_called_once_with("Virtual Machine Image", "image-1", "status", "Deleting")
+		enqueue.assert_called_once_with("image-1")
+
+	def test_an_archived_image_a_virtual_machine_still_uses_is_left_alone(self) -> None:
+		database, _get_all, enqueue = self.reclaim(is_referenced=True)
+
+		database.set_value.assert_not_called()
+		enqueue.assert_not_called()
+
+	def test_only_archived_machine_images_are_considered(self) -> None:
+		_database, get_all, _enqueue = self.reclaim(is_referenced=False)
+
+		self.assertEqual(get_all.call_args.kwargs["filters"], {"image_type": "machine", "status": "Archived"})
+
+
 class TestMachineImageCleanup(UnitTestCase):
 	def test_cleanup_removes_uploads_objects_and_staged_data(self) -> None:
 		service = VirtualMachineImageDeletionService()

--- a/atlas/vm/core/test_vm_image_deletion.py
+++ b/atlas/vm/core/test_vm_image_deletion.py
@@ -86,7 +86,6 @@ class TestMachineImageDeletionRequest(UnitTestCase):
 
 class TestArchivedImageReclamation(UnitTestCase):
 	def reclaim(self, is_referenced: bool):
-		"""Run one reclamation pass over a single archived image."""
 		service = VirtualMachineImageDeletionService()
 		database = Mock(exists=Mock(return_value=is_referenced), set_value=Mock())
 

--- a/atlas/vm/core/test_vm_service.py
+++ b/atlas/vm/core/test_vm_service.py
@@ -328,6 +328,33 @@ class TestVirtualMachineNetworkChanges(UnitTestCase):
 
 		update_network.assert_called_once_with({"public_network_throughput_mibps": 25})
 
+	def test_an_unowned_pool_address_is_claimed_for_the_tenant(self) -> None:
+		virtual_machine = SimpleNamespace(name="VM-00001", tenant_id=7, server="server-1")
+		address = SimpleNamespace(
+			tenant_id=-1, status="Allocated", virtual_machine=None, begin_assignment=Mock()
+		)
+
+		with patch("atlas.vm.core.vm_service.frappe.get_doc", return_value=address):
+			VirtualMachineService(virtual_machine).assign_ip_address("203.0.113.10")
+
+		self.assertEqual(address.tenant_id, 7)
+		address.begin_assignment.assert_called_once_with("server-1", "VM-00001")
+
+	def test_an_attached_pool_address_is_not_claimed(self) -> None:
+		virtual_machine = SimpleNamespace(name="VM-00001", tenant_id=7, server="server-1")
+		address = SimpleNamespace(
+			tenant_id=-1, status="Attached", virtual_machine=None, begin_assignment=Mock()
+		)
+
+		with (
+			patch("atlas.vm.core.vm_service.frappe.get_doc", return_value=address),
+			self.assertRaises(frappe.ValidationError),
+		):
+			VirtualMachineService(virtual_machine).assign_ip_address("203.0.113.10")
+
+		self.assertEqual(address.tenant_id, -1)
+		address.begin_assignment.assert_not_called()
+
 	def test_an_ip_address_from_another_tenant_is_rejected(self) -> None:
 		virtual_machine = SimpleNamespace(name="VM-00001", tenant_id=7, server="server-1")
 		address = SimpleNamespace(tenant_id=8, status="Allocated", virtual_machine=None)

--- a/atlas/vm/core/vm_image_deletion.py
+++ b/atlas/vm/core/vm_image_deletion.py
@@ -29,18 +29,31 @@ class VirtualMachineImageInUse(AtlasUserError):
 class VirtualMachineImageDeletionService:
 	"""Own the deletion of one Machine image."""
 
-	def request(self, image: VirtualMachineImage) -> None:
-		"""Mark one unused Machine image for deletion and queue its cleanup."""
-		if image.image_type != "machine":
-			frappe.throw(_("Only a Machine image can be deleted."), exc=AtlasUserError)
-		if image.status != "Available":
-			frappe.throw(_("Only an Available Machine image can be deleted."), exc=AtlasUserError)
-		self.validate_is_unused(cast(str, image.name))
+	def request(self, image: VirtualMachineImage) -> str:
+		"""Retire one image, and reclaim its artifacts when nothing needs them."""
+		if image.status not in ("Available", "Failed"):
+			frappe.throw(_("Only an Available or Failed image can be deleted."), exc=AtlasUserError)
 
-		image.status = "Deleting"
+		image.status = "Deleting" if self.is_reclaimable(image) else "Archived"
 		image.enabled = 0
 		image.save()
-		self.enqueue(cast(str, image.name))
+
+		if image.status == "Deleting":
+			self.enqueue(cast(str, image.name))
+
+		return cast(str, image.status)
+
+	@staticmethod
+	def is_reclaimable(image: VirtualMachineImage) -> bool:
+		"""Return whether the stored artifacts can be removed now.
+
+		A System image stays shared, so only a Machine image that no virtual
+		machine references releases its storage.
+		"""
+		if image.image_type != "machine":
+			return False
+
+		return not frappe.db.exists("Virtual Machine", {"virtual_machine_image": image.name})
 
 	def enqueue(self, image_name: str) -> None:
 		"""Enqueue one repeatable Machine image cleanup."""

--- a/atlas/vm/core/vm_image_deletion.py
+++ b/atlas/vm/core/vm_image_deletion.py
@@ -43,6 +43,19 @@ class VirtualMachineImageDeletionService:
 
 		return cast(str, image.status)
 
+	def reclaim_archived(self) -> None:
+		"""Delete each archived Machine image that lost its last virtual machine."""
+		for name in frappe.get_all(
+			"Virtual Machine Image",
+			filters={"image_type": "machine", "status": "Archived"},
+			pluck="name",
+		):
+			if frappe.db.exists("Virtual Machine", {"virtual_machine_image": name}):
+				continue
+
+			frappe.db.set_value("Virtual Machine Image", name, "status", "Deleting")
+			self.enqueue(name)
+
 	@staticmethod
 	def is_reclaimable(image: VirtualMachineImage) -> bool:
 		"""Return whether the stored artifacts can be removed now.
@@ -115,15 +128,16 @@ class VirtualMachineImageDeletionService:
 
 
 def enqueue_pending_virtual_machine_image_deletions() -> None:
-	"""Resume Machine image deletions that did not finish."""
-	names = frappe.get_all(
+	"""Resume unfinished deletions and reclaim an archived image that is now unused."""
+	service = VirtualMachineImageDeletionService()
+	for name in frappe.get_all(
 		"Virtual Machine Image",
 		filters={"image_type": "machine", "status": "Deleting"},
 		pluck="name",
-	)
-	service = VirtualMachineImageDeletionService()
-	for name in names:
+	):
 		service.enqueue(name)
+
+	service.reclaim_archived()
 
 
 @run_as_admin

--- a/atlas/vm/core/vm_service.py
+++ b/atlas/vm/core/vm_service.py
@@ -8,6 +8,7 @@ from frappe import _
 
 from atlas.atlas.core.exceptions import AtlasUserError
 from atlas.atlas.core.mesh_address import get_virtual_machine_mesh_address
+from atlas.metal_server.core.ip_address_service import UNOWNED_TENANT_ID
 from atlas.vm.core.metal_client import MetalClient, MetalClientError
 from atlas.vm.core.metal_models import MetalVirtualMachine
 from atlas.vm.core.models import EGRESS_MODES, VirtualMachineCreateRequest
@@ -344,10 +345,12 @@ class VirtualMachineService:
 			"MetalServerIPAddress",
 			frappe.get_doc("Metal Server IP Address", server_ip_address, for_update=True),
 		)
-		if address.tenant_id != self.virtual_machine.tenant_id:
+		if address.tenant_id not in (self.virtual_machine.tenant_id, UNOWNED_TENANT_ID):
 			frappe.throw(_("The IP address belongs to another tenant."), exc=frappe.PermissionError)
 		if address.status != "Allocated" or address.virtual_machine:
 			frappe.throw(_("The IP address is not available."), exc=frappe.ValidationError)
+
+		address.tenant_id = self.virtual_machine.tenant_id
 		address.begin_assignment(self.virtual_machine.server, self.virtual_machine.name)
 		return address
 

--- a/atlas/vm/doctype/virtual_machine_image/test_virtual_machine_image.py
+++ b/atlas/vm/doctype/virtual_machine_image/test_virtual_machine_image.py
@@ -50,6 +50,12 @@ class TestVirtualMachineImage(UnitTestCase):
 			setattr(image, key, value)
 		return image
 
+	def test_an_archived_image_cannot_boot_a_virtual_machine(self) -> None:
+		image = self.make_image(status="Archived")
+
+		with self.assertRaises(frappe.ValidationError):
+			image.validate_is_available()
+
 	def test_download_returns_only_the_selected_artifact(self) -> None:
 		image = self.make_image()
 		with (

--- a/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.js
+++ b/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.js
@@ -23,6 +23,22 @@ frappe.ui.form.on("Virtual Machine Image", {
 			});
 		}
 
+		if (["Available", "Failed"].includes(frm.doc.status)) {
+			frm.add_custom_button(
+				__("Delete Image"),
+				() => {
+					frappe.confirm(
+						__(
+							"Delete {0}? New virtual machines cannot use it. Its artifacts stay while a virtual machine still needs them.",
+							[frm.doc.title]
+						),
+						() => frm.call("request_deletion").then(() => frm.reload_doc())
+					);
+				},
+				__("Dangerous Actions")
+			);
+		}
+
 		if (frm.doc.artifact_storage === "Site File" && frm.doc.status === "Available") {
 			frm.add_custom_button(__("Migrate to Object Storage"), () => {
 				frm.call("migrate_to_object_storage").then(() => frm.reload_doc());

--- a/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.json
+++ b/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.json
@@ -70,7 +70,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nSnapshotting\nUploading\nCompleting\nCleaning\nAvailable\nFailed\nDeleting",
+   "options": "Pending\nSnapshotting\nUploading\nCompleting\nCleaning\nAvailable\nFailed\nDeleting\nArchived",
    "read_only": 1,
    "reqd": 1
   },
@@ -377,6 +377,10 @@
   {
    "color": "Red",
    "title": "Deleting"
+  },
+  {
+   "color": "Gray",
+   "title": "Archived"
   }
  ],
  "title_field": "title"

--- a/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.py
+++ b/atlas/vm/doctype/virtual_machine_image/virtual_machine_image.py
@@ -77,6 +77,7 @@ class VirtualMachineImage(Document):
 			"Available",
 			"Failed",
 			"Deleting",
+			"Archived",
 		]
 		tenant_id: DF.Int
 		title: DF.Data
@@ -270,10 +271,10 @@ class VirtualMachineImage(Document):
 		VirtualMachineImageStorageMigration().request(self)
 
 	@frappe.whitelist(methods=["POST"])
-	def request_deletion(self) -> None:
-		"""Queue deletion of this unused Machine image."""
+	def request_deletion(self) -> str:
+		"""Retire this image and return the status it reached."""
 		self.check_permission("write")
 
 		from atlas.vm.core.vm_image_deletion import VirtualMachineImageDeletionService
 
-		VirtualMachineImageDeletionService().request(self)
+		return VirtualMachineImageDeletionService().request(self)

--- a/clients/atlas-client/atlas_client/api/images/delete_image.py
+++ b/clients/atlas-client/atlas_client/api/images/delete_image.py
@@ -76,8 +76,9 @@ def sync_detailed(
 ) -> Response[Any | ImageResponse]:
     """ Delete image
 
-     Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored
-    artifacts and remaining host snapshot data.
+     Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored
+    artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes
+    Archived and keeps its artifacts.
 
     Args:
         image_id (str):
@@ -113,8 +114,9 @@ def sync(
 ) -> Any | ImageResponse | None:
     """ Delete image
 
-     Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored
-    artifacts and remaining host snapshot data.
+     Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored
+    artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes
+    Archived and keeps its artifacts.
 
     Args:
         image_id (str):
@@ -145,8 +147,9 @@ async def asyncio_detailed(
 ) -> Response[Any | ImageResponse]:
     """ Delete image
 
-     Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored
-    artifacts and remaining host snapshot data.
+     Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored
+    artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes
+    Archived and keeps its artifacts.
 
     Args:
         image_id (str):
@@ -182,8 +185,9 @@ async def asyncio(
 ) -> Any | ImageResponse | None:
     """ Delete image
 
-     Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored
-    artifacts and remaining host snapshot data.
+     Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored
+    artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes
+    Archived and keeps its artifacts.
 
     Args:
         image_id (str):

--- a/clients/atlas-client/atlas_client/api/images/list_images.py
+++ b/clients/atlas-client/atlas_client/api/images/list_images.py
@@ -8,6 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...types import Response, UNSET
 from ... import errors
 
+from ...models.list_images_image_type_type_0 import ListImagesImageTypeType0
 from ...models.page_image_response import PageImageResponse
 from ...types import UNSET, Unset
 from typing import cast
@@ -18,6 +19,7 @@ def _get_kwargs(
     *,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
+    image_type: ListImagesImageTypeType0 | None | Unset = UNSET,
     x_tenant_id: int,
 
 ) -> dict[str, Any]:
@@ -34,6 +36,15 @@ def _get_kwargs(
     params["offset"] = offset
 
     params["limit"] = limit
+
+    json_image_type: None | str | Unset
+    if isinstance(image_type, Unset):
+        json_image_type = UNSET
+    elif isinstance(image_type, ListImagesImageTypeType0):
+        json_image_type = image_type.value
+    else:
+        json_image_type = image_type
+    params["image_type"] = json_image_type
 
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
@@ -79,16 +90,20 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
+    image_type: ListImagesImageTypeType0 | None | Unset = UNSET,
     x_tenant_id: int,
 
 ) -> Response[PageImageResponse]:
     """ List images
 
-     Returns one page of System and Machine images owned by the tenant in newest-first order.
+     Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A
+    disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as
+    `system` or `machine` to return only that type. Omit it to return both.
 
     Args:
         offset (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 20.
+        image_type (ListImagesImageTypeType0 | None | Unset):
         x_tenant_id (int):
 
     Raises:
@@ -103,6 +118,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         offset=offset,
 limit=limit,
+image_type=image_type,
 x_tenant_id=x_tenant_id,
 
     )
@@ -118,16 +134,20 @@ def sync(
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
+    image_type: ListImagesImageTypeType0 | None | Unset = UNSET,
     x_tenant_id: int,
 
 ) -> PageImageResponse | None:
     """ List images
 
-     Returns one page of System and Machine images owned by the tenant in newest-first order.
+     Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A
+    disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as
+    `system` or `machine` to return only that type. Omit it to return both.
 
     Args:
         offset (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 20.
+        image_type (ListImagesImageTypeType0 | None | Unset):
         x_tenant_id (int):
 
     Raises:
@@ -143,6 +163,7 @@ def sync(
         client=client,
 offset=offset,
 limit=limit,
+image_type=image_type,
 x_tenant_id=x_tenant_id,
 
     ).parsed
@@ -152,16 +173,20 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
+    image_type: ListImagesImageTypeType0 | None | Unset = UNSET,
     x_tenant_id: int,
 
 ) -> Response[PageImageResponse]:
     """ List images
 
-     Returns one page of System and Machine images owned by the tenant in newest-first order.
+     Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A
+    disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as
+    `system` or `machine` to return only that type. Omit it to return both.
 
     Args:
         offset (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 20.
+        image_type (ListImagesImageTypeType0 | None | Unset):
         x_tenant_id (int):
 
     Raises:
@@ -176,6 +201,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         offset=offset,
 limit=limit,
+image_type=image_type,
 x_tenant_id=x_tenant_id,
 
     )
@@ -191,16 +217,20 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     offset: int | Unset = 0,
     limit: int | Unset = 20,
+    image_type: ListImagesImageTypeType0 | None | Unset = UNSET,
     x_tenant_id: int,
 
 ) -> PageImageResponse | None:
     """ List images
 
-     Returns one page of System and Machine images owned by the tenant in newest-first order.
+     Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A
+    disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as
+    `system` or `machine` to return only that type. Omit it to return both.
 
     Args:
         offset (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 20.
+        image_type (ListImagesImageTypeType0 | None | Unset):
         x_tenant_id (int):
 
     Raises:
@@ -216,6 +246,7 @@ async def asyncio(
         client=client,
 offset=offset,
 limit=limit,
+image_type=image_type,
 x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/clients/atlas-client/atlas_client/models/__init__.py
+++ b/clients/atlas-client/atlas_client/models/__init__.py
@@ -17,6 +17,7 @@ from .ip_address_assignment_payload import IPAddressAssignmentPayload
 from .ip_address_response import IPAddressResponse
 from .json_web_key import JSONWebKey
 from .json_web_key_set_response import JSONWebKeySetResponse
+from .list_images_image_type_type_0 import ListImagesImageTypeType0
 from .metadata_replacement_payload import MetadataReplacementPayload
 from .metadata_replacement_payload_metadata import MetadataReplacementPayloadMetadata
 from .network_update_payload import NetworkUpdatePayload
@@ -56,6 +57,7 @@ __all__ = (
     "IPAddressResponse",
     "JSONWebKey",
     "JSONWebKeySetResponse",
+    "ListImagesImageTypeType0",
     "MetadataReplacementPayload",
     "MetadataReplacementPayloadMetadata",
     "NetworkUpdatePayload",

--- a/clients/atlas-client/atlas_client/models/list_images_image_type_type_0.py
+++ b/clients/atlas-client/atlas_client/models/list_images_image_type_type_0.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+class ListImagesImageTypeType0(StrEnum):
+    MACHINE = "machine"
+    SYSTEM = "system"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/openapi/atlas-client.json
+++ b/clients/openapi/atlas-client.json
@@ -1283,7 +1283,7 @@
   "paths": {
     "/api/atlas/images": {
       "get": {
-        "description": "Returns one page of System and Machine images owned by the tenant in newest-first order.",
+        "description": "Returns one page of enabled System and Machine images owned by the tenant in newest-first order. A disabled image cannot boot a virtual machine, so the list leaves it out. Pass `image_type` as `system` or `machine` to return only that type. Omit it to return both.",
         "operationId": "list_images",
         "parameters": [
           {
@@ -1319,6 +1319,27 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "image_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "system",
+                    "machine"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Image Type"
+            }
           }
         ],
         "responses": {
@@ -1341,7 +1362,7 @@
     },
     "/api/atlas/images/{image_id}": {
       "delete": {
-        "description": "Starts deletion of an unused Available image that the tenant owns. A cleanup job removes its stored artifacts and remaining host snapshot data.",
+        "description": "Retires an Available or Failed image that the tenant owns. A cleanup job removes the stored artifacts and remaining host snapshot data of an unused Machine image. Any other image becomes Archived and keeps its artifacts.",
         "operationId": "delete_image",
         "parameters": [
           {
@@ -1376,7 +1397,7 @@
             "description": "Deletion started. Poll the image route."
           },
           "409": {
-            "description": "A virtual machine uses this image, or another tenant owns it."
+            "description": "Another tenant owns this System image."
           }
         },
         "summary": "Delete image",

--- a/metal/internal/vm/manager.go
+++ b/metal/internal/vm/manager.go
@@ -22,6 +22,10 @@ import (
 // defaultFastApplyTimeout bounds an immediate guest update.
 const defaultFastApplyTimeout = 2 * time.Second
 
+// informationAttempts bounds the reads that settle a record pair caught mid
+// removal. The window is one file unlink, so a second read almost always agrees.
+const informationAttempts = 3
+
 // ManagerConfig contains persistent VM manager settings.
 type ManagerConfig struct {
 	MachinesDirectory string
@@ -210,16 +214,38 @@ func (manager *Manager) ListIDs(_ context.Context) ([]string, error) {
 }
 
 // information reads both records without taking the VM lock.
+//
+// A removal unlinks the two records one after the other, so a lock-free read can
+// find one present and the other already gone. Reporting that as ErrNotFound
+// would tell a caller the VM is destroyed while it still exists, and a caller
+// acts on that, so the pair is read again until it agrees.
 func (manager *Manager) information(identifier string) (Information, error) {
-	desired, err := manager.store.readDesired(identifier)
-	if err != nil {
-		return Information{}, err
+	var lastError error
+
+	for range informationAttempts {
+		desired, desiredError := manager.store.readDesired(identifier)
+		observed, observedError := manager.store.readObserved(identifier)
+		if desiredError == nil && observedError == nil {
+			return informationFromRecords(desired, observed, observed.Disk), nil
+		}
+
+		lastError = errors.Join(desiredError, observedError)
+		if !isTornRemoval(desiredError, observedError) {
+			return Information{}, lastError
+		}
 	}
-	observed, err := manager.store.readObserved(identifier)
-	if err != nil {
-		return Information{}, err
+
+	return Information{}, lastError
+}
+
+// isTornRemoval reports whether one record is gone while the other is present,
+// which only a removal in progress produces.
+func isTornRemoval(desiredError, observedError error) bool {
+	if errors.Is(desiredError, ErrNotFound) && observedError == nil {
+		return true
 	}
-	return informationFromRecords(desired, observed, observed.Disk), nil
+
+	return errors.Is(observedError, ErrNotFound) && desiredError == nil
 }
 
 // allocateUserID returns a host user ID that no stored or temporary VM holds.

--- a/metal/internal/vm/manager.go
+++ b/metal/internal/vm/manager.go
@@ -22,12 +22,8 @@ import (
 // defaultFastApplyTimeout bounds an immediate guest update.
 const defaultFastApplyTimeout = 2 * time.Second
 
-// informationAttempts bounds the reads that settle a record pair caught mid
-// removal. The window is one file unlink, so a second read almost always agrees.
 const informationAttempts = 3
 
-// informationRetryDelay separates those reads. It has to outlast one unlink, or
-// every attempt lands in the same window and the pair never settles.
 const informationRetryDelay = 5 * time.Millisecond
 
 // ManagerConfig contains persistent VM manager settings.
@@ -217,18 +213,11 @@ func (manager *Manager) ListIDs(_ context.Context) ([]string, error) {
 	return manager.store.listIDs()
 }
 
-// information reads both records without taking the VM lock.
-//
-// A removal unlinks the two records one after the other, so a lock-free read can
-// find one present and the other already gone. Reporting that as ErrNotFound
-// would tell a caller the VM is destroyed while it still exists, and a caller
-// acts on that, so the pair is read again until it agrees.
+// information retries a read when removal leaves one record temporarily absent.
 func (manager *Manager) information(identifier string) (Information, error) {
 	var lastError error
 
 	for attempt := range informationAttempts {
-		// Back off before reading again. Immediate reads are fast enough to land
-		// inside one removal, which would settle nothing.
 		if attempt > 0 {
 			time.Sleep(informationRetryDelay)
 		}
@@ -248,8 +237,7 @@ func (manager *Manager) information(identifier string) (Information, error) {
 	return Information{}, lastError
 }
 
-// isTornRemoval reports whether one record is gone while the other is present,
-// which only a removal in progress produces.
+// isTornRemoval reports whether removal left one record temporarily absent.
 func isTornRemoval(desiredError, observedError error) bool {
 	if errors.Is(desiredError, ErrNotFound) && observedError == nil {
 		return true

--- a/metal/internal/vm/manager.go
+++ b/metal/internal/vm/manager.go
@@ -163,18 +163,16 @@ func (manager *Manager) Create(ctx context.Context, identifier string, specifica
 	return informationFromRecords(desired, observed, DiskUsage{}), nil
 }
 
-// Information returns the persisted desired and observed VM state.
-func (manager *Manager) Information(ctx context.Context, identifier string) (Information, error) {
-	virtualMachine := manager.newVirtualMachine(identifier)
-	unlock, err := virtualMachine.lock(ctx)
-	if err != nil {
-		return Information{}, err
-	}
-	defer unlock()
+// Information returns the persisted desired and observed VM state. It takes no
+// operation lock, because a status read must not wait for the reconcile pass
+// that holds the lock across an image pull and a boot. Each record is written
+// atomically, so a read sees whole records.
+func (manager *Manager) Information(_ context.Context, identifier string) (Information, error) {
 	// Incoming migration targets are not normal VMs.
 	if manager.isTargetReserved(identifier) {
 		return Information{}, ErrNotFound
 	}
+
 	return manager.information(identifier)
 }
 

--- a/metal/internal/vm/manager.go
+++ b/metal/internal/vm/manager.go
@@ -26,6 +26,10 @@ const defaultFastApplyTimeout = 2 * time.Second
 // removal. The window is one file unlink, so a second read almost always agrees.
 const informationAttempts = 3
 
+// informationRetryDelay separates those reads. It has to outlast one unlink, or
+// every attempt lands in the same window and the pair never settles.
+const informationRetryDelay = 5 * time.Millisecond
+
 // ManagerConfig contains persistent VM manager settings.
 type ManagerConfig struct {
 	MachinesDirectory string
@@ -222,7 +226,13 @@ func (manager *Manager) ListIDs(_ context.Context) ([]string, error) {
 func (manager *Manager) information(identifier string) (Information, error) {
 	var lastError error
 
-	for range informationAttempts {
+	for attempt := range informationAttempts {
+		// Back off before reading again. Immediate reads are fast enough to land
+		// inside one removal, which would settle nothing.
+		if attempt > 0 {
+			time.Sleep(informationRetryDelay)
+		}
+
 		desired, desiredError := manager.store.readDesired(identifier)
 		observed, observedError := manager.store.readObserved(identifier)
 		if desiredError == nil && observedError == nil {

--- a/metal/internal/vm/manager_test.go
+++ b/metal/internal/vm/manager_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -639,5 +640,53 @@ func TestRunTemporaryRejectsInvalidIdentifier(t *testing.T) {
 	})
 	if !errors.Is(err, ErrConflict) {
 		t.Fatalf("temporary machine error = %v, want conflict", err)
+	}
+}
+
+func TestInformationStopsRetryingAPairThatStaysTorn(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	if _, err := manager.Create(context.Background(), "machine-1", testSpecification()); err != nil {
+		t.Fatal(err)
+	}
+
+	// A removal unlinks the two records in turn. A read between them must not
+	// report a virtual machine that still exists as gone.
+	if err := os.Remove(manager.store.observedPath("machine-1")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := manager.Information(context.Background(), "machine-1")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound once the retries give up, got %v", err)
+	}
+}
+
+func TestInformationReadsAWholePair(t *testing.T) {
+	manager, _, _, _ := newTestManager(t)
+	if _, err := manager.Create(context.Background(), "machine-1", testSpecification()); err != nil {
+		t.Fatal(err)
+	}
+
+	information, err := manager.Information(context.Background(), "machine-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if information.ID != "machine-1" {
+		t.Fatalf("want machine-1, got %q", information.ID)
+	}
+}
+
+func TestATornRemovalIsOnlyOneMissingRecord(t *testing.T) {
+	if !isTornRemoval(fmt.Errorf("read: %w", ErrNotFound), nil) {
+		t.Fatal("a missing desired record with an observed record present is torn")
+	}
+	if !isTornRemoval(nil, fmt.Errorf("read: %w", ErrNotFound)) {
+		t.Fatal("a missing observed record with a desired record present is torn")
+	}
+	if isTornRemoval(fmt.Errorf("read: %w", ErrNotFound), fmt.Errorf("read: %w", ErrNotFound)) {
+		t.Fatal("both records missing is a completed removal, not a torn read")
+	}
+	if isTornRemoval(errors.New("permission denied"), nil) {
+		t.Fatal("an unrelated failure is not a torn read")
 	}
 }

--- a/metal/internal/vm/manager_test.go
+++ b/metal/internal/vm/manager_test.go
@@ -649,8 +649,6 @@ func TestInformationStopsRetryingAPairThatStaysTorn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A removal unlinks the two records in turn. A read between them must not
-	// report a virtual machine that still exists as gone.
 	if err := os.Remove(manager.store.observedPath("machine-1")); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

This pull request groups miscellaneous Atlas fixes for image lifecycle handling, VM status reads, and server IP ownership.

## What changed

- Retire images safely when virtual machines still use them.
- Reclaim archived Machine images after their last virtual machine is removed.
- Filter image listings by type and exclude disabled images.
- Add the generated API client updates for the image API changes.
- Allow virtual machines to claim unowned pool addresses.
- Add a System Manager action to reset an address to the shared pool and record the previous tenant.
- Make VM status reads resilient to slow reads and record pairs caught during removal.
- Add focused tests and update image and IP address documentation.
- Remove verbose comments from the affected code.

## Why

These changes keep image and address state consistent, prevent misleading VM status responses during concurrent file removal, and document the current API and lifecycle behavior.

## Screenshots

Not applicable. This pull request has no visual changes.

## Related issues

No linked issue.