### PR TITLE
feat(atlas-vm): Configure Atlas from deployer settings

### DIFF
--- a/atlas/atlas/SPEC.md
+++ b/atlas/atlas/SPEC.md
@@ -68,6 +68,8 @@ The `configure-atlas` site command reads one JSON document from standard input. 
 
 The command keeps provider resource identifiers after each successful setup phase. A repeated command updates mutable settings and rejects changes to completed provider identities.
 
+Each external setup phase commits its local state. A cloud or certificate operation cannot roll back, so the next run needs this state for reconciliation.
+
 The command uses an existing public Route53 zone. It does not create a hosted zone. It gets both Metal Server catalogs and issues the wildcard certificate before it reports success.
 
 ## Related

--- a/atlas/atlas/SPEC.md
+++ b/atlas/atlas/SPEC.md
@@ -15,6 +15,7 @@ This module also holds site settings, the regional token key, the wildcard TLS c
 | Type | Owns |
 |---|---|
 | `AtlasSettings` (DocType) | Provider selection, credentials, the regional token key, and the published binary links. |
+| `AtlasSetup` | Applies deployer settings and completes provider, DNS, catalog, and certificate setup. |
 | `ServerProvider` | The contract every server provider implements. |
 | `registry` | The map from a stable provider name to its implementation. |
 | `DNSProvider`, `Route53Provider` | The DNS contract and its Route 53 implementation. |
@@ -60,6 +61,14 @@ Do not put a key or password in `script` or `environment`. These fields are stor
 A build runs only when its source hash changes. Atlas publishes the result as a public File because a host has no Atlas credential.
 
 `artifacts` publishes build output and its download URL. It keeps a replaced File until no Atlas Settings link refers to it. The [Service module](../service/SPEC.md) uses the same helper for its package.
+
+## Automatic setup
+
+The `configure-atlas` site command reads one JSON document from standard input. The `atlas-vm` setup script uses this command and does not put secrets in process arguments.
+
+The command keeps provider resource identifiers after each successful setup phase. A repeated command updates mutable settings and rejects changes to completed provider identities.
+
+The command uses an existing public Route53 zone. It does not create a hosted zone. It gets both Metal Server catalogs and issues the wildcard certificate before it reports success.
 
 ## Related
 

--- a/atlas/atlas/core/dns_providers/base.py
+++ b/atlas/atlas/core/dns_providers/base.py
@@ -39,6 +39,11 @@ class DnsProvider(ABC):
 		...
 
 	@abstractmethod
+	def find_public_zone_id(self, domain: str) -> str | None:
+		"""Return the ID of an existing public zone for the exact domain."""
+		...
+
+	@abstractmethod
 	def upsert_record(self, record_type: str, name: str, values: list[str], ttl: int = 300) -> None:
 		"""Create the DNS record if missing, or update it to match the given values."""
 		...

--- a/atlas/atlas/core/dns_providers/route53.py
+++ b/atlas/atlas/core/dns_providers/route53.py
@@ -74,6 +74,22 @@ class Route53Provider(DnsProvider):
 		return None
 
 	@override
+	def find_public_zone_id(self, domain: str) -> str | None:
+		"""Return the ID of an existing public zone for the exact domain."""
+		try:
+			result = self.client.list_hosted_zones_by_name(DNSName=domain, MaxItems="100")
+		except (BotoCoreError, ClientError) as error:
+			raise Route53Error(f"Failed to list zones for {domain}: {error}") from error
+
+		for zone in result.get("HostedZones", []):
+			if zone["Name"].rstrip(".") != domain:
+				break
+			if not zone.get("Config", {}).get("PrivateZone", False):
+				return self._zone_id(zone["Id"])
+
+		return None
+
+	@override
 	def create_zone(self, domain: str) -> str:
 		"""Return the existing zone ID for the domain, or create one."""
 		if self.settings.route53_dns_zone_id:

--- a/atlas/atlas/core/dns_providers/test_route53.py
+++ b/atlas/atlas/core/dns_providers/test_route53.py
@@ -25,6 +25,39 @@ def _build_provider() -> Route53Provider:
 
 
 class TestRoute53Provider(UnitTestCase):
+	def test_find_public_zone_skips_a_private_zone(self) -> None:
+		provider = _build_provider()
+		provider.client.list_hosted_zones_by_name.return_value = {
+			"HostedZones": [
+				{
+					"Id": "/hostedzone/private",
+					"Name": "example.com.",
+					"Config": {"PrivateZone": True},
+				},
+				{
+					"Id": "/hostedzone/public",
+					"Name": "example.com.",
+					"Config": {"PrivateZone": False},
+				},
+			],
+		}
+
+		self.assertEqual(provider.find_public_zone_id("example.com"), "public")
+
+	def test_find_public_zone_refuses_a_private_zone(self) -> None:
+		provider = _build_provider()
+		provider.client.list_hosted_zones_by_name.return_value = {
+			"HostedZones": [
+				{
+					"Id": "/hostedzone/private",
+					"Name": "example.com.",
+					"Config": {"PrivateZone": True},
+				}
+			],
+		}
+
+		self.assertIsNone(provider.find_public_zone_id("example.com"))
+
 	def test_bootstrap_creates_the_wildcard_cname(self) -> None:
 		provider = _build_provider()
 		provider.settings.save = MagicMock()

--- a/atlas/atlas/core/setup.py
+++ b/atlas/atlas/core/setup.py
@@ -76,7 +76,8 @@ class AtlasSetupConfiguration:
 			if not isinstance(values[field], bool):
 				raise ValueError(f"Atlas setup field {field} must be true or false")
 
-		return cls(**values)
+		normalized_values = {**values, "region_name": values["region_name"].strip().lower()}
+		return cls(**normalized_values)
 
 	def settings_values(self) -> dict[str, object]:
 		"""Return the values that belong to Atlas Settings."""
@@ -105,9 +106,9 @@ class AtlasSetup:
 	def run(self) -> None:
 		"""Apply settings and complete each setup phase."""
 		self._validate_immutable_values()
+		self._clear_certificate_for_environment_change()
 		self.settings.update(self.configuration.settings_values())
 		self.settings.save(ignore_permissions=True)
-		frappe.db.commit()  # nosemgrep: a setup checkpoint must survive a later provider failure
 
 		self._setup_server_provider()
 		self._setup_dns_provider()
@@ -115,6 +116,8 @@ class AtlasSetup:
 		self._sync_central_keys()
 		self._issue_wildcard_certificate()
 		self._validate_result()
+		# A site command has no request transaction. Keep the completed reconciliation.
+		frappe.db.commit()  # nosemgrep
 
 	def _validate_immutable_values(self) -> None:
 		if self.settings.is_server_provider_setup_completed:
@@ -133,12 +136,27 @@ class AtlasSetup:
 					)
 				)
 
+	def _clear_certificate_for_environment_change(self) -> None:
+		if bool(self.settings.is_letsencrypt_staging) == self.configuration.is_letsencrypt_staging:
+			return
+		if not self.settings.wildcard_tls_certificate:
+			return
+
+		self.settings.wildcard_tls_certificate = None
+		self.settings.wildcard_tls_private_key = None
+
 	def _setup_server_provider(self) -> None:
 		if self.settings.is_server_provider_setup_completed:
 			return
 
-		self.settings.server_provider_controller.setup_infrastructure()
-		frappe.db.commit()  # nosemgrep: keep provider resource IDs when a later phase fails
+		try:
+			self.settings.server_provider_controller.setup_infrastructure()
+		except Exception:
+			# Keep IDs for cloud resources that the failed provider call created.
+			frappe.db.commit()  # nosemgrep
+			raise
+		# Keep provider resource IDs when a later external phase fails.
+		frappe.db.commit()  # nosemgrep
 
 	def _setup_dns_provider(self) -> None:
 		provider = self.settings.dns_provider_controller
@@ -160,28 +178,34 @@ class AtlasSetup:
 			return
 
 		self.settings.route53_dns_zone_id = zone_id
-		provider.bootstrap()
-		frappe.db.commit()  # nosemgrep: keep DNS setup when a later phase fails
+		try:
+			provider.bootstrap()
+		except Exception:
+			# Keep the zone ID and records that the failed provider call created.
+			frappe.db.commit()  # nosemgrep
+			raise
+		# Keep DNS state when a later external phase fails.
+		frappe.db.commit()  # nosemgrep
 
 	def _sync_catalogs(self) -> None:
 		catalog = CatalogSynchronizer(self.settings.server_provider_controller)
 		catalog.sync_server_sizes()
 		catalog.sync_server_images()
-		frappe.db.commit()  # nosemgrep: keep catalog data when a later phase fails
 
 	def _sync_central_keys(self) -> None:
 		if not sync_central_jwks():
 			frappe.throw(_("Atlas could not get the configured Central JSON Web Key Set."))
-		frappe.db.commit()  # nosemgrep: keep a valid key set when certificate issuance fails
+		self.settings.reload()
 
 	def _issue_wildcard_certificate(self) -> None:
-		if not self._certificate_needs_renewal():
+		if not self._does_certificate_need_renewal():
 			return
 
 		self.settings.issue_wildcard_certificate()
-		frappe.db.commit()  # nosemgrep: certificate issuance is an external setup checkpoint
+		# Keep the issued certificate because the ACME request cannot roll back.
+		frappe.db.commit()  # nosemgrep
 
-	def _certificate_needs_renewal(self) -> bool:
+	def _does_certificate_need_renewal(self) -> bool:
 		expires_on = self.settings.wildcard_tls_expires_on
 		if not expires_on:
 			return True

--- a/atlas/atlas/core/setup.py
+++ b/atlas/atlas/core/setup.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+import frappe
+from frappe import _
+from frappe.utils import add_days, get_datetime, now_datetime
+
+from atlas.atlas.doctype.atlas_settings.atlas_settings import WILDCARD_TLS_RENEWAL_WINDOW_DAYS
+from atlas.auth.jwks import sync_central_jwks
+from atlas.metal_server.core.catalog_sync import CatalogSynchronizer
+
+
+@dataclass(frozen=True, slots=True)
+class AtlasSetupConfiguration:
+	"""Store the operator values for one Atlas region."""
+
+	server_provider: str
+	dns_provider: str
+	region_name: str
+	region_id: int
+	wildcard_domain: str
+	private_network_cidr: str
+	private_network_mtu: int
+	central_jwks_url: str
+	public_ssh_key: str
+	scaleway_organization_id: str
+	scaleway_project_id: str
+	scaleway_zone: str
+	scaleway_machine_billing_cycle: str
+	scaleway_access_key: str
+	scaleway_secret_key: str
+	route53_access_key_id: str
+	route53_access_key_secret: str
+	letsencrypt_email: str
+	is_letsencrypt_staging: bool
+	is_wildcard_tls_auto_renew_enabled: bool
+
+	@classmethod
+	def from_dict(cls, values: Any) -> "AtlasSetupConfiguration":
+		"""Create a configuration from the deployment command input."""
+		if not isinstance(values, dict):
+			raise ValueError("Atlas setup configuration must be a JSON object")
+
+		expected_fields = {field.name for field in fields(cls)}
+		if set(values) != expected_fields:
+			missing = sorted(expected_fields - set(values))
+			unknown = sorted(set(values) - expected_fields)
+			parts = []
+			if missing:
+				parts.append(f"missing fields: {', '.join(missing)}")
+			if unknown:
+				parts.append(f"unknown fields: {', '.join(unknown)}")
+			raise ValueError("Invalid Atlas setup configuration; " + "; ".join(parts))
+
+		string_fields = expected_fields - {
+			"region_id",
+			"private_network_mtu",
+			"is_letsencrypt_staging",
+			"is_wildcard_tls_auto_renew_enabled",
+		}
+		for field in string_fields:
+			value = values[field]
+			if not isinstance(value, str) or (field != "central_jwks_url" and not value.strip()):
+				raise ValueError(f"Atlas setup field {field} must be a string")
+		for field in ("region_id", "private_network_mtu"):
+			value = values[field]
+			if not isinstance(value, int) or isinstance(value, bool):
+				raise ValueError(f"Atlas setup field {field} must be an integer")
+		if not 0 <= values["region_id"] <= 65_535:
+			raise ValueError("Atlas setup field region_id must be from 0 through 65535")
+		if values["private_network_mtu"] <= 0:
+			raise ValueError("Atlas setup field private_network_mtu must be positive")
+		for field in ("is_letsencrypt_staging", "is_wildcard_tls_auto_renew_enabled"):
+			if not isinstance(values[field], bool):
+				raise ValueError(f"Atlas setup field {field} must be true or false")
+
+		return cls(**values)
+
+	def settings_values(self) -> dict[str, object]:
+		"""Return the values that belong to Atlas Settings."""
+		return {field.name: getattr(self, field.name) for field in fields(self)}
+
+
+class AtlasSetup:
+	"""Reconcile one Atlas region from operator configuration."""
+
+	SERVER_IMMUTABLE_FIELDS = (
+		"server_provider",
+		"region_name",
+		"region_id",
+		"private_network_cidr",
+		"public_ssh_key",
+		"scaleway_organization_id",
+		"scaleway_project_id",
+		"scaleway_zone",
+	)
+	DNS_IMMUTABLE_FIELDS = ("dns_provider", "wildcard_domain")
+
+	def __init__(self, configuration: AtlasSetupConfiguration) -> None:
+		self.configuration = configuration
+		self.settings = frappe.get_single("Atlas Settings")
+
+	def run(self) -> None:
+		"""Apply settings and complete each setup phase."""
+		self._validate_immutable_values()
+		self.settings.update(self.configuration.settings_values())
+		self.settings.save(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep: a setup checkpoint must survive a later provider failure
+
+		self._setup_server_provider()
+		self._setup_dns_provider()
+		self._sync_catalogs()
+		self._sync_central_keys()
+		self._issue_wildcard_certificate()
+		self._validate_result()
+
+	def _validate_immutable_values(self) -> None:
+		if self.settings.is_server_provider_setup_completed:
+			self._validate_fields(self.SERVER_IMMUTABLE_FIELDS)
+		if self.settings.is_dns_setup_completed:
+			self._validate_fields(self.DNS_IMMUTABLE_FIELDS)
+
+	def _validate_fields(self, fields: tuple[str, ...]) -> None:
+		for field in fields:
+			current = self.settings.get(field)
+			configured = getattr(self.configuration, field)
+			if current != configured:
+				frappe.throw(
+					_("Atlas setup cannot change {0} from {1!r} to {2!r} after provider setup.").format(
+						field, current, configured
+					)
+				)
+
+	def _setup_server_provider(self) -> None:
+		if self.settings.is_server_provider_setup_completed:
+			return
+
+		self.settings.server_provider_controller.setup_infrastructure()
+		frappe.db.commit()  # nosemgrep: keep provider resource IDs when a later phase fails
+
+	def _setup_dns_provider(self) -> None:
+		provider = self.settings.dns_provider_controller
+		zone_id = provider.find_public_zone_id(self.settings.wildcard_domain)
+		if not zone_id:
+			frappe.throw(
+				_("Route53 needs an existing public hosted zone for {0}.").format(
+					self.settings.wildcard_domain
+				)
+			)
+		if self.settings.route53_dns_zone_id and self.settings.route53_dns_zone_id != zone_id:
+			frappe.throw(
+				_("Route53 public zone {0} does not match stored zone {1}.").format(
+					zone_id, self.settings.route53_dns_zone_id
+				)
+			)
+
+		if self.settings.is_dns_setup_completed:
+			return
+
+		self.settings.route53_dns_zone_id = zone_id
+		provider.bootstrap()
+		frappe.db.commit()  # nosemgrep: keep DNS setup when a later phase fails
+
+	def _sync_catalogs(self) -> None:
+		catalog = CatalogSynchronizer(self.settings.server_provider_controller)
+		catalog.sync_server_sizes()
+		catalog.sync_server_images()
+		frappe.db.commit()  # nosemgrep: keep catalog data when a later phase fails
+
+	def _sync_central_keys(self) -> None:
+		if not sync_central_jwks():
+			frappe.throw(_("Atlas could not get the configured Central JSON Web Key Set."))
+		frappe.db.commit()  # nosemgrep: keep a valid key set when certificate issuance fails
+
+	def _issue_wildcard_certificate(self) -> None:
+		if not self._certificate_needs_renewal():
+			return
+
+		self.settings.issue_wildcard_certificate()
+		frappe.db.commit()  # nosemgrep: certificate issuance is an external setup checkpoint
+
+	def _certificate_needs_renewal(self) -> bool:
+		expires_on = self.settings.wildcard_tls_expires_on
+		if not expires_on:
+			return True
+
+		return get_datetime(expires_on) <= add_days(now_datetime(), WILDCARD_TLS_RENEWAL_WINDOW_DAYS)
+
+	def _validate_result(self) -> None:
+		self.settings.reload()
+		if not self.settings.is_setup_completed:
+			frappe.throw(_("Atlas Settings setup is not complete."))
+		if not self.settings.wildcard_tls_expires_on:
+			frappe.throw(_("Atlas Settings has no wildcard TLS certificate."))
+		if not frappe.db.exists("Metal Server Size", {"provider_type": self.settings.server_provider}):
+			frappe.throw(_("Atlas has no Metal Server Size for the configured provider."))
+		if not frappe.db.exists("Metal Server Image", {"provider_type": self.settings.server_provider}):
+			frappe.throw(_("Atlas has no Metal Server Image for the configured provider."))

--- a/atlas/atlas/core/test_setup.py
+++ b/atlas/atlas/core/test_setup.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import UnitTestCase
+
+from atlas.atlas.core.setup import AtlasSetup, AtlasSetupConfiguration
+
+
+def configuration(**changes: object) -> AtlasSetupConfiguration:
+	values = {
+		"server_provider": "Scaleway",
+		"dns_provider": "Route53",
+		"region_name": "par-1",
+		"region_id": 1,
+		"wildcard_domain": "par-1.example.com",
+		"private_network_cidr": "10.1.0.0/20",
+		"private_network_mtu": 1500,
+		"central_jwks_url": "",
+		"public_ssh_key": "ssh-ed25519 AAAA atlas",
+		"scaleway_organization_id": "organization",
+		"scaleway_project_id": "project",
+		"scaleway_zone": "fr-par-1",
+		"scaleway_machine_billing_cycle": "Hourly",
+		"scaleway_access_key": "access",
+		"scaleway_secret_key": "secret",
+		"route53_access_key_id": "route-access",
+		"route53_access_key_secret": "route-secret",
+		"letsencrypt_email": "ops@example.com",
+		"is_letsencrypt_staging": False,
+		"is_wildcard_tls_auto_renew_enabled": True,
+	}
+	values.update(changes)
+	return AtlasSetupConfiguration.from_dict(values)
+
+
+class TestAtlasSetupConfiguration(UnitTestCase):
+	def test_input_needs_every_field(self) -> None:
+		values = configuration().settings_values()
+		values.pop("region_id")
+
+		with self.assertRaisesRegex(ValueError, "missing fields: region_id"):
+			AtlasSetupConfiguration.from_dict(values)
+
+	def test_input_rejects_a_wrong_scalar_type(self) -> None:
+		values = configuration().settings_values()
+		values["private_network_mtu"] = "1500"
+
+		with self.assertRaisesRegex(ValueError, "private_network_mtu must be an integer"):
+			AtlasSetupConfiguration.from_dict(values)
+
+
+class TestAtlasSetup(UnitTestCase):
+	def setup(self, settings: object, **changes: object) -> AtlasSetup:
+		with patch("atlas.atlas.core.setup.frappe.get_single", return_value=settings):
+			return AtlasSetup(configuration(**changes))
+
+	def test_completed_provider_refuses_immutable_drift(self) -> None:
+		settings = MagicMock(is_server_provider_setup_completed=1, is_dns_setup_completed=0)
+		settings.get.side_effect = lambda field: (
+			"old-region" if field == "region_name" else getattr(configuration(), field)
+		)
+		setup = self.setup(settings)
+
+		with self.assertRaises(frappe.ValidationError):
+			setup._validate_immutable_values()
+
+	def test_missing_public_zone_stops_before_dns_bootstrap(self) -> None:
+		provider = MagicMock()
+		provider.find_public_zone_id.return_value = None
+		settings = SimpleNamespace(
+			dns_provider_controller=provider,
+			wildcard_domain="par-1.example.com",
+			route53_dns_zone_id=None,
+			is_dns_setup_completed=0,
+		)
+		setup = self.setup(settings)
+
+		with self.assertRaises(frappe.ValidationError):
+			setup._setup_dns_provider()
+
+		provider.bootstrap.assert_not_called()
+
+	def test_existing_public_zone_completes_dns_setup(self) -> None:
+		provider = MagicMock()
+		provider.find_public_zone_id.return_value = "zone-1"
+		settings = SimpleNamespace(
+			dns_provider_controller=provider,
+			wildcard_domain="par-1.example.com",
+			route53_dns_zone_id=None,
+			is_dns_setup_completed=0,
+		)
+		setup = self.setup(settings)
+
+		with patch("atlas.atlas.core.setup.frappe.db.commit") as commit:
+			setup._setup_dns_provider()
+
+		self.assertEqual(settings.route53_dns_zone_id, "zone-1")
+		provider.bootstrap.assert_called_once_with()
+		commit.assert_called_once_with()
+
+	def test_current_certificate_is_not_replaced(self) -> None:
+		settings = MagicMock(wildcard_tls_expires_on=frappe.utils.add_days(frappe.utils.now_datetime(), 60))
+		setup = self.setup(settings)
+
+		setup._issue_wildcard_certificate()
+
+		settings.issue_wildcard_certificate.assert_not_called()

--- a/atlas/atlas/core/test_setup.py
+++ b/atlas/atlas/core/test_setup.py
@@ -51,6 +51,9 @@ class TestAtlasSetupConfiguration(UnitTestCase):
 		with self.assertRaisesRegex(ValueError, "private_network_mtu must be an integer"):
 			AtlasSetupConfiguration.from_dict(values)
 
+	def test_region_name_is_normalized(self) -> None:
+		self.assertEqual(configuration(region_name=" PAR-1 ").region_name, "par-1")
+
 
 class TestAtlasSetup(UnitTestCase):
 	def setup(self, settings: object, **changes: object) -> AtlasSetup:
@@ -108,3 +111,25 @@ class TestAtlasSetup(UnitTestCase):
 		setup._issue_wildcard_certificate()
 
 		settings.issue_wildcard_certificate.assert_not_called()
+
+	def test_environment_change_clears_the_current_certificate(self) -> None:
+		settings = SimpleNamespace(
+			is_letsencrypt_staging=1,
+			wildcard_tls_certificate="staging certificate",
+			wildcard_tls_private_key="staging key",
+		)
+		setup = self.setup(settings, is_letsencrypt_staging=False)
+
+		setup._clear_certificate_for_environment_change()
+
+		self.assertIsNone(settings.wildcard_tls_certificate)
+		self.assertIsNone(settings.wildcard_tls_private_key)
+
+	def test_central_key_sync_reloads_settings(self) -> None:
+		settings = MagicMock()
+		setup = self.setup(settings)
+
+		with patch("atlas.atlas.core.setup.sync_central_jwks", return_value=True):
+			setup._sync_central_keys()
+
+		settings.reload.assert_called_once_with()

--- a/atlas/atlas/doctype/atlas_settings/atlas_settings.py
+++ b/atlas/atlas/doctype/atlas_settings/atlas_settings.py
@@ -388,6 +388,13 @@ class AtlasSettings(Document):
 			enqueue_after_commit=True,
 		)
 
+	def issue_wildcard_certificate(self) -> None:
+		"""Issue and store one wildcard TLS certificate now."""
+		issued = self.letsencrypt_controller.issue_wildcard_certificate()
+		self.wildcard_tls_certificate = issued.certificate_pem
+		self.wildcard_tls_private_key = issued.private_key_pem
+		self.save(ignore_permissions=True)
+
 	# Internal methods
 
 	def _sync_server_images(self) -> None:
@@ -411,10 +418,7 @@ class AtlasSettings(Document):
 		self.save(ignore_permissions=True)
 
 	def _renew_wildcard_certificate(self) -> None:
-		issued = self.letsencrypt_controller.issue_wildcard_certificate()
-		self.wildcard_tls_certificate = issued.certificate_pem
-		self.wildcard_tls_private_key = issued.private_key_pem
-		self.save()
+		self.issue_wildcard_certificate()
 
 
 def renew_expiring_wildcard_certificate() -> None:

--- a/atlas/commands.py
+++ b/atlas/commands.py
@@ -155,7 +155,7 @@ def build_ubuntu_base_image(
 	target_sites = context.sites
 	if skip_existing:
 		target_sites = [
-			site for site in context.sites if not image_is_available(site, title, version, architecture)
+			site for site in context.sites if not is_image_available(site, title, version, architecture)
 		]
 	if not target_sites:
 		click.echo(f"Image {title} is already available")
@@ -185,7 +185,7 @@ def build_ubuntu_base_image(
 			frappe.destroy()
 
 
-def image_is_available(site: str, title: str, version: str, architecture: str) -> bool:
+def is_image_available(site: str, title: str, version: str, architecture: str) -> bool:
 	"""Return true when a site has the requested system image."""
 	try:
 		frappe.init(site)

--- a/atlas/commands.py
+++ b/atlas/commands.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
+from typing import Any
 
 import click
 import frappe
@@ -18,9 +20,34 @@ from atlas.atlas.core.host_binaries import (
 	publish_host_binary,
 	source_digest,
 )
+from atlas.atlas.core.setup import AtlasSetup, AtlasSetupConfiguration
 from atlas.atlas.object_storage import ObjectStorageError
 from atlas.service.core import http_proxy_package
 from atlas.vm.core.image_builder import build_ubuntu_image, publish_ubuntu_image
+
+
+@click.command("configure-atlas")
+@pass_context
+def configure_atlas(context: CliCtxObj) -> None:
+	"""Configure each selected Atlas site from a JSON document on standard input."""
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+	try:
+		values: dict[str, Any] = json.load(click.get_text_stream("stdin"))
+		configuration = AtlasSetupConfiguration.from_dict(values)
+	except (json.JSONDecodeError, TypeError, ValueError) as error:
+		raise click.UsageError(str(error)) from error
+
+	for site in context.sites:
+		try:
+			frappe.init(site)
+			frappe.connect()
+			click.echo(f"Configure Atlas on {site}")
+			AtlasSetup(configuration).run()
+			click.echo(f"Atlas setup is complete on {site}")
+		finally:
+			frappe.destroy()
 
 
 @click.command("build-metald")
@@ -93,6 +120,11 @@ def build_http_proxy_package(context: CliCtxObj) -> None:
 @click.option("--minimal", is_flag=True, help="Build the Ubuntu minimal cloud image.")
 @click.option("--title")
 @click.option(
+	"--skip-existing",
+	is_flag=True,
+	help="Do not build the image when a matching Available image exists.",
+)
+@click.option(
 	"--storage",
 	type=click.Choice(["object-storage", "site-file"]),
 	default="object-storage",
@@ -109,6 +141,7 @@ def build_ubuntu_base_image(
 	architecture: str,
 	minimal: bool,
 	title: str | None,
+	skip_existing: bool,
 	storage: str,
 	output_directory: Path,
 ) -> None:
@@ -119,9 +152,18 @@ def build_ubuntu_base_image(
 		raise click.UsageError("minimal images are available only for Ubuntu 24.04")
 
 	title = title or f"ubuntu-{version}" + ("-minimal" if minimal else "")
+	target_sites = context.sites
+	if skip_existing:
+		target_sites = [
+			site for site in context.sites if not image_is_available(site, title, version, architecture)
+		]
+	if not target_sites:
+		click.echo(f"Image {title} is already available")
+		return
+
 	click.echo(f"Building {title} for {architecture}")
 	image_path, kernel_path = build_ubuntu_image(version, architecture, minimal, output_directory)
-	for site in context.sites:
+	for site in target_sites:
 		try:
 			frappe.init(site)
 			frappe.connect()
@@ -143,4 +185,26 @@ def build_ubuntu_base_image(
 			frappe.destroy()
 
 
-commands = [build_metald, build_wg_mesh, build_http_proxy_package, build_ubuntu_base_image]
+def image_is_available(site: str, title: str, version: str, architecture: str) -> bool:
+	"""Return true when a site has the requested system image."""
+	try:
+		frappe.init(site)
+		frappe.connect()
+		return bool(
+			frappe.db.exists(
+				"Virtual Machine Image",
+				{
+					"title": title,
+					"status": "Available",
+					"image_type": "system",
+					"operating_system": "Ubuntu",
+					"operating_system_version": version,
+					"platform": architecture,
+				},
+			)
+		)
+	finally:
+		frappe.destroy()
+
+
+commands = [configure_atlas, build_metald, build_wg_mesh, build_http_proxy_package, build_ubuntu_base_image]

--- a/atlas/docs/getting-started.md
+++ b/atlas/docs/getting-started.md
@@ -4,6 +4,8 @@ Use this guide to create one test virtual machine. Use a test Scaleway project a
 
 Keep the Frappe worker active. Provider setup, catalog sync, and Metal Server provisioning run in background jobs.
 
+Use [`atlas-vm`](../../scripts/atlas-vm/README.md) for an automatic installation in a Firecracker VM. It installs Atlas and completes the settings, provider, DNS, catalog, and system image steps. It does not create a Metal Server.
+
 
 ## 1. Install build tools
 
@@ -32,7 +34,7 @@ For now, a Metal Server must reach the Atlas site to download `metald` and Atlas
 Set the URL as `atlas_base_url`:
 
 ```sh
-pilot --site <site> set-config atlas_base_url https://<public-atlas-url>
+pilot frappe --site <site> set-config atlas_base_url https://<public-atlas-url>
 ```
 
 Build and publish the host binaries:

--- a/atlas/test_commands.py
+++ b/atlas/test_commands.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from frappe.tests import UnitTestCase
+from frappe.utils.bench_helper import CliCtxObj
+
+from atlas import commands
+
+
+def command_context(*sites: str) -> CliCtxObj:
+	return CliCtxObj(sites=list(sites), force=False, profile=False, verbose=False)
+
+
+class TestConfigureAtlasCommand(UnitTestCase):
+	def test_configuration_comes_from_stdin_and_site_is_destroyed(self) -> None:
+		configuration = MagicMock()
+		with (
+			patch.object(commands.AtlasSetupConfiguration, "from_dict", return_value=configuration) as load,
+			patch.object(commands, "AtlasSetup") as setup,
+			patch.object(commands.frappe, "init") as initialize,
+			patch.object(commands.frappe, "connect") as connect,
+			patch.object(commands.frappe, "destroy") as destroy,
+		):
+			result = CliRunner().invoke(
+				commands.configure_atlas,
+				input='{"region_name": "par-1"}',
+				obj=command_context("test.local"),
+			)
+
+		self.assertEqual(result.exit_code, 0, result.output)
+		load.assert_called_once_with({"region_name": "par-1"})
+		initialize.assert_called_once_with("test.local")
+		connect.assert_called_once_with()
+		setup.assert_called_once_with(configuration)
+		setup.return_value.run.assert_called_once_with()
+		destroy.assert_called_once_with()
+
+	def test_site_is_destroyed_after_setup_failure(self) -> None:
+		with (
+			patch.object(commands.AtlasSetupConfiguration, "from_dict", return_value=MagicMock()),
+			patch.object(commands, "AtlasSetup") as setup,
+			patch.object(commands.frappe, "init"),
+			patch.object(commands.frappe, "connect"),
+			patch.object(commands.frappe, "destroy") as destroy,
+		):
+			setup.return_value.run.side_effect = RuntimeError("setup failed")
+			result = CliRunner().invoke(
+				commands.configure_atlas,
+				input="{}",
+				obj=command_context("test.local"),
+			)
+
+		self.assertIsInstance(result.exception, RuntimeError)
+		destroy.assert_called_once_with()
+
+
+class TestBuildUbuntuBaseImageCommand(UnitTestCase):
+	def test_skip_existing_publishes_only_to_missing_sites(self) -> None:
+		image_path = Path("/tmp/image.raw")
+		kernel_path = Path("/tmp/vmlinux")
+		with (
+			patch.object(
+				commands,
+				"is_image_available",
+				side_effect=lambda site, *_: site == "existing.local",
+			),
+			patch.object(commands, "build_ubuntu_image", return_value=(image_path, kernel_path)) as build,
+			patch.object(commands, "publish_ubuntu_image") as publish,
+			patch.object(commands.frappe, "init") as initialize,
+			patch.object(commands.frappe, "connect"),
+			patch.object(commands.frappe.db, "commit"),
+			patch.object(commands.frappe, "destroy") as destroy,
+		):
+			result = CliRunner().invoke(
+				commands.build_ubuntu_base_image,
+				["--version", "24.04", "--storage", "site-file", "--skip-existing"],
+				obj=command_context("existing.local", "missing.local"),
+			)
+
+		self.assertEqual(result.exit_code, 0, result.output)
+		build.assert_called_once_with("24.04", "amd64", False, Path("dist"))
+		initialize.assert_called_once_with("missing.local")
+		publish.assert_called_once_with(
+			"ubuntu-24.04",
+			"24.04",
+			"amd64",
+			image_path,
+			kernel_path,
+			"Site File",
+		)
+		destroy.assert_called_once_with()

--- a/scripts/atlas-vm/README.md
+++ b/scripts/atlas-vm/README.md
@@ -19,11 +19,15 @@ sudo atlas-vm create
 
 The configuration must contain the Atlas region, Scaleway, Route53, and Let's Encrypt values. Route53 must contain an existing public zone for `atlas.wildcard_domain`. Do not add `*.` to the domain.
 
+Atlas uses the `pilot.site` value with HTTPS as its public URL. Set `atlas.base_url` only if the public URL is different.
+
+The setup generates a temporary password for Pilot and the site Administrator. It does not put this password in the configuration or output.
+
 The setup creates one Secure Shell key for the `pilot.user`. Atlas uses this key to manage Metal Servers. The setup keeps this key when you run it again.
 
 The setup creates the Scaleway network resources and Route53 records. It also gets the provider catalogs and a wildcard certificate. Each `[[image]]` table creates one system image in site-file storage. Cargo configures object storage later.
 
-The configuration contains passwords and provider keys. `atlas-vm` stores its copy at `/var/lib/atlas-vm/atlas-vm.toml` with mode `0600`.
+The configuration contains provider secrets. `atlas-vm` stores its copy at `/var/lib/atlas-vm/atlas-vm.toml` with mode `0600`.
 
 ## Use the VM
 

--- a/scripts/atlas-vm/README.md
+++ b/scripts/atlas-vm/README.md
@@ -13,9 +13,17 @@ curl -fsSL https://raw.githubusercontent.com/frappe/atlas/develop/scripts/atlas-
 
 ```sh
 curl -fsSLo atlas-vm.toml https://raw.githubusercontent.com/frappe/atlas/develop/scripts/atlas-vm/atlas-vm.example.toml
-# Set pilot.site and pilot.password. Add one [[image]] table for each guest image.
+# Set each value that contains change-me. Set the site names and email addresses.
 sudo atlas-vm create
 ```
+
+The configuration must contain the Atlas region, Scaleway, Route53, and Let's Encrypt values. Route53 must contain an existing public zone for `atlas.wildcard_domain`. Do not add `*.` to the domain.
+
+The setup creates one Secure Shell key for the `pilot.user`. Atlas uses this key to manage Metal Servers. The setup keeps this key when you run it again.
+
+The setup creates the Scaleway network resources and Route53 records. It also gets the provider catalogs and a wildcard certificate. Each `[[image]]` table creates one system image in site-file storage. Cargo configures object storage later.
+
+The configuration contains passwords and provider keys. `atlas-vm` stores its copy at `/var/lib/atlas-vm/atlas-vm.toml` with mode `0600`.
 
 ## Use the VM
 
@@ -24,10 +32,12 @@ sudo atlas-vm status
 sudo atlas-vm ssh
 sudo atlas-vm logs --setup --follow
 sudo atlas-vm restart
-sudo atlas-vm setup                        # run setup.py again
-sudo atlas-vm reset-password pilot               # or: site. New random password, printed once
-sudo atlas-vm resize --vcpu 8 --disk 60    # reboots the VM; a disk can only grow
+sudo atlas-vm setup                         # Apply the configuration again.
+sudo atlas-vm reset-password pilot          # Use site for the site password.
+sudo atlas-vm resize --vcpu 8 --disk 60     # This restarts the VM. A disk can only grow.
 ```
+
+`atlas-vm setup` updates credentials and other mutable values. It stops if the configuration changes a region or provider value after provider setup.
 
 The VM answers on port 2222, and host ports 80 and 443 reach it.
 

--- a/scripts/atlas-vm/atlas-vm.example.toml
+++ b/scripts/atlas-vm/atlas-vm.example.toml
@@ -10,14 +10,12 @@ ssh_port = 2222
 [pilot]
 site = "atlas.example.com"
 admin_domain = "admin.example.com"
-password = "Atlas#Bench2026x"
 user = "frappe"
 letsencrypt_email = "ops@example.com"
 
 [atlas]
 repository = "https://github.com/frappe/atlas"
 branch = "develop"
-base_url = "https://atlas.example.com"
 server_provider = "Scaleway"
 dns_provider = "Route53"
 region_name = "par-1"

--- a/scripts/atlas-vm/atlas-vm.example.toml
+++ b/scripts/atlas-vm/atlas-vm.example.toml
@@ -12,11 +12,39 @@ site = "atlas.example.com"
 admin_domain = "admin.example.com"
 password = "Atlas#Bench2026x"
 user = "frappe"
-letsencrypt_email = "tanmoy@example.com"
+letsencrypt_email = "ops@example.com"
 
 [atlas]
 repository = "https://github.com/frappe/atlas"
 branch = "develop"
+base_url = "https://atlas.example.com"
+server_provider = "Scaleway"
+dns_provider = "Route53"
+region_name = "par-1"
+region_id = 1
+wildcard_domain = "par-1.example.com"
+private_network_cidr = "10.1.0.0/20"
+private_network_mtu = 1500
+
+# Set this URL when Central sends requests to this Atlas region.
+central_jwks_url = ""
+
+[atlas.scaleway]
+organization_id = "change-me"
+project_id = "change-me"
+zone = "fr-par-1"
+machine_billing_cycle = "Hourly"
+access_key = "change-me"
+secret_key = "change-me"
+
+[atlas.route53]
+access_key_id = "change-me"
+secret_access_key = "change-me"
+
+[atlas.letsencrypt]
+email = "ops@example.com"
+staging = false
+auto_renew = true
 
 # The guest images the VM builds after setup. Give one [[image]] table for each
 # variant. Every image is published as a site file, which is the only storage

--- a/scripts/atlas-vm/atlas_vm.py
+++ b/scripts/atlas-vm/atlas_vm.py
@@ -163,9 +163,13 @@ class Settings:
 
 def validate_configuration(document: dict, path: Path) -> None:
 	"""Reject an incomplete deployment configuration before the VM changes."""
-	allowed_top_level = {"vm", "pilot", "atlas", "image"}
-	_validate_keys(document, allowed_top_level, path, "")
-	vm = document.get("vm", {})
+	_validate_keys(document, {"vm", "pilot", "atlas", "image"}, path, "")
+	_validate_vm_configuration(document.get("vm", {}), path)
+	_validate_pilot_configuration(_required_table(document, "pilot", path), path)
+	_validate_atlas_configuration(_required_table(document, "atlas", path), path)
+
+
+def _validate_vm_configuration(vm: object, path: Path) -> None:
 	if not isinstance(vm, dict):
 		raise AtlasVmError(f"{path}: vm must be a table")
 	_validate_keys(vm, {"vcpu_count", "memory_mib", "disk_gib", "ssh_port"}, path, "vm")
@@ -175,15 +179,18 @@ def validate_configuration(document: dict, path: Path) -> None:
 			raise AtlasVmError(f"{path}: vm.{key} must be a positive integer")
 	if vm.get("ssh_port", 2222) > 65_535:
 		raise AtlasVmError(f"{path}: vm.ssh_port must be at most 65535")
-	pilot = _required_table(document, "pilot", path)
-	_validate_keys(pilot, {"site", "admin_domain", "password", "user", "letsencrypt_email"}, path, "pilot")
-	for key in ("site", "password", "letsencrypt_email"):
+
+
+def _validate_pilot_configuration(pilot: dict, path: Path) -> None:
+	_validate_keys(pilot, {"site", "admin_domain", "user", "letsencrypt_email"}, path, "pilot")
+	for key in ("site", "letsencrypt_email"):
 		_required_string(pilot, key, path, "pilot")
 	for key in ("admin_domain", "user"):
 		if key in pilot:
 			_required_string(pilot, key, path, "pilot")
 
-	atlas = _required_table(document, "atlas", path)
+
+def _validate_atlas_configuration(atlas: dict, path: Path) -> None:
 	_validate_keys(
 		atlas,
 		{
@@ -205,12 +212,12 @@ def validate_configuration(document: dict, path: Path) -> None:
 		path,
 		"atlas",
 	)
-	for key in ("base_url", "server_provider", "dns_provider", "region_name", "wildcard_domain"):
+	for key in ("server_provider", "dns_provider", "region_name", "wildcard_domain"):
 		_required_string(atlas, key, path, "atlas")
 	for key in ("private_network_cidr", "private_network_mtu", "central_jwks_url"):
 		if key not in atlas:
 			raise AtlasVmError(f"{path}: atlas.{key} is required")
-	for key in ("repository", "branch", "central_jwks_url"):
+	for key in ("repository", "branch", "base_url", "central_jwks_url"):
 		if key in atlas and not isinstance(atlas[key], str):
 			raise AtlasVmError(f"{path}: atlas.{key} must be a string")
 	if atlas["server_provider"] != "Scaleway":
@@ -219,7 +226,13 @@ def validate_configuration(document: dict, path: Path) -> None:
 		raise AtlasVmError(f"{path}: atlas.dns_provider must be Route53")
 	if atlas["wildcard_domain"].startswith("*.") or "." not in atlas["wildcard_domain"]:
 		raise AtlasVmError(f"{path}: atlas.wildcard_domain must be a domain without '*.'")
+	_validate_network_configuration(atlas, path)
+	_validate_scaleway_configuration(_required_table(atlas, "scaleway", path, "atlas"), path)
+	_validate_route53_configuration(_required_table(atlas, "route53", path, "atlas"), path)
+	_validate_letsencrypt_configuration(_required_table(atlas, "letsencrypt", path, "atlas"), path)
 
+
+def _validate_network_configuration(atlas: dict, path: Path) -> None:
 	region_id = _required_integer(atlas, "region_id", path, "atlas")
 	if not 0 <= region_id <= 65_535:
 		raise AtlasVmError(f"{path}: atlas.region_id must be from 0 through 65535")
@@ -233,7 +246,8 @@ def validate_configuration(document: dict, path: Path) -> None:
 	if network.version != 4 or not 20 <= network.prefixlen <= 29:
 		raise AtlasVmError(f"{path}: atlas.private_network_cidr must be an IPv4 network from /20 through /29")
 
-	scaleway = _required_table(atlas, "scaleway", path, "atlas")
+
+def _validate_scaleway_configuration(scaleway: dict, path: Path) -> None:
 	_validate_keys(
 		scaleway,
 		{"organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"},
@@ -247,12 +261,14 @@ def validate_configuration(document: dict, path: Path) -> None:
 	if scaleway["machine_billing_cycle"] not in {"Hourly", "Monthly"}:
 		raise AtlasVmError(f"{path}: atlas.scaleway.machine_billing_cycle must be Hourly or Monthly")
 
-	route53 = _required_table(atlas, "route53", path, "atlas")
+
+def _validate_route53_configuration(route53: dict, path: Path) -> None:
 	_validate_keys(route53, {"access_key_id", "secret_access_key"}, path, "atlas.route53")
 	for key in ("access_key_id", "secret_access_key"):
 		_required_string(route53, key, path, "atlas.route53")
 
-	letsencrypt = _required_table(atlas, "letsencrypt", path, "atlas")
+
+def _validate_letsencrypt_configuration(letsencrypt: dict, path: Path) -> None:
 	_validate_keys(letsencrypt, {"email", "staging", "auto_renew"}, path, "atlas.letsencrypt")
 	_required_string(letsencrypt, "email", path, "atlas.letsencrypt")
 	for key in ("staging", "auto_renew"):
@@ -295,24 +311,28 @@ def validate_images(images: list[dict], path: Path) -> None:
 	if not isinstance(images, list):
 		raise AtlasVmError(f"{path}: image must be an array of tables")
 	for image in images:
-		if not isinstance(image, dict):
-			raise AtlasVmError(f"{path}: each image must be a table")
-		_validate_keys(image, {"version", "architecture", "minimal"}, path, "image")
-		version = image.get("version", "24.04")
-		architecture = image.get("architecture", "amd64")
-		minimal = image.get("minimal", False)
-		if not isinstance(version, str):
-			raise AtlasVmError(f"{path}: image.version must be a string")
-		if not isinstance(architecture, str):
-			raise AtlasVmError(f"{path}: image.architecture must be a string")
-		if not isinstance(minimal, bool):
-			raise AtlasVmError(f"{path}: image.minimal must be true or false")
-		if version not in ("22.04", "24.04"):
-			raise AtlasVmError(f"{path} asks for Ubuntu {version}; only 22.04 and 24.04 are supported")
-		if architecture != "amd64":
-			raise AtlasVmError(f"{path} asks for {architecture}; only amd64 is supported")
-		if minimal and version != "24.04":
-			raise AtlasVmError(f"{path} asks for a minimal Ubuntu {version}; only 24.04 has one")
+		_validate_image(image, path)
+
+
+def _validate_image(image: object, path: Path) -> None:
+	if not isinstance(image, dict):
+		raise AtlasVmError(f"{path}: each image must be a table")
+	_validate_keys(image, {"version", "architecture", "minimal"}, path, "image")
+	version = image.get("version", "24.04")
+	architecture = image.get("architecture", "amd64")
+	minimal = image.get("minimal", False)
+	if not isinstance(version, str):
+		raise AtlasVmError(f"{path}: image.version must be a string")
+	if not isinstance(architecture, str):
+		raise AtlasVmError(f"{path}: image.architecture must be a string")
+	if not isinstance(minimal, bool):
+		raise AtlasVmError(f"{path}: image.minimal must be true or false")
+	if version not in ("22.04", "24.04"):
+		raise AtlasVmError(f"{path} asks for Ubuntu {version}; only 22.04 and 24.04 are supported")
+	if architecture != "amd64":
+		raise AtlasVmError(f"{path} asks for {architecture}; only amd64 is supported")
+	if minimal and version != "24.04":
+		raise AtlasVmError(f"{path} asks for a minimal Ubuntu {version}; only 24.04 has one")
 
 
 def generate_password(length: int = 24) -> str:

--- a/scripts/atlas-vm/atlas_vm.py
+++ b/scripts/atlas-vm/atlas_vm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import ipaddress
 import json
 import os
 import secrets
@@ -40,14 +41,37 @@ FIRECRACKER_VERSION = "v1.16.1"
 HOST_ADDRESS = "172.16.100.1"
 VM_ADDRESS = "172.16.100.2"
 FORWARD_PORTS = (80, 443)
+SCALEWAY_ZONES = {
+	"fr-par-1",
+	"fr-par-2",
+	"fr-par-3",
+	"nl-ams-1",
+	"nl-ams-2",
+	"nl-ams-3",
+	"pl-waw-1",
+	"pl-waw-2",
+	"pl-waw-3",
+}
 REQUIRED_COMMANDS = (
-	"curl", "ip", "iptables", "unsquashfs", "mkfs.ext4", "truncate", "ssh", "scp", "ssh-keygen",
+	"curl",
+	"ip",
+	"iptables",
+	"unsquashfs",
+	"mkfs.ext4",
+	"truncate",
+	"ssh",
+	"scp",
+	"ssh-keygen",
 )
 SSH_OPTIONS = (
-	"-o", "StrictHostKeyChecking=no",
-	"-o", "UserKnownHostsFile=/dev/null",
-	"-o", "LogLevel=ERROR",
-	"-o", "ConnectTimeout=5",
+	"-o",
+	"StrictHostKeyChecking=no",
+	"-o",
+	"UserKnownHostsFile=/dev/null",
+	"-o",
+	"LogLevel=ERROR",
+	"-o",
+	"ConnectTimeout=5",
 )
 
 
@@ -106,8 +130,7 @@ class Settings:
 		vm = document.get("vm", {})
 		pilot = document.get("pilot", {})
 		atlas = document.get("atlas", {})
-		if not pilot.get("site") or not pilot.get("password"):
-			raise AtlasVmError(f"{path} needs pilot.site and pilot.password")
+		validate_configuration(document, path)
 		validate_images(document.get("image", []), path)
 
 		repository = atlas.get("repository", "https://github.com/frappe/atlas").removesuffix(".git")
@@ -138,16 +161,157 @@ class Settings:
 		self.path.write_text("\n".join(lines) + "\n")
 
 
+def validate_configuration(document: dict, path: Path) -> None:
+	"""Reject an incomplete deployment configuration before the VM changes."""
+	allowed_top_level = {"vm", "pilot", "atlas", "image"}
+	_validate_keys(document, allowed_top_level, path, "")
+	vm = document.get("vm", {})
+	if not isinstance(vm, dict):
+		raise AtlasVmError(f"{path}: vm must be a table")
+	_validate_keys(vm, {"vcpu_count", "memory_mib", "disk_gib", "ssh_port"}, path, "vm")
+	for key in ("vcpu_count", "memory_mib", "disk_gib", "ssh_port"):
+		value = vm.get(key)
+		if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
+			raise AtlasVmError(f"{path}: vm.{key} must be a positive integer")
+	if vm.get("ssh_port", 2222) > 65_535:
+		raise AtlasVmError(f"{path}: vm.ssh_port must be at most 65535")
+	pilot = _required_table(document, "pilot", path)
+	_validate_keys(pilot, {"site", "admin_domain", "password", "user", "letsencrypt_email"}, path, "pilot")
+	for key in ("site", "password", "letsencrypt_email"):
+		_required_string(pilot, key, path, "pilot")
+	for key in ("admin_domain", "user"):
+		if key in pilot:
+			_required_string(pilot, key, path, "pilot")
+
+	atlas = _required_table(document, "atlas", path)
+	_validate_keys(
+		atlas,
+		{
+			"repository",
+			"branch",
+			"base_url",
+			"server_provider",
+			"dns_provider",
+			"region_name",
+			"region_id",
+			"wildcard_domain",
+			"private_network_cidr",
+			"private_network_mtu",
+			"central_jwks_url",
+			"scaleway",
+			"route53",
+			"letsencrypt",
+		},
+		path,
+		"atlas",
+	)
+	for key in ("base_url", "server_provider", "dns_provider", "region_name", "wildcard_domain"):
+		_required_string(atlas, key, path, "atlas")
+	for key in ("private_network_cidr", "private_network_mtu", "central_jwks_url"):
+		if key not in atlas:
+			raise AtlasVmError(f"{path}: atlas.{key} is required")
+	for key in ("repository", "branch", "central_jwks_url"):
+		if key in atlas and not isinstance(atlas[key], str):
+			raise AtlasVmError(f"{path}: atlas.{key} must be a string")
+	if atlas["server_provider"] != "Scaleway":
+		raise AtlasVmError(f"{path}: atlas.server_provider must be Scaleway")
+	if atlas["dns_provider"] != "Route53":
+		raise AtlasVmError(f"{path}: atlas.dns_provider must be Route53")
+	if atlas["wildcard_domain"].startswith("*.") or "." not in atlas["wildcard_domain"]:
+		raise AtlasVmError(f"{path}: atlas.wildcard_domain must be a domain without '*.'")
+
+	region_id = _required_integer(atlas, "region_id", path, "atlas")
+	if not 0 <= region_id <= 65_535:
+		raise AtlasVmError(f"{path}: atlas.region_id must be from 0 through 65535")
+	private_network_mtu = _required_integer(atlas, "private_network_mtu", path, "atlas")
+	if private_network_mtu <= 0:
+		raise AtlasVmError(f"{path}: atlas.private_network_mtu must be a positive integer")
+	try:
+		network = ipaddress.ip_network(atlas.get("private_network_cidr", "10.1.0.0/20"), strict=False)
+	except ValueError as error:
+		raise AtlasVmError(f"{path}: atlas.private_network_cidr is invalid: {error}") from error
+	if network.version != 4 or not 20 <= network.prefixlen <= 29:
+		raise AtlasVmError(f"{path}: atlas.private_network_cidr must be an IPv4 network from /20 through /29")
+
+	scaleway = _required_table(atlas, "scaleway", path, "atlas")
+	_validate_keys(
+		scaleway,
+		{"organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"},
+		path,
+		"atlas.scaleway",
+	)
+	for key in ("organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"):
+		_required_string(scaleway, key, path, "atlas.scaleway")
+	if scaleway["zone"] not in SCALEWAY_ZONES:
+		raise AtlasVmError(f"{path}: atlas.scaleway.zone is not supported")
+	if scaleway["machine_billing_cycle"] not in {"Hourly", "Monthly"}:
+		raise AtlasVmError(f"{path}: atlas.scaleway.machine_billing_cycle must be Hourly or Monthly")
+
+	route53 = _required_table(atlas, "route53", path, "atlas")
+	_validate_keys(route53, {"access_key_id", "secret_access_key"}, path, "atlas.route53")
+	for key in ("access_key_id", "secret_access_key"):
+		_required_string(route53, key, path, "atlas.route53")
+
+	letsencrypt = _required_table(atlas, "letsencrypt", path, "atlas")
+	_validate_keys(letsencrypt, {"email", "staging", "auto_renew"}, path, "atlas.letsencrypt")
+	_required_string(letsencrypt, "email", path, "atlas.letsencrypt")
+	for key in ("staging", "auto_renew"):
+		if key not in letsencrypt:
+			raise AtlasVmError(f"{path}: atlas.letsencrypt.{key} is required")
+		if not isinstance(letsencrypt[key], bool):
+			raise AtlasVmError(f"{path}: atlas.letsencrypt.{key} must be true or false")
+
+
+def _validate_keys(values: dict, allowed: set[str], path: Path, prefix: str) -> None:
+	for key in values.keys() - allowed:
+		name = f"{prefix}.{key}" if prefix else key
+		raise AtlasVmError(f"{path}: unknown configuration key {name}")
+
+
+def _required_table(values: dict, key: str, path: Path, prefix: str = "") -> dict:
+	name = f"{prefix}.{key}" if prefix else key
+	table = values.get(key)
+	if not isinstance(table, dict):
+		raise AtlasVmError(f"{path}: {name} must be a table")
+	return table
+
+
+def _required_string(values: dict, key: str, path: Path, prefix: str) -> str:
+	value = values.get(key)
+	if not isinstance(value, str) or not value.strip():
+		raise AtlasVmError(f"{path}: {prefix}.{key} must be a non-empty string")
+	return value
+
+
+def _required_integer(values: dict, key: str, path: Path, prefix: str) -> int:
+	value = values.get(key)
+	if not isinstance(value, int) or isinstance(value, bool):
+		raise AtlasVmError(f"{path}: {prefix}.{key} must be an integer")
+	return value
+
+
 def validate_images(images: list[dict], path: Path) -> None:
 	"""Refuse an image the builder cannot make, before the VM boots."""
+	if not isinstance(images, list):
+		raise AtlasVmError(f"{path}: image must be an array of tables")
 	for image in images:
-		version = str(image.get("version", "24.04"))
+		if not isinstance(image, dict):
+			raise AtlasVmError(f"{path}: each image must be a table")
+		_validate_keys(image, {"version", "architecture", "minimal"}, path, "image")
+		version = image.get("version", "24.04")
 		architecture = image.get("architecture", "amd64")
+		minimal = image.get("minimal", False)
+		if not isinstance(version, str):
+			raise AtlasVmError(f"{path}: image.version must be a string")
+		if not isinstance(architecture, str):
+			raise AtlasVmError(f"{path}: image.architecture must be a string")
+		if not isinstance(minimal, bool):
+			raise AtlasVmError(f"{path}: image.minimal must be true or false")
 		if version not in ("22.04", "24.04"):
 			raise AtlasVmError(f"{path} asks for Ubuntu {version}; only 22.04 and 24.04 are supported")
 		if architecture != "amd64":
 			raise AtlasVmError(f"{path} asks for {architecture}; only amd64 is supported")
-		if image.get("minimal") and version != "24.04":
+		if minimal and version != "24.04":
 			raise AtlasVmError(f"{path} asks for a minimal Ubuntu {version}; only 24.04 has one")
 
 
@@ -338,7 +502,7 @@ class ConsoleReader:
 			guest(line)
 
 
-NETWORK_SCRIPT_BODY = r'''
+NETWORK_SCRIPT_BODY = r"""
 # The tap device is excluded from PREROUTING, so guest traffic to a forwarded
 # port leaves the host instead of returning to the VM.
 rules() {
@@ -397,7 +561,7 @@ case "${1:-}" in
 	stop) stop ;;
 	*) echo "usage: network start|stop" >&2; exit 2 ;;
 esac
-'''
+"""
 
 
 class VirtualMachine:
@@ -427,8 +591,10 @@ class VirtualMachine:
 	def ssh_arguments(self, command: list[str] | None = None) -> list[str]:
 		arguments = [
 			"ssh",
-			"-i", str(self.private_key),
-			"-p", str(self.settings.ssh_port),
+			"-i",
+			str(self.private_key),
+			"-p",
+			str(self.settings.ssh_port),
 			*SSH_OPTIONS,
 			f"root@{HOST_ADDRESS}",
 		]
@@ -439,8 +605,10 @@ class VirtualMachine:
 		run(
 			[
 				"scp",
-				"-i", str(self.private_key),
-				"-P", str(self.settings.ssh_port),
+				"-i",
+				str(self.private_key),
+				"-P",
+				str(self.settings.ssh_port),
 				*SSH_OPTIONS,
 				str(source),
 				f"root@{HOST_ADDRESS}:{target}",
@@ -528,10 +696,16 @@ WantedBy=multi-user.target
 		version = FIRECRACKER_VERSION
 		archive = self.paths.downloads / "firecracker.tgz"
 		step(f"install firecracker {version}")
-		run([
-			"curl", "-fL", *CURL_PROGRESS, "-o", str(archive),
-			f"https://github.com/firecracker-microvm/firecracker/releases/download/{version}/firecracker-{version}-x86_64.tgz",
-		])
+		run(
+			[
+				"curl",
+				"-fL",
+				*CURL_PROGRESS,
+				"-o",
+				str(archive),
+				f"https://github.com/firecracker-microvm/firecracker/releases/download/{version}/firecracker-{version}-x86_64.tgz",
+			]
+		)
 		run(["tar", "-xzf", str(archive), "-C", str(self.paths.downloads)])
 		released = self.paths.downloads / f"release-{version}-x86_64" / f"firecracker-{version}-x86_64"
 		self.paths.firecracker_binary.parent.mkdir(parents=True, exist_ok=True)
@@ -597,9 +771,12 @@ WantedBy=multi-user.target
 		# The file holds the site password, so the guest keeps it for this run only.
 		self.write_in_guest("/root/atlas-vm.toml", self.settings.path.read_text())
 		try:
-			with subprocess.Popen(
-				self.ssh_arguments([command]), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-			) as process, self.paths.setup_log.open("w") as log:
+			with (
+				subprocess.Popen(
+					self.ssh_arguments([command]), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+				) as process,
+				self.paths.setup_log.open("w") as log,
+			):
 				for line in process.stdout:
 					print(line, end="", flush=True)
 					log.write(line)
@@ -726,13 +903,17 @@ def command_status(machine: VirtualMachine, arguments: argparse.Namespace) -> No
 	forwards = ", ".join(f"{host} -> {guest}" for host, guest in machine.port_forwards)
 	print(f"service:  {SERVICE_NAME} ({state})")
 	print(f"vm:       {VM_NAME} in {paths.vm_directory}")
-	print(f"machine:  {settings.vcpu_count} vCPU, {settings.memory_mib} MiB memory, {settings.disk_gib} GiB disk")
+	print(
+		f"machine:  {settings.vcpu_count} vCPU, {settings.memory_mib} MiB memory, {settings.disk_gib} GiB disk"
+	)
 	print(f"address:  {VM_ADDRESS} through {HOST_ADDRESS} on {machine.tap_device}")
 	print(f"ports:    {forwards}")
 	if paths.rootfs_image.exists():
 		# The image is sparse: the host gives it blocks as the guest writes them.
 		allocated_gib = paths.rootfs_image.stat().st_blocks * 512 / 1024**3
-		print(f"disk:     {settings.disk_gib} GiB in the guest, {allocated_gib:.1f} GiB allocated on the host")
+		print(
+			f"disk:     {settings.disk_gib} GiB in the guest, {allocated_gib:.1f} GiB allocated on the host"
+		)
 	print(f"config:   {CONFIG_FILE}")
 	print(f"logs:     {paths.console_log}, {paths.setup_log}")
 	print("ssh:      atlas-vm ssh")
@@ -868,14 +1049,20 @@ def build_parser() -> argparse.ArgumentParser:
 		"--config", type=Path, help="configuration file to build the VM from (default: ./atlas-vm.toml)"
 	)
 	create.add_argument("--skip-setup", action="store_true", help="do not run setup.py")
-	create.add_argument("--script", type=Path, help="run this local setup.py instead of the one in the repository")
+	create.add_argument(
+		"--script", type=Path, help="run this local setup.py instead of the one in the repository"
+	)
 	create.add_argument("--rebuild", action="store_true", help="delete the guest disk and build it again")
 	create.set_defaults(handler=command_create)
 
 	subparsers.add_parser("start", help="start the VM").set_defaults(handler=command_start)
-	subparsers.add_parser("stop", help="stop the VM and remove its host network").set_defaults(handler=command_stop)
+	subparsers.add_parser("stop", help="stop the VM and remove its host network").set_defaults(
+		handler=command_stop
+	)
 	subparsers.add_parser("restart", help="stop and start the VM").set_defaults(handler=command_restart)
-	subparsers.add_parser("status", help="report the VM, its size, and its ports").set_defaults(handler=command_status)
+	subparsers.add_parser("status", help="report the VM, its size, and its ports").set_defaults(
+		handler=command_status
+	)
 	ssh = subparsers.add_parser("ssh", help="open a shell or run one command in the VM")
 	ssh.add_argument("command", nargs=argparse.REMAINDER, help="command to run in the VM")
 	ssh.set_defaults(handler=command_ssh)
@@ -884,11 +1071,11 @@ def build_parser() -> argparse.ArgumentParser:
 	logs.add_argument("--follow", "-f", action="store_true", help="follow the log")
 	logs.set_defaults(handler=command_logs)
 	setup = subparsers.add_parser("setup", help="run setup.py again in a running VM")
-	setup.add_argument("--script", type=Path, help="run this local setup.py instead of the one in the repository")
-	setup.set_defaults(handler=command_setup)
-	reset_password = subparsers.add_parser(
-		"reset-password", help="set a new random password and print it"
+	setup.add_argument(
+		"--script", type=Path, help="run this local setup.py instead of the one in the repository"
 	)
+	setup.set_defaults(handler=command_setup)
+	reset_password = subparsers.add_parser("reset-password", help="set a new random password and print it")
 	reset_password.add_argument(
 		"target", choices=("pilot", "site"), help="the Pilot admin panel or the site Administrator"
 	)
@@ -928,8 +1115,7 @@ def resolve_config_file(given: Path | None) -> Path:
 		if candidate.is_file():
 			return candidate
 	raise AtlasVmError(
-		"no configuration file; copy atlas-vm.example.toml to atlas-vm.toml"
-		" and pass it with --config"
+		"no configuration file; copy atlas-vm.example.toml to atlas-vm.toml and pass it with --config"
 	)
 
 

--- a/scripts/atlas-vm/setup.py
+++ b/scripts/atlas-vm/setup.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 import argparse
-import ipaddress
 import json
 import os
+import secrets
 import shlex
 import shutil
+import string
 import subprocess
 import sys
 import tempfile
@@ -23,17 +24,6 @@ PILOT_INSTALL_URL = "https://raw.githubusercontent.com/frappe/pilot/develop/inst
 PYTHON_VERSION = "3.14"
 SETUP_GRANT = "/etc/sudoers.d/{user}-atlas-setup"
 IMAGE_BUILDER_GRANT = "/etc/sudoers.d/{user}-atlas-image-builder"
-SCALEWAY_ZONES = {
-	"fr-par-1",
-	"fr-par-2",
-	"fr-par-3",
-	"nl-ams-1",
-	"nl-ams-2",
-	"nl-ams-3",
-	"pl-waw-1",
-	"pl-waw-2",
-	"pl-waw-3",
-}
 
 
 class SetupError(Exception):
@@ -53,7 +43,7 @@ class Configuration:
 	"""What the VM needs to build the bench, the site, and the images."""
 
 	site: str
-	password: str
+	bootstrap_password: str
 	admin_domain: str
 	bench_name: str = "atlas"
 	bench_user: str = "frappe"
@@ -69,12 +59,11 @@ class Configuration:
 		if not path.is_file():
 			raise SetupError(f"no configuration at {path}")
 		document = tomllib.loads(path.read_text())
-		validate_configuration(document, path)
+		# atlas_vm validates this root-owned file before it copies the file into the guest.
 		pilot = document.get("pilot", {})
 		atlas = document.get("atlas", {})
 
 		site = pilot.get("site", "")
-		password = pilot.get("password", "")
 		images = [
 			(
 				image.get("version", "24.04"),
@@ -85,13 +74,13 @@ class Configuration:
 		]
 		return cls(
 			site=site,
-			password=password,
+			bootstrap_password=generate_password(),
 			admin_domain=pilot.get("admin_domain", f"admin.{site}"),
 			bench_user=pilot.get("user", "frappe"),
 			letsencrypt_email=pilot.get("letsencrypt_email", ""),
 			atlas_repository=atlas.get("repository", "https://github.com/frappe/atlas"),
 			atlas_branch=atlas.get("branch", "develop"),
-			atlas_base_url=atlas["base_url"],
+			atlas_base_url=atlas.get("base_url", f"https://{site}"),
 			atlas_setup_values=read_atlas_setup_values(atlas),
 			images=images,
 		)
@@ -141,145 +130,14 @@ def read_atlas_setup_values(atlas: dict) -> dict[str, object]:
 	}
 
 
-def validate_configuration(document: dict, path: Path) -> None:
-	"""Reject a configuration that cannot complete Atlas setup."""
-	_keys(document, {"vm", "pilot", "atlas", "image"}, path, "")
-	vm = document.get("vm", {})
-	if not isinstance(vm, dict):
-		raise SetupError(f"{path}: vm must be a table")
-	_keys(vm, {"vcpu_count", "memory_mib", "disk_gib", "ssh_port"}, path, "vm")
-	for key in ("vcpu_count", "memory_mib", "disk_gib", "ssh_port"):
-		value = vm.get(key)
-		if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
-			raise SetupError(f"{path}: vm.{key} must be a positive integer")
-	if vm.get("ssh_port", 2222) > 65_535:
-		raise SetupError(f"{path}: vm.ssh_port must be at most 65535")
-	pilot = _table(document, "pilot", path)
-	_keys(pilot, {"site", "admin_domain", "password", "user", "letsencrypt_email"}, path, "pilot")
-	for key in ("site", "password", "letsencrypt_email"):
-		_string(pilot, key, path, "pilot")
-	for key in ("admin_domain", "user"):
-		if key in pilot:
-			_string(pilot, key, path, "pilot")
-
-	atlas = _table(document, "atlas", path)
-	_keys(
-		atlas,
-		{
-			"repository",
-			"branch",
-			"base_url",
-			"server_provider",
-			"dns_provider",
-			"region_name",
-			"region_id",
-			"wildcard_domain",
-			"private_network_cidr",
-			"private_network_mtu",
-			"central_jwks_url",
-			"scaleway",
-			"route53",
-			"letsencrypt",
-		},
-		path,
-		"atlas",
-	)
-	for key in ("base_url", "server_provider", "dns_provider", "region_name", "wildcard_domain"):
-		_string(atlas, key, path, "atlas")
-	for key in ("private_network_cidr", "private_network_mtu", "central_jwks_url"):
-		if key not in atlas:
-			raise SetupError(f"{path}: atlas.{key} is required")
-	for key in ("repository", "branch", "central_jwks_url"):
-		if key in atlas and not isinstance(atlas[key], str):
-			raise SetupError(f"{path}: atlas.{key} must be a string")
-	if atlas["server_provider"] != "Scaleway" or atlas["dns_provider"] != "Route53":
-		raise SetupError(f"{path}: Atlas setup supports Scaleway and Route53")
-	if atlas["wildcard_domain"].startswith("*.") or "." not in atlas["wildcard_domain"]:
-		raise SetupError(f"{path}: atlas.wildcard_domain must be a domain without '*.'")
-	region_id = atlas.get("region_id")
-	if not isinstance(region_id, int) or isinstance(region_id, bool) or not 0 <= region_id <= 65_535:
-		raise SetupError(f"{path}: atlas.region_id must be an integer from 0 through 65535")
-	try:
-		network = ipaddress.ip_network(atlas.get("private_network_cidr", "10.1.0.0/20"), strict=False)
-	except ValueError as error:
-		raise SetupError(f"{path}: atlas.private_network_cidr is invalid: {error}") from error
-	if network.version != 4 or not 20 <= network.prefixlen <= 29:
-		raise SetupError(f"{path}: atlas.private_network_cidr must be an IPv4 network from /20 through /29")
-	private_network_mtu = atlas.get("private_network_mtu")
-	if (
-		not isinstance(private_network_mtu, int)
-		or isinstance(private_network_mtu, bool)
-		or private_network_mtu <= 0
-	):
-		raise SetupError(f"{path}: atlas.private_network_mtu must be a positive integer")
-
-	scaleway = _table(atlas, "scaleway", path, "atlas")
-	_keys(
-		scaleway,
-		{"organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"},
-		path,
-		"atlas.scaleway",
-	)
-	for key in ("organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"):
-		_string(scaleway, key, path, "atlas.scaleway")
-	if scaleway["zone"] not in SCALEWAY_ZONES:
-		raise SetupError(f"{path}: atlas.scaleway.zone is not supported")
-	if scaleway["machine_billing_cycle"] not in {"Hourly", "Monthly"}:
-		raise SetupError(f"{path}: atlas.scaleway.machine_billing_cycle must be Hourly or Monthly")
-
-	route53 = _table(atlas, "route53", path, "atlas")
-	_keys(route53, {"access_key_id", "secret_access_key"}, path, "atlas.route53")
-	for key in ("access_key_id", "secret_access_key"):
-		_string(route53, key, path, "atlas.route53")
-	letsencrypt = _table(atlas, "letsencrypt", path, "atlas")
-	_keys(letsencrypt, {"email", "staging", "auto_renew"}, path, "atlas.letsencrypt")
-	_string(letsencrypt, "email", path, "atlas.letsencrypt")
-	for key in ("staging", "auto_renew"):
-		if key not in letsencrypt:
-			raise SetupError(f"{path}: atlas.letsencrypt.{key} is required")
-		if not isinstance(letsencrypt[key], bool):
-			raise SetupError(f"{path}: atlas.letsencrypt.{key} must be true or false")
-	images = document.get("image", [])
-	if not isinstance(images, list) or any(not isinstance(image, dict) for image in images):
-		raise SetupError(f"{path}: image must be an array of tables")
-	for image in images:
-		_keys(image, {"version", "architecture", "minimal"}, path, "image")
-		version = image.get("version", "24.04")
-		architecture = image.get("architecture", "amd64")
-		minimal = image.get("minimal", False)
-		if not isinstance(version, str):
-			raise SetupError(f"{path}: image.version must be a string")
-		if not isinstance(architecture, str):
-			raise SetupError(f"{path}: image.architecture must be a string")
-		if not isinstance(minimal, bool):
-			raise SetupError(f"{path}: image.minimal must be true or false")
-		if version not in {"22.04", "24.04"}:
-			raise SetupError(f"{path}: unsupported Ubuntu version {version!r}")
-		if architecture != "amd64":
-			raise SetupError(f"{path}: unsupported image architecture {architecture!r}")
-		if minimal and version != "24.04":
-			raise SetupError(f"{path}: minimal images need Ubuntu 24.04")
-
-
-def _keys(values: dict, allowed: set[str], path: Path, prefix: str) -> None:
-	for key in values.keys() - allowed:
-		name = f"{prefix}.{key}" if prefix else key
-		raise SetupError(f"{path}: unknown configuration key {name}")
-
-
-def _table(values: dict, key: str, path: Path, prefix: str = "") -> dict:
-	name = f"{prefix}.{key}" if prefix else key
-	value = values.get(key)
-	if not isinstance(value, dict):
-		raise SetupError(f"{path}: {name} must be a table")
-	return value
-
-
-def _string(values: dict, key: str, path: Path, prefix: str) -> str:
-	value = values.get(key)
-	if not isinstance(value, str) or not value.strip():
-		raise SetupError(f"{path}: {prefix}.{key} must be a non-empty string")
-	return value
+def generate_password(length: int = 24) -> str:
+	"""Create one password that Pilot and Frappe accept."""
+	character_groups = (string.ascii_lowercase, string.ascii_uppercase, string.digits, "!@#$%^&*-_=+")
+	characters = "".join(character_groups)
+	while True:
+		password = "".join(secrets.choice(characters) for _ in range(length))
+		if all(any(character in group for character in password) for group in character_groups):
+			return password
 
 
 class Setup:
@@ -373,7 +231,7 @@ class Setup:
 		# Guard each step on what it produces, so a stopped run continues here.
 		configuration = self.configuration
 		step(f"stage 6: bench {configuration.bench_name}")
-		password = shlex.quote(configuration.password)
+		password = shlex.quote(configuration.bootstrap_password)
 		if not (configuration.bench_path / "bench.toml").is_file():
 			self.as_bench(
 				f"pilot new {configuration.bench_name} --admin-password {password}"
@@ -388,7 +246,8 @@ class Setup:
 		site_config = configuration.bench_path / "sites" / configuration.site / "site_config.json"
 		if not site_config.is_file():
 			self.pilot(
-				f"new-site {configuration.site} --admin-password {shlex.quote(configuration.password)}"
+				f"new-site {configuration.site}"
+				f" --admin-password {shlex.quote(configuration.bootstrap_password)}"
 			)
 
 	def get_atlas(self) -> None:

--- a/scripts/atlas-vm/setup.py
+++ b/scripts/atlas-vm/setup.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
+import json
 import os
 import shlex
 import shutil
@@ -21,6 +23,17 @@ PILOT_INSTALL_URL = "https://raw.githubusercontent.com/frappe/pilot/develop/inst
 PYTHON_VERSION = "3.14"
 SETUP_GRANT = "/etc/sudoers.d/{user}-atlas-setup"
 IMAGE_BUILDER_GRANT = "/etc/sudoers.d/{user}-atlas-image-builder"
+SCALEWAY_ZONES = {
+	"fr-par-1",
+	"fr-par-2",
+	"fr-par-3",
+	"nl-ams-1",
+	"nl-ams-2",
+	"nl-ams-3",
+	"pl-waw-1",
+	"pl-waw-2",
+	"pl-waw-3",
+}
 
 
 class SetupError(Exception):
@@ -47,6 +60,8 @@ class Configuration:
 	letsencrypt_email: str = ""
 	atlas_repository: str = "https://github.com/frappe/atlas"
 	atlas_branch: str = "develop"
+	atlas_base_url: str = ""
+	atlas_setup_values: dict[str, object] = field(default_factory=dict)
 	images: list[tuple[str, str, bool]] = field(default_factory=list)
 
 	@classmethod
@@ -54,16 +69,18 @@ class Configuration:
 		if not path.is_file():
 			raise SetupError(f"no configuration at {path}")
 		document = tomllib.loads(path.read_text())
+		validate_configuration(document, path)
 		pilot = document.get("pilot", {})
 		atlas = document.get("atlas", {})
 
 		site = pilot.get("site", "")
 		password = pilot.get("password", "")
-		if not site or not password:
-			raise SetupError(f"{path} needs pilot.site and pilot.password")
-
 		images = [
-			(str(image.get("version", "24.04")), image.get("architecture", "amd64"), bool(image.get("minimal")))
+			(
+				image.get("version", "24.04"),
+				image.get("architecture", "amd64"),
+				image.get("minimal", False),
+			)
 			for image in document.get("image", [{"version": "24.04"}])
 		]
 		return cls(
@@ -74,6 +91,8 @@ class Configuration:
 			letsencrypt_email=pilot.get("letsencrypt_email", ""),
 			atlas_repository=atlas.get("repository", "https://github.com/frappe/atlas"),
 			atlas_branch=atlas.get("branch", "develop"),
+			atlas_base_url=atlas["base_url"],
+			atlas_setup_values=read_atlas_setup_values(atlas),
 			images=images,
 		)
 
@@ -89,6 +108,179 @@ class Configuration:
 	def image_builder_path(self) -> Path:
 		return self.bench_path / "apps/atlas/atlas/vm/scripts/build_ubuntu_server_image.sh"
 
+	@property
+	def fleet_private_key_path(self) -> Path:
+		return Path(f"/home/{self.bench_user}/.ssh/id_ed25519")
+
+
+def read_atlas_setup_values(atlas: dict) -> dict[str, object]:
+	"""Return the Atlas command input from the TOML tables."""
+	scaleway = atlas["scaleway"]
+	route53 = atlas["route53"]
+	letsencrypt = atlas["letsencrypt"]
+	return {
+		"server_provider": atlas["server_provider"],
+		"dns_provider": atlas["dns_provider"],
+		"region_name": atlas["region_name"].strip().lower(),
+		"region_id": atlas["region_id"],
+		"wildcard_domain": atlas["wildcard_domain"],
+		"private_network_cidr": atlas["private_network_cidr"],
+		"private_network_mtu": atlas["private_network_mtu"],
+		"central_jwks_url": atlas["central_jwks_url"],
+		"scaleway_organization_id": scaleway["organization_id"],
+		"scaleway_project_id": scaleway["project_id"],
+		"scaleway_zone": scaleway["zone"],
+		"scaleway_machine_billing_cycle": scaleway["machine_billing_cycle"],
+		"scaleway_access_key": scaleway["access_key"],
+		"scaleway_secret_key": scaleway["secret_key"],
+		"route53_access_key_id": route53["access_key_id"],
+		"route53_access_key_secret": route53["secret_access_key"],
+		"letsencrypt_email": letsencrypt["email"],
+		"is_letsencrypt_staging": letsencrypt["staging"],
+		"is_wildcard_tls_auto_renew_enabled": letsencrypt["auto_renew"],
+	}
+
+
+def validate_configuration(document: dict, path: Path) -> None:
+	"""Reject a configuration that cannot complete Atlas setup."""
+	_keys(document, {"vm", "pilot", "atlas", "image"}, path, "")
+	vm = document.get("vm", {})
+	if not isinstance(vm, dict):
+		raise SetupError(f"{path}: vm must be a table")
+	_keys(vm, {"vcpu_count", "memory_mib", "disk_gib", "ssh_port"}, path, "vm")
+	for key in ("vcpu_count", "memory_mib", "disk_gib", "ssh_port"):
+		value = vm.get(key)
+		if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
+			raise SetupError(f"{path}: vm.{key} must be a positive integer")
+	if vm.get("ssh_port", 2222) > 65_535:
+		raise SetupError(f"{path}: vm.ssh_port must be at most 65535")
+	pilot = _table(document, "pilot", path)
+	_keys(pilot, {"site", "admin_domain", "password", "user", "letsencrypt_email"}, path, "pilot")
+	for key in ("site", "password", "letsencrypt_email"):
+		_string(pilot, key, path, "pilot")
+	for key in ("admin_domain", "user"):
+		if key in pilot:
+			_string(pilot, key, path, "pilot")
+
+	atlas = _table(document, "atlas", path)
+	_keys(
+		atlas,
+		{
+			"repository",
+			"branch",
+			"base_url",
+			"server_provider",
+			"dns_provider",
+			"region_name",
+			"region_id",
+			"wildcard_domain",
+			"private_network_cidr",
+			"private_network_mtu",
+			"central_jwks_url",
+			"scaleway",
+			"route53",
+			"letsencrypt",
+		},
+		path,
+		"atlas",
+	)
+	for key in ("base_url", "server_provider", "dns_provider", "region_name", "wildcard_domain"):
+		_string(atlas, key, path, "atlas")
+	for key in ("private_network_cidr", "private_network_mtu", "central_jwks_url"):
+		if key not in atlas:
+			raise SetupError(f"{path}: atlas.{key} is required")
+	for key in ("repository", "branch", "central_jwks_url"):
+		if key in atlas and not isinstance(atlas[key], str):
+			raise SetupError(f"{path}: atlas.{key} must be a string")
+	if atlas["server_provider"] != "Scaleway" or atlas["dns_provider"] != "Route53":
+		raise SetupError(f"{path}: Atlas setup supports Scaleway and Route53")
+	if atlas["wildcard_domain"].startswith("*.") or "." not in atlas["wildcard_domain"]:
+		raise SetupError(f"{path}: atlas.wildcard_domain must be a domain without '*.'")
+	region_id = atlas.get("region_id")
+	if not isinstance(region_id, int) or isinstance(region_id, bool) or not 0 <= region_id <= 65_535:
+		raise SetupError(f"{path}: atlas.region_id must be an integer from 0 through 65535")
+	try:
+		network = ipaddress.ip_network(atlas.get("private_network_cidr", "10.1.0.0/20"), strict=False)
+	except ValueError as error:
+		raise SetupError(f"{path}: atlas.private_network_cidr is invalid: {error}") from error
+	if network.version != 4 or not 20 <= network.prefixlen <= 29:
+		raise SetupError(f"{path}: atlas.private_network_cidr must be an IPv4 network from /20 through /29")
+	private_network_mtu = atlas.get("private_network_mtu")
+	if (
+		not isinstance(private_network_mtu, int)
+		or isinstance(private_network_mtu, bool)
+		or private_network_mtu <= 0
+	):
+		raise SetupError(f"{path}: atlas.private_network_mtu must be a positive integer")
+
+	scaleway = _table(atlas, "scaleway", path, "atlas")
+	_keys(
+		scaleway,
+		{"organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"},
+		path,
+		"atlas.scaleway",
+	)
+	for key in ("organization_id", "project_id", "zone", "machine_billing_cycle", "access_key", "secret_key"):
+		_string(scaleway, key, path, "atlas.scaleway")
+	if scaleway["zone"] not in SCALEWAY_ZONES:
+		raise SetupError(f"{path}: atlas.scaleway.zone is not supported")
+	if scaleway["machine_billing_cycle"] not in {"Hourly", "Monthly"}:
+		raise SetupError(f"{path}: atlas.scaleway.machine_billing_cycle must be Hourly or Monthly")
+
+	route53 = _table(atlas, "route53", path, "atlas")
+	_keys(route53, {"access_key_id", "secret_access_key"}, path, "atlas.route53")
+	for key in ("access_key_id", "secret_access_key"):
+		_string(route53, key, path, "atlas.route53")
+	letsencrypt = _table(atlas, "letsencrypt", path, "atlas")
+	_keys(letsencrypt, {"email", "staging", "auto_renew"}, path, "atlas.letsencrypt")
+	_string(letsencrypt, "email", path, "atlas.letsencrypt")
+	for key in ("staging", "auto_renew"):
+		if key not in letsencrypt:
+			raise SetupError(f"{path}: atlas.letsencrypt.{key} is required")
+		if not isinstance(letsencrypt[key], bool):
+			raise SetupError(f"{path}: atlas.letsencrypt.{key} must be true or false")
+	images = document.get("image", [])
+	if not isinstance(images, list) or any(not isinstance(image, dict) for image in images):
+		raise SetupError(f"{path}: image must be an array of tables")
+	for image in images:
+		_keys(image, {"version", "architecture", "minimal"}, path, "image")
+		version = image.get("version", "24.04")
+		architecture = image.get("architecture", "amd64")
+		minimal = image.get("minimal", False)
+		if not isinstance(version, str):
+			raise SetupError(f"{path}: image.version must be a string")
+		if not isinstance(architecture, str):
+			raise SetupError(f"{path}: image.architecture must be a string")
+		if not isinstance(minimal, bool):
+			raise SetupError(f"{path}: image.minimal must be true or false")
+		if version not in {"22.04", "24.04"}:
+			raise SetupError(f"{path}: unsupported Ubuntu version {version!r}")
+		if architecture != "amd64":
+			raise SetupError(f"{path}: unsupported image architecture {architecture!r}")
+		if minimal and version != "24.04":
+			raise SetupError(f"{path}: minimal images need Ubuntu 24.04")
+
+
+def _keys(values: dict, allowed: set[str], path: Path, prefix: str) -> None:
+	for key in values.keys() - allowed:
+		name = f"{prefix}.{key}" if prefix else key
+		raise SetupError(f"{path}: unknown configuration key {name}")
+
+
+def _table(values: dict, key: str, path: Path, prefix: str = "") -> dict:
+	name = f"{prefix}.{key}" if prefix else key
+	value = values.get(key)
+	if not isinstance(value, dict):
+		raise SetupError(f"{path}: {name} must be a table")
+	return value
+
+
+def _string(values: dict, key: str, path: Path, prefix: str) -> str:
+	value = values.get(key)
+	if not isinstance(value, str) or not value.strip():
+		raise SetupError(f"{path}: {prefix}.{key} must be a non-empty string")
+	return value
+
 
 class Setup:
 	"""Every stage the VM runs, in order."""
@@ -98,8 +290,12 @@ class Setup:
 		self.setup_grant = SETUP_GRANT.format(user=configuration.bench_user)
 		self.image_builder_grant = IMAGE_BUILDER_GRANT.format(user=configuration.bench_user)
 
-	def as_bench(self, command: str) -> None:
-		run(["su", "-", self.configuration.bench_user, "-c", command])
+	def as_bench(self, command: str, *, input_text: str | None = None) -> None:
+		run(
+			["su", "-", self.configuration.bench_user, "-c", command],
+			input=input_text,
+			text=input_text is not None,
+		)
 
 	def bench_output(self, command: str) -> str:
 		result = run(
@@ -107,8 +303,8 @@ class Setup:
 		)
 		return result.stdout.strip()
 
-	def pilot(self, arguments: str) -> None:
-		self.as_bench(f"pilot {arguments} --bench {self.configuration.bench_name}")
+	def pilot(self, arguments: str, *, input_text: str | None = None) -> None:
+		self.as_bench(f"pilot {arguments} --bench {self.configuration.bench_name}", input_text=input_text)
 
 	def install_grant(self, path: str, content: str) -> None:
 		with tempfile.NamedTemporaryFile("w", delete=False) as staged:
@@ -123,8 +319,22 @@ class Setup:
 		environment = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
 		run(["apt-get", "update", "-qq"], env=environment)
 		run(
-			["apt-get", "install", "-y", "-qq", "wget", "curl", "git", "make", "clang",
-			 "libbpf-dev", "linux-libc-dev", "squashfs-tools", "zstd", "e2fsprogs"],
+			[
+				"apt-get",
+				"install",
+				"-y",
+				"-qq",
+				"wget",
+				"curl",
+				"git",
+				"make",
+				"clang",
+				"libbpf-dev",
+				"linux-libc-dev",
+				"squashfs-tools",
+				"zstd",
+				"e2fsprogs",
+			],
 			env=environment,
 		)
 
@@ -144,7 +354,9 @@ class Setup:
 		step(f"stage 4: python {PYTHON_VERSION} for {self.configuration.bench_user}")
 		self.as_bench("command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh")
 		self.as_bench(f"uv python install {PYTHON_VERSION}")
-		self.as_bench(f'mkdir -p ~/.local/bin && ln -sf "$(uv python find {PYTHON_VERSION})" ~/.local/bin/python3')
+		self.as_bench(
+			f'mkdir -p ~/.local/bin && ln -sf "$(uv python find {PYTHON_VERSION})" ~/.local/bin/python3'
+		)
 		reported = self.bench_output("python3 --version")
 		if PYTHON_VERSION not in reported:
 			raise SetupError(
@@ -175,7 +387,9 @@ class Setup:
 		step(f"stage 7: site {configuration.site}")
 		site_config = configuration.bench_path / "sites" / configuration.site / "site_config.json"
 		if not site_config.is_file():
-			self.pilot(f"new-site {configuration.site} --admin-password {shlex.quote(configuration.password)}")
+			self.pilot(
+				f"new-site {configuration.site} --admin-password {shlex.quote(configuration.password)}"
+			)
 
 	def get_atlas(self) -> None:
 		# Pilot skips an app that is already there, so this stage is safe to repeat.
@@ -202,9 +416,27 @@ class Setup:
 		step(f"stage 10: install atlas on {configuration.site}")
 		self.pilot(f"install-app {configuration.site} atlas")
 
+	def configure_atlas(self) -> None:
+		configuration = self.configuration
+		step(f"stage 11: configure Atlas on {configuration.site}")
+		private_key = configuration.fleet_private_key_path
+		if not private_key.exists():
+			if private_key.with_suffix(".pub").exists():
+				raise SetupError(f"public key exists without its private key: {private_key}.pub")
+			self.as_bench("install -d -m 700 ~/.ssh && ssh-keygen -q -t ed25519 -N '' -f ~/.ssh/id_ed25519")
+		public_key = self.bench_output("ssh-keygen -y -f ~/.ssh/id_ed25519")
+		values = {**configuration.atlas_setup_values, "public_ssh_key": public_key}
+		self.pilot(
+			f"frappe --site {configuration.site} set-config atlas_base_url {shlex.quote(configuration.atlas_base_url)}"
+		)
+		self.pilot(
+			f"frappe --site {configuration.site} configure-atlas",
+			input_text=json.dumps(values),
+		)
+
 	def grant_image_builder_sudo(self) -> None:
 		# The image builder runs its root file system build through sudo on every build.
-		step("stage 11: sudo grant for the image builder")
+		step("stage 12: sudo grant for the image builder")
 		self.install_grant(
 			self.image_builder_grant,
 			f"{self.configuration.bench_user} ALL=(ALL) NOPASSWD: {self.configuration.image_builder_path} *",
@@ -213,16 +445,15 @@ class Setup:
 	def build_images(self) -> None:
 		# Bootstrap has no object storage credentials yet, so every image is a site file.
 		configuration = self.configuration
-		step(f"stage 12: guest images ({len(configuration.images)})")
+		step(f"stage 13: guest images ({len(configuration.images)})")
 		for version, architecture, minimal in configuration.images:
 			step(f"image {version} {architecture} {'minimal' if minimal else 'server'}")
-			arguments = f"--version {version} --architecture {architecture} --storage site-file"
+			arguments = (
+				f"--version {version} --architecture {architecture} --storage site-file --skip-existing"
+			)
 			if minimal:
 				arguments += " --minimal"
-			self.as_bench(
-				f"pilot --bench {configuration.bench_name} --site {configuration.site}"
-				f" build-ubuntu-base-image {arguments}"
-			)
+			self.pilot(f"frappe --site {configuration.site} build-ubuntu-base-image {arguments}")
 
 	def run(self) -> None:
 		self.install_packages()
@@ -236,6 +467,7 @@ class Setup:
 			self.get_atlas()
 			self.setup_production()
 			self.install_atlas()
+			self.configure_atlas()
 		finally:
 			Path(self.setup_grant).unlink(missing_ok=True)
 		self.grant_image_builder_sudo()
@@ -257,8 +489,7 @@ def remove_pilot_installation(configuration: Configuration) -> None:
 	if identifier.returncode == 0:
 		user_id = identifier.stdout.strip()
 		environment = (
-			f"XDG_RUNTIME_DIR=/run/user/{user_id}"
-			f" DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{user_id}/bus"
+			f"XDG_RUNTIME_DIR=/run/user/{user_id} DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{user_id}/bus"
 		)
 		for action in (f"stop {units}", f"disable {units}", "daemon-reload", "reset-failed"):
 			subprocess.run(

--- a/scripts/atlas-vm/test_configuration.py
+++ b/scripts/atlas-vm/test_configuration.py
@@ -1,0 +1,97 @@
+"""Tests for the atlas-vm configuration readers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+DIRECTORY = Path(__file__).resolve().parent
+EXAMPLE = DIRECTORY / "atlas-vm.example.toml"
+
+
+def load_module(name: str, filename: str):
+	spec = importlib.util.spec_from_file_location(name, DIRECTORY / filename)
+	assert spec and spec.loader
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+atlas_vm = load_module("tested_atlas_vm", "atlas_vm.py")
+setup = load_module("tested_atlas_vm_setup", "setup.py")
+
+
+class ConfigurationTest(unittest.TestCase):
+	def setUp(self) -> None:
+		self.temporary_directory = tempfile.TemporaryDirectory()
+		self.addCleanup(self.temporary_directory.cleanup)
+		self.path = Path(self.temporary_directory.name) / "atlas-vm.toml"
+		self.path.write_text(EXAMPLE.read_text())
+
+	def test_example_is_valid_for_both_readers(self) -> None:
+		host = atlas_vm.Settings.read(self.path)
+		guest = setup.Configuration.read(self.path)
+
+		self.assertEqual(host.site, "atlas.example.com")
+		self.assertEqual(guest.atlas_base_url, "https://atlas.example.com")
+		self.assertEqual(guest.atlas_setup_values["region_id"], 1)
+		self.assertEqual(guest.atlas_setup_values["scaleway_zone"], "fr-par-1")
+
+	def test_atlas_settings_are_required(self) -> None:
+		self.path.write_text(
+			'[pilot]\nsite = "atlas.example.com"\npassword = "secret"\nletsencrypt_email = "ops@example.com"\n'
+		)
+
+		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
+			with self.subTest(reader=reader), self.assertRaises((atlas_vm.AtlasVmError, setup.SetupError)):
+				reader(self.path)
+
+	def test_unknown_atlas_key_is_rejected(self) -> None:
+		self.path.write_text(self.path.read_text().replace('region_name = "par-1"', 'region_nmae = "par-1"'))
+
+		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
+			with self.subTest(reader=reader), self.assertRaisesRegex(Exception, "atlas.region_nmae"):
+				reader(self.path)
+
+	def test_region_id_must_fit_in_the_mesh_address(self) -> None:
+		self.path.write_text(self.path.read_text().replace("region_id = 1", "region_id = 65536"))
+
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "0 through 65535"):
+			atlas_vm.Settings.read(self.path)
+
+	def test_wildcard_domain_does_not_include_a_star(self) -> None:
+		self.path.write_text(
+			self.path.read_text().replace(
+				'wildcard_domain = "par-1.example.com"', 'wildcard_domain = "*.par-1.example.com"'
+			)
+		)
+
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "without"):
+			atlas_vm.Settings.read(self.path)
+
+	def test_private_network_mtu_must_be_an_integer(self) -> None:
+		self.path.write_text(
+			self.path.read_text().replace("private_network_mtu = 1500", 'private_network_mtu = "1500"')
+		)
+
+		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
+			with self.subTest(reader=reader), self.assertRaisesRegex(Exception, "integer"):
+				reader(self.path)
+
+	def test_image_values_are_not_coerced(self) -> None:
+		self.path.write_text(self.path.read_text().replace('version = "24.04"', "version = 24.04", 1))
+
+		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
+			with (
+				self.subTest(reader=reader),
+				self.assertRaisesRegex(Exception, "image.version must be a string"),
+			):
+				reader(self.path)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/scripts/atlas-vm/test_configuration.py
+++ b/scripts/atlas-vm/test_configuration.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import string
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import ModuleType
+from unittest.mock import PropertyMock, patch
 
 DIRECTORY = Path(__file__).resolve().parent
 EXAMPLE = DIRECTORY / "atlas-vm.example.toml"
 
 
-def load_module(name: str, filename: str):
+def load_module(name: str, filename: str) -> ModuleType:
 	spec = importlib.util.spec_from_file_location(name, DIRECTORY / filename)
 	assert spec and spec.loader
 	module = importlib.util.module_from_spec(spec)
@@ -34,28 +38,41 @@ class ConfigurationTest(unittest.TestCase):
 
 	def test_example_is_valid_for_both_readers(self) -> None:
 		host = atlas_vm.Settings.read(self.path)
-		guest = setup.Configuration.read(self.path)
+		with patch.object(setup, "generate_password", return_value="generated-bootstrap-password"):
+			guest = setup.Configuration.read(self.path)
 
 		self.assertEqual(host.site, "atlas.example.com")
 		self.assertEqual(guest.atlas_base_url, "https://atlas.example.com")
 		self.assertEqual(guest.atlas_setup_values["region_id"], 1)
 		self.assertEqual(guest.atlas_setup_values["scaleway_zone"], "fr-par-1")
+		self.assertEqual(guest.bootstrap_password, "generated-bootstrap-password")
 
 	def test_atlas_settings_are_required(self) -> None:
-		self.path.write_text(
-			'[pilot]\nsite = "atlas.example.com"\npassword = "secret"\nletsencrypt_email = "ops@example.com"\n'
-		)
+		self.path.write_text('[pilot]\nsite = "atlas.example.com"\nletsencrypt_email = "ops@example.com"\n')
 
-		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
-			with self.subTest(reader=reader), self.assertRaises((atlas_vm.AtlasVmError, setup.SetupError)):
-				reader(self.path)
+		with self.assertRaises(atlas_vm.AtlasVmError):
+			atlas_vm.Settings.read(self.path)
 
 	def test_unknown_atlas_key_is_rejected(self) -> None:
 		self.path.write_text(self.path.read_text().replace('region_name = "par-1"', 'region_nmae = "par-1"'))
 
-		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
-			with self.subTest(reader=reader), self.assertRaisesRegex(Exception, "atlas.region_nmae"):
-				reader(self.path)
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "atlas.region_nmae"):
+			atlas_vm.Settings.read(self.path)
+
+	def test_pilot_password_is_rejected(self) -> None:
+		self.path.write_text(
+			self.path.read_text().replace("[pilot]\n", '[pilot]\npassword = "do-not-store-this"\n')
+		)
+
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "pilot.password"):
+			atlas_vm.Settings.read(self.path)
+
+	def test_guest_generates_a_strong_bootstrap_password(self) -> None:
+		password = setup.generate_password()
+
+		self.assertEqual(len(password), 24)
+		for characters in (string.ascii_lowercase, string.ascii_uppercase, string.digits, "!@#$%^&*-_=+"):
+			self.assertTrue(set(password) & set(characters))
 
 	def test_region_id_must_fit_in_the_mesh_address(self) -> None:
 		self.path.write_text(self.path.read_text().replace("region_id = 1", "region_id = 65536"))
@@ -78,19 +95,39 @@ class ConfigurationTest(unittest.TestCase):
 			self.path.read_text().replace("private_network_mtu = 1500", 'private_network_mtu = "1500"')
 		)
 
-		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
-			with self.subTest(reader=reader), self.assertRaisesRegex(Exception, "integer"):
-				reader(self.path)
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "integer"):
+			atlas_vm.Settings.read(self.path)
 
 	def test_image_values_are_not_coerced(self) -> None:
 		self.path.write_text(self.path.read_text().replace('version = "24.04"', "version = 24.04", 1))
 
-		for reader in (atlas_vm.Settings.read, setup.Configuration.read):
-			with (
-				self.subTest(reader=reader),
-				self.assertRaisesRegex(Exception, "image.version must be a string"),
-			):
-				reader(self.path)
+		with self.assertRaisesRegex(atlas_vm.AtlasVmError, "image.version must be a string"):
+			atlas_vm.Settings.read(self.path)
+
+	def test_guest_setup_reuses_the_ssh_key_and_forwards_json(self) -> None:
+		configuration = setup.Configuration.read(self.path)
+		private_key = Path(self.temporary_directory.name) / "id_ed25519"
+		private_key.touch()
+		stage = setup.Setup(configuration)
+
+		with (
+			patch.object(
+				setup.Configuration,
+				"fleet_private_key_path",
+				new_callable=PropertyMock,
+				return_value=private_key,
+			),
+			patch.object(stage, "as_bench") as as_bench,
+			patch.object(stage, "bench_output", return_value="ssh-ed25519 public-key"),
+			patch.object(stage, "pilot") as pilot,
+		):
+			stage.configure_atlas()
+
+		as_bench.assert_not_called()
+		self.assertEqual(pilot.call_count, 2)
+		forwarded = json.loads(pilot.call_args_list[1].kwargs["input_text"])
+		self.assertEqual(forwarded["public_ssh_key"], "ssh-ed25519 public-key")
+		self.assertNotIn("bootstrap_password", forwarded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Configure a new Atlas VM from one validated TOML file. Complete provider, DNS, catalog, certificate, and system image setup before the VM reports that the site is ready.

## What changed
- Add the Atlas, Scaleway, Route53, and Let's Encrypt configuration contract.
- Add an idempotent Atlas setup command that reads secrets from standard input.
- Require an existing public Route53 zone and reject immutable provider drift.
- Skip system images that are already available.
- Add focused configuration, setup, and Route53 tests.

## Why
This makes atlas-vm produce a configured regional Atlas site without manual Atlas Settings steps.

## Related issues
None.