### PR TITLE
fix(metal): Map a public IPv4 for host-originated traffic

### DIFF
--- a/metal/internal/network/egress.go
+++ b/metal/internal/network/egress.go
@@ -132,14 +132,19 @@ func publicIPv4RuleCheck(step []string) []string {
 	return check
 }
 
-// publicIPv4Steps maps the public address to the guest: DNAT in, SNAT out,
-// forwarding both ways, and a second DNAT inside the namespace. The SNAT rule is
-// inserted first, so it wins over any wider masquerade rule.
+// publicIPv4Steps maps the public address to the guest: DNAT in for forwarded and
+// host-originated traffic, SNAT out, forwarding both ways, and a second DNAT inside
+// the namespace. The SNAT rule is inserted first, so it wins over any wider
+// masquerade rule.
 func publicIPv4Steps(virtualMachineID, namespace, guestVirtualEthernet, namespaceIPAddress, publicIPv4 string) [][]string {
 	comment := publicIPv4Comment(virtualMachineID)
 	return [][]string{
 		// Inbound: the public address becomes the namespace transit address.
 		{"iptables", "-t", "nat", "-A", "PREROUTING", "-d", publicIPv4, "-m", "comment", "--comment", comment, "-j", "DNAT", "--to-destination", namespaceIPAddress},
+
+		// Host-originated: a local process reaches a co-located VM through its
+		// public address. Such a packet skips PREROUTING, so OUTPUT repeats the map.
+		{"iptables", "-t", "nat", "-A", "OUTPUT", "-d", publicIPv4, "-m", "comment", "--comment", comment, "-j", "DNAT", "--to-destination", namespaceIPAddress},
 
 		// Outbound: the VM leaves as its public address. Inserted at position 1,
 		// so it wins over the wider masquerade rule that egress adds.

--- a/metal/internal/network/egress_test.go
+++ b/metal/internal/network/egress_test.go
@@ -32,3 +32,16 @@ func TestDefaultRouteStepsAreSafeToRepeat(t *testing.T) {
 		t.Fatalf("default route step = %v, want replace", steps[0])
 	}
 }
+
+func TestPublicIPv4StepsMapHostOriginatedTraffic(t *testing.T) {
+	steps := publicIPv4Steps("vm-10", "metal-vm-10", "vpeer0", "10.6.26.130", "203.0.113.7")
+
+	want := []string{
+		"iptables", "-t", "nat", "-A", "OUTPUT", "-d", "203.0.113.7",
+		"-m", "comment", "--comment", "metal-public-ipv4-vm-10",
+		"-j", "DNAT", "--to-destination", "10.6.26.130",
+	}
+	if !slices.ContainsFunc(steps, func(step []string) bool { return slices.Equal(step, want) }) {
+		t.Fatalf("steps = %v, want one matching %v", steps, want)
+	}
+}


### PR DESCRIPTION
## Issue

A virtual machine stayed in the `unknown` state because `metald` could not download its image through a proxy that runs on the same host.

## Summary

The public IPv4 map applied only to forwarded traffic. This adds the same map for traffic that a host process starts, so a host can reach a virtual machine on that host through its public address.

## What changed

- Add an `OUTPUT` DNAT rule to `publicIPv4Steps`, next to the `PREROUTING` rule.
- Add a test that the step set maps host-originated traffic.

## Why

`PREROUTING` applies only to forwarded packets. A packet that a local process starts goes through `OUTPUT`, which had no rule, so it left through the uplink to an address that does not route back and the connection timed out.

This applies to every virtual machine with a public IPv4 address, not only a proxy. A local process is the only client that reaches such an address from the host, so the gap showed first when `metald` fetched an image through a co-located proxy.

Rule cleanup lists the whole `nat` table and deletes by comment, so it removes the new rule without a change.